### PR TITLE
Clearly Inform The User About Configuration Errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,21 @@ else()
         ${CMAKE_CURRENT_LIST_DIR}/third_party/tinycbor/src/cborerrorstrings.c
         ${CMAKE_CURRENT_LIST_DIR}/third_party/tinycbor/src/cborvalidation.c
     )
+
+    # Ensure integrator called the functions necessary to configure bristlemouth
+    set(ERROR_MESSAGE "")
+    if("${BM_IP_STACK}" STREQUAL "" OR NOT BM_IP_INCLUDES)
+        set(ERROR_MESSAGE "IP Stack")
+    endif()
+    if("${BM_OS}" STREQUAL "" OR NOT BM_OS_INCLUDES)
+        set(ERROR_MESSAGE "Operating System")
+    endif()
+    if (NOT "${ERROR_MESSAGE}" STREQUAL "")
+        message(FATAL_ERROR "The ${ERROR_MESSAGE} must be chosen in order to\
+        build the application. To see how this is configured, please visit:\
+        https://bristlemouth.github.io/bm_core/usage.html#build-system-integration"
+        )
+    endif()
     append_platform_file(SOURCES ${BM_IP_STACK} ${CMAKE_CURRENT_LIST_DIR})
     append_platform_file(SOURCES ${BM_OS} ${bm_common_SOURCE_DIR})
     include_directories(


### PR DESCRIPTION
This adds some logic in the CMakeLists file to inform the user of a os/ip stack configuration error