### PR TITLE
Adds Documentation Framework

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,18 @@
+name: Deploy Docs to Pages
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  pages:
+    runs-on: ubuntu-22.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+    - id: deployment
+      uses: sphinx-notes/pages@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-/build
+**build
 **init.vim
+**venv
+**.DS_Store

--- a/README.md
+++ b/README.md
@@ -69,3 +69,12 @@ Other elements that integrators may need to specify:
 - Resource interests, including topics that are published or subscribed to, and services that are hosted (giving replies) or to which requests are made.
 
 More to come...
+
+## Documentation
+Documentation is hosted on this github [page]() that covers the integration API and its usage.
+In order to build the documentation `python` and `make` are required.
+Python dependencies are installed by running `pip install -r docs/requirements.txt`.
+It is recommended that these be installed in a python virtual environment.
+To build the documentation locally,
+run following command from the root of the repository `make -C docs html`.
+All documentation can then be found under the `build` directory at the root of the repository.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = src
+BUILDDIR      = ../build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+myst-parser==4.0.0
+sphinx==7.3.7
+sphinx-rtd-theme==2.0.0

--- a/docs/src/_templates/layout.html
+++ b/docs/src/_templates/layout.html
@@ -1,0 +1,79 @@
+{% extends "!layout.html" %}
+  {% block footer %} {{ super() }}
+
+  <style>
+    /* Sidebar header (and topbar for mobile) */
+    .wy-side-nav-search, .wy-nav-top {
+      background: #ff6700;
+      color: #000000;
+      a:link {
+        color: #FFFFFF;
+      }
+      a:visited {
+        color: #FFFFFF
+      }
+    }
+    /* Vertical Menu Header */
+    .wy-menu-vertical header, .wy-menu-vertical p.caption {
+      color: #000000;
+    }
+    .wy-menu-vertical {
+      a:link {
+        color: #FFFFFF;
+      }
+      a:visited {
+        color: #FFFFFF
+      }
+    }
+    /* Sidebar */
+    .wy-nav-side {
+      background: #FF6700;
+    }
+    /* Vertical Menu */
+    .wy-menu-vertical {
+      color: #000000;
+    }
+    /* Code Blocks */
+    .rst-content div[class^=highlight], .rst-content {
+      border: 0px solid #000000
+    }
+    .highlight {
+      background: #292929;
+      .kt {
+        color: #F49B5E;
+      };
+      .nf {
+        color: #D3722C;
+      }
+      .k {
+        color: #F87C1C;
+      };
+      .c {
+        color: #DCA488;
+      };
+      .c1 {
+        color: #DCA488;
+      };
+    }
+    /* Main content view */
+    .wy-nav-content {
+      background: #000000;
+      color: #FFFFFF;
+      max-width: 100%;
+      a:link {
+        color: #FC5404;
+      }
+      a:visited {
+        color: #FCAC7C
+      }
+    }
+    .tr {
+      border-color: #000000
+    }
+    /* Overlap of main content view */
+    .wy-nav-content-wrap {
+      background: #000000;
+    }
+}
+  </style>
+{% endblock %}

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,24 @@
+# API Reference
+
+Minimal API for the integrator is the philosophy behind Bristlemouth.
+The API required is as follows.
+
+## Network Interface
+
+Bristlemouth requires 10BASE-T1L transceiver in order to communicate with other devices on the network.
+Currently the supported drivers for the 10BASE-T1L transceiver are as follows:
+
+- ADIN2111
+
+### ADIN2111
+
+In order to configure the ADIN2111 driver the following is needed,
+
+<!--- Infomration regarding initializing the adin driver here --->
+
+
+## Bristlemouth Stack
+
+The bristlemouth stack is configured with the following,
+
+<!--- Infomration regarding initializing the bm stack here --->

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -1,0 +1,44 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'bristlemouth'
+author = 'Bristlemouth'
+release = '0.0.1'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ['myst_parser']
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_tile = 'Bristlemouth Integration'
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['']
+html_show_sourcelink = False
+html_show_copyright = False
+html_show_sphinx = False
+html_theme_options = {
+    'analytics_anonymize_ip': False,
+    'logo_only': True,
+    'display_version': True,
+    'prev_next_buttons_location': 'bottom',
+    'style_external_links': False,
+    'collapse_navigation': True,
+    'sticky_navigation': True,
+    'navigation_depth': 4,
+    'includehidden': True,
+    'titles_only': False,
+}
+html_logo = 'https://global.discourse-cdn.com/standard17/uploads/bristlemouth/original/1X/7f7c25cb6f75217f8eb21508bb2a2229d2adbfbb.png'

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,0 +1,14 @@
+Bristlemouth Integration Guide
+==============================
+
+
+Bristlemouth is an open standard delivering plug-and-play hardware interfaces for marine applications.
+It is utilized to deliver power and data to devices over a 2 conductor interface.
+The following is a guide to integrating custom hardware into the bristlemouth ecosystem.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   usage.md
+   api.md

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -1,0 +1,51 @@
+# Usage
+
+If you have your own sensor, on your own microcontroller,
+with your own firmware,
+and you're wondering what would be required to make your device compatible with Bristlemouth,
+read on!
+
+## Build System Integration
+Bristlemouth heavily relies on being built with CMake.
+In order to integrate it within your own project,
+CMake is highly recommended.
+The following explains how to integrate Bristlemouth into your own project utilizing CMake:
+
+```
+# Show how to integrate with CMake here
+```
+
+<!--- Explain any info pertaining to CMake integration down here --->
+
+
+Bristlemouth can be integrated into other build systems by...
+
+<!--- Show how other build systems can utilize bm--->
+
+## Running The Bristlemouth Stack
+Once Bristlemouth has been added to the project,
+it can be integrated within the project by configuring the following components:
+
+<!--- TODO: Refine this--->
+- Network Interface
+- Bristlemouth
+
+These items are configured by calling their initialization functions.
+An example of this and how the Bristlemouth stack is to be serviced is shown below:
+
+```C
+Adin2111 adin;
+Bristlemouth bm;
+
+int main() {
+    // other sensor setup
+    adin->init(...pins...spi peripheral...);
+    bm->init(adin, config);
+    for(;;) {
+        // other sensor code
+        bm->update();
+    }
+}
+```
+
+<!--- Explain function parameters here?--->


### PR DESCRIPTION
Framework for usage and API documentation layout and initial push

Howdy all,
please try and follow the README for building the docs and let me know how it goes!

@towynlin I will need you to active [publishing with github actions](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow) in order to push to our hosted github page. I am using [this action](https://github.com/marketplace/actions/sphinx-to-github-pages) to push our documentation to Github pages.

Not sure how to test this when the action is not in main yet so this PR might have to get merged through and then any adjustments to pushing it to a page might have to be made after.

Below are some screenshots:
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/55071359-8524-4a2f-b5d9-91ccc53ac032">

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/606e36b9-43b1-44f5-9b9e-bb7474cfb4d4">