### PR TITLE
feat(adin): expose tx port mask

### DIFF
--- a/drivers/adin2111/bm_adin2111.h
+++ b/drivers/adin2111/bm_adin2111.h
@@ -2,6 +2,8 @@
 #include "network_interface.h"
 #include "util.h"
 
+#define ADIN2111_PORT_MASK (3U)
+
 typedef struct {
   void *device_handle;
   NetworkInterfaceCallbacks const *callbacks;

--- a/network/network_interface.h
+++ b/network/network_interface.h
@@ -7,7 +7,8 @@ typedef struct {
 } NetworkInterfaceCallbacks;
 
 typedef struct {
-  BmErr (*const send)(void *self, uint8_t *data, size_t length);
+  BmErr (*const send)(void *self, uint8_t *data, size_t length,
+                      uint8_t port_mask);
   BmErr (*const enable)(void *self);
   BmErr (*const disable)(void *self);
 } NetworkInterfaceTrait;

--- a/test/src/bm_adin2111_test.cpp
+++ b/test/src/bm_adin2111_test.cpp
@@ -49,7 +49,7 @@ static NetworkInterface setup(void) {
 
 TEST(Adin2111, send) {
   NetworkInterface netif = setup();
-  BmErr err = netif.trait->send(netif.self, (unsigned char *)"hello", 5);
+  BmErr err = netif.trait->send(netif.self, (unsigned char *)"hello", 5, 3U);
   EXPECT_EQ(err, BmOK);
 }
 

--- a/test/src/bm_adin2111_test.cpp
+++ b/test/src/bm_adin2111_test.cpp
@@ -49,7 +49,8 @@ static NetworkInterface setup(void) {
 
 TEST(Adin2111, send) {
   NetworkInterface netif = setup();
-  BmErr err = netif.trait->send(netif.self, (unsigned char *)"hello", 5, 3U);
+  BmErr err = netif.trait->send(netif.self, (unsigned char *)"hello", 5,
+                                ADIN2111_PORT_MASK);
   EXPECT_EQ(err, BmOK);
 }
 


### PR DESCRIPTION
On first pass, I didn't see anywhere in the code that we ever sent to only one port, even though I knew it had to be there somewhere. Now, refactoring L2 to use the new adin driver, I found it. This PR adds a port mask parameter to the `send` function.