### PR TITLE
Victor/add dfu header

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/tinycbor"]
+	path = third_party/tinycbor
+	url = https://github.com/sofarocean/tinycbor

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,16 @@ FetchContent_MakeAvailable(bm_common)
 
 #TODO: Configuration will determine RTOS and IP stack here
 
+# TODO - is this needed here or leave it in the application cmake files?
+set(COMPILE_FLAGS
+    -DCBOR_CUSTOM_ALLOC_INCLUDE="tinycbor_alloc.h"
+    -DCBOR_PARSER_MAX_RECURSIONS=10
+)
+
 include_directories(
     ${CMAKE_CURRENT_LIST_DIR}/include
     ${bm_common_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_LIST_DIR}/third_party/tinycbor/src
 )
 
 
@@ -48,6 +55,11 @@ else()
         src/ping.c
         src/resource_discovery.c
         src/topology.c
+        ${CMAKE_CURRENT_LIST_DIR}/third_party/tinycbor/src/cborparser.c
+        ${CMAKE_CURRENT_LIST_DIR}/third_party/tinycbor/src/cborencoder_float.c
+        ${CMAKE_CURRENT_LIST_DIR}/third_party/tinycbor/src/cborencoder.c
+        ${CMAKE_CURRENT_LIST_DIR}/third_party/tinycbor/src/cborerrorstrings.c
+        ${CMAKE_CURRENT_LIST_DIR}/third_party/tinycbor/src/cborvalidation.c
     )
     add_library(bmcore ${SOURCES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,6 @@ FetchContent_MakeAvailable(bm_common)
 
 #TODO: Configuration will determine RTOS and IP stack here
 
-# TODO - is this needed here or leave it in the application cmake files?
 set(COMPILE_FLAGS
     -DCBOR_CUSTOM_ALLOC_INCLUDE="tinycbor_alloc.h"
     -DCBOR_PARSER_MAX_RECURSIONS=10

--- a/include/bm_configs_generic.h
+++ b/include/bm_configs_generic.h
@@ -1,12 +1,17 @@
 #ifndef __BM_CONFIGS_GENERIC_H__
 #define __BM_CONFIGS_GENERIC_H__
 
-
-#include "util.h"
+#include "cbor.h"
 #include "messages.h"
+#include "util.h"
 #include <stdint.h>
 
 #define BM_MAX_KEY_LEN_BYTES 32
+#define BM_MAX_NUM_KV 50
+#define BM_MAX_KEY_LEN_BYTES 32
+#define BM_MAX_STR_LEN_BYTES 50
+#define BM_MAX_CONFIG_BUFFER_SIZE_BYTES 50
+#define BM_CONFIG_VERSION 0
 
 typedef enum {
   UINT32,
@@ -23,13 +28,18 @@ typedef struct {
   GenericConfigDataTypes valueType;
 } __attribute__((packed, aligned(1))) GenericConfigKey;
 
-const GenericConfigKey *bcmp_config_get_stored_keys(uint8_t &num_stored_keys, BmConfigPartition partition);
-bool bcmp_remove_key(const char *key, size_t key_len, BmConfigPartition partition);
+const GenericConfigKey *
+bcmp_config_get_stored_keys(uint8_t &num_stored_keys,
+                            BmConfigPartition partition);
+bool bcmp_remove_key(const char *key, size_t key_len,
+                     BmConfigPartition partition);
 bool bcmp_config_needs_commit(BmConfigPartition partition);
 bool bcmp_commit_config(BmConfigPartition partition);
 bool bcmp_set_config(const char *key, size_t key_len, uint8_t *value,
                      size_t value_len, BmConfigPartition partition);
 bool bcmp_get_config(const char *key, size_t key_len, uint8_t *value,
                      size_t &value_len, BmConfigPartition partition);
+bool bm_cbor_type_to_config_type(const CborValue *value,
+                                 GenericConfigDataTypes *configType);
 
 #endif // __BM_CONFIGS_GENERIC_H__

--- a/include/bm_dfu_generic.h
+++ b/include/bm_dfu_generic.h
@@ -6,9 +6,12 @@ BmErr bm_dfu_client_set_pending_and_reset(void);
 BmErr bm_dfu_client_fail_update_and_reset(void);
 BmErr bm_dfu_client_flash_area_open(const void **flash_area);
 BmErr bm_dfu_client_flash_area_close(const void *flash_area);
-BmErr bm_dfu_client_flash_area_write(const void *flash_area, uint32_t off, const void *src, uint32_t len);
-BmErr bm_dfu_client_flash_area_erase(const void *flash_area, uint32_t off, uint32_t len);
+BmErr bm_dfu_client_flash_area_write(const void *flash_area, uint32_t off,
+                                     const void *src, uint32_t len);
+BmErr bm_dfu_client_flash_area_erase(const void *flash_area, uint32_t off,
+                                     uint32_t len);
 uint32_t bm_dfu_client_flash_area_get_size(const void *flash_area);
 bool bm_dfu_client_confirm_is_enabled(void);
 void bm_dfu_client_confirm_enable(bool en);
-BmErr bm_dfu_host_get_chunk(uint32_t offset, uint8_t *buffer, size_t len, uint32_t timeoutMs);
+BmErr bm_dfu_host_get_chunk(uint32_t offset, uint8_t *buffer, size_t len,
+                            uint32_t timeouts);

--- a/include/bm_dfu_generic.h
+++ b/include/bm_dfu_generic.h
@@ -1,7 +1,13 @@
 #include "util.h"
+#include <stdint.h>
 
-
-// TODO - add the dfu functions that we will need... need to reference the dfu code to see what we need
-// write
-// read
-// erase
+BmErr bm_dfu_set_confirmed(void);
+BmErr bm_dfu_set_pending_and_reset(void);
+BmErr bm_dfu_fail_update_and_reset(void);
+BmErr bm_dfu_flash_area_open(const void **flash_area);
+BmErr bm_dfu_flash_area_close(const void *flash_area);
+BmErr bm_dfu_flash_area_write(const void *flash_area, uint32_t off, const void *src, uint32_t len);
+BmErr bm_dfu_flash_area_erase(const void *flash_area, uint32_t off, uint32_t len);
+uint32_t bm_dfu_flash_area_get_size(const void *flash_area);
+bool bm_dfu_confirm_is_enabled(void);
+void bm_dfu_confirm_enable(bool en);

--- a/include/bm_dfu_generic.h
+++ b/include/bm_dfu_generic.h
@@ -1,13 +1,14 @@
 #include "util.h"
 #include <stdint.h>
 
-BmErr bm_dfu_set_confirmed(void);
-BmErr bm_dfu_set_pending_and_reset(void);
-BmErr bm_dfu_fail_update_and_reset(void);
-BmErr bm_dfu_flash_area_open(const void **flash_area);
-BmErr bm_dfu_flash_area_close(const void *flash_area);
-BmErr bm_dfu_flash_area_write(const void *flash_area, uint32_t off, const void *src, uint32_t len);
-BmErr bm_dfu_flash_area_erase(const void *flash_area, uint32_t off, uint32_t len);
-uint32_t bm_dfu_flash_area_get_size(const void *flash_area);
-bool bm_dfu_confirm_is_enabled(void);
-void bm_dfu_confirm_enable(bool en);
+BmErr bm_dfu_client_set_confirmed(void);
+BmErr bm_dfu_client_set_pending_and_reset(void);
+BmErr bm_dfu_client_fail_update_and_reset(void);
+BmErr bm_dfu_client_flash_area_open(const void **flash_area);
+BmErr bm_dfu_client_flash_area_close(const void *flash_area);
+BmErr bm_dfu_client_flash_area_write(const void *flash_area, uint32_t off, const void *src, uint32_t len);
+BmErr bm_dfu_client_flash_area_erase(const void *flash_area, uint32_t off, uint32_t len);
+uint32_t bm_dfu_client_flash_area_get_size(const void *flash_area);
+bool bm_dfu_client_confirm_is_enabled(void);
+void bm_dfu_client_confirm_enable(bool en);
+BmErr bm_dfu_host_get_chunk(uint32_t offset, uint8_t *buffer, size_t len, uint32_t timeoutMs);

--- a/include/tinycbor_alloc.h
+++ b/include/tinycbor_alloc.h
@@ -1,0 +1,3 @@
+#include "bm_os.h"
+#define cbor_malloc bm_malloc
+#define cbor_free bm_free

--- a/src/platform/bm_lwip.c
+++ b/src/platform/bm_lwip.c
@@ -109,16 +109,14 @@ static uint8_t bcmp_recv(void *arg, struct raw_pcb *pcb, struct pbuf *pbuf,
       // Make a copy of the IP address since we'll be modifying it later when we
       // remove the src/dest ports (and since it might not be in the pbuf so someone
       // else is managing that memory)
-      struct pbuf *p_ref = pbuf_alloc(PBUF_IP, pbuf->len, PBUF_RAM);
       ip_addr_t *src_ref = (ip_addr_t *)bm_malloc(sizeof(ip_addr_t));
       ip_addr_t *dst_ref = (ip_addr_t *)bm_malloc(sizeof(ip_addr_t));
       LwipLayout *layout = (LwipLayout *)bm_malloc(sizeof(LwipLayout));
-      pbuf_copy(p_ref, pbuf);
       memcpy(dst_ref, ip6_hdr->dest.addr, sizeof(ip_addr_t));
       memcpy(src_ref, src, sizeof(ip_addr_t));
-      *layout = (LwipLayout){p_ref, src_ref, dst_ref};
+      *layout = (LwipLayout){pbuf, src_ref, dst_ref};
 
-      BcmpQueueItem item = {BcmpEventRx, (void *)layout, p_ref->len};
+      BcmpQueueItem item = {BCMP_EVT_RX, (void *)layout, layout->pbuf->len};
       if (bm_queue_send(queue, &item, 0) != BmOK) {
         printf("Error sending to Queue\n");
         pbuf_free(pbuf);
@@ -238,10 +236,10 @@ BmErr bm_ip_tx_copy(void *payload, const void *data, uint32_t size,
  @details The destination address is optional, if NULL the address passed
           into bm_ip_tx_new will be utilized
 
- @param payload abstracted payload to be 
+ @param payload abstracted payload to be
  @param dst destination IP address to send the message to
 
- @return 
+ @return
  */
 BmErr bm_ip_tx_perform(void *payload, const void *dst) {
   BmErr err = BmEINVAL;

--- a/src/platform/bm_lwip.c
+++ b/src/platform/bm_lwip.c
@@ -116,7 +116,7 @@ static uint8_t bcmp_recv(void *arg, struct raw_pcb *pcb, struct pbuf *pbuf,
       memcpy(src_ref, src, sizeof(ip_addr_t));
       *layout = (LwipLayout){pbuf, src_ref, dst_ref};
 
-      BcmpQueueItem item = {BCMP_EVT_RX, (void *)layout, layout->pbuf->len};
+      BcmpQueueItem item = {BcmpEventRx, (void *)layout, layout->pbuf->len};
       if (bm_queue_send(queue, &item, 0) != BmOK) {
         printf("Error sending to Queue\n");
         pbuf_free(pbuf);


### PR DESCRIPTION
Add in the function declerations for generic dfu function calls.

Also includes a change to `bm_lwip.c` to not allocate another pbuf, but instead pass the already existing one.

Not sure why the test build is failling since I didn' make any changes to the test files or files that are tested 🤔. Sounds like it may be related to new changes in `bm_common`. I'll wait for https://github.com/bristlemouth/bm_core/pull/8 to be merged, rebase, then see what happens. Update: it is passing the CI now that it has been rebased!