### PR TITLE
Feature/add time tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -42,7 +42,15 @@ jobs:
     - name: coverage
       if: contains(matrix.os, 'ubuntu')
       run:
-        gcovr -r ./src --html-details ./coverage/report.html --html-theme github.dark-green build/test
+        gcovr -r . \
+        --html-details ./coverage/report.html \
+        --html-theme github.dark-green \
+        --filter bcmp \
+        --filter middleware \
+        --filter dirvers \
+        --filter network \
+        --filter common \
+        build/test
     - name: artifacts
       if: contains(matrix.os, 'ubuntu')
       uses: actions/upload-artifact@v4

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -46,7 +46,7 @@ jobs:
               --html-theme github.dark-green \
               --filter bcmp \
               --filter middleware \
-              --filter dirvers \
+              --filter drivers \
               --filter network \
               --filter common \
               build/test

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -43,13 +43,13 @@ jobs:
       if: contains(matrix.os, 'ubuntu')
       run: |
         gcovr --html-details ./coverage/report.html \
-        --html-theme github.dark-green \
-        --filter bcmp \
-        --filter middleware \
-        --filter dirvers \
-        --filter network \
-        --filter common \
-        build/test
+              --html-theme github.dark-green \
+              --filter bcmp \
+              --filter middleware \
+              --filter dirvers \
+              --filter network \
+              --filter common \
+              build/test
     - name: artifacts
       if: contains(matrix.os, 'ubuntu')
       uses: actions/upload-artifact@v4

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -42,8 +42,7 @@ jobs:
     - name: coverage
       if: contains(matrix.os, 'ubuntu')
       run:
-        gcovr -r . \
-        --html-details ./coverage/report.html \
+        gcovr --html-details ./coverage/report.html \
         --html-theme github.dark-green \
         --filter bcmp \
         --filter middleware \

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -41,7 +41,7 @@ jobs:
         pip install gcovr==7.2
     - name: coverage
       if: contains(matrix.os, 'ubuntu')
-      run:
+      run: |
         gcovr --html-details ./coverage/report.html \
         --html-theme github.dark-green \
         --filter bcmp \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,9 +54,6 @@ set(COMPILE_FLAGS
 set(BM_INCLUDES
     ${CMAKE_CURRENT_LIST_DIR}/bcmp
     ${CMAKE_CURRENT_LIST_DIR}/common
-    # TDOO: When we have multiple network device drivers, we will need to
-    #      change this to include the driver of choice
-    ${CMAKE_CURRENT_LIST_DIR}/drivers/adin2111
     ${CMAKE_CURRENT_LIST_DIR}/middleware
     ${CMAKE_CURRENT_LIST_DIR}/network
     ${CMAKE_CURRENT_LIST_DIR}/third_party

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,9 @@ set(COMPILE_FLAGS
 set(BM_INCLUDES
     ${CMAKE_CURRENT_LIST_DIR}/bcmp
     ${CMAKE_CURRENT_LIST_DIR}/common
+    # TDOO: When we have multiple network device drivers, we will need to
+    #      change this to include the driver of choice
+    ${CMAKE_CURRENT_LIST_DIR}/drivers/adin2111
     ${CMAKE_CURRENT_LIST_DIR}/middleware
     ${CMAKE_CURRENT_LIST_DIR}/network
     ${CMAKE_CURRENT_LIST_DIR}/third_party
@@ -64,8 +67,8 @@ set(BM_INCLUDES
 include_directories(${BM_INCLUDES})
 
 if(ENABLE_TESTING)
-    set(CMAKE_CXX_FLAGS "-g -Wall --coverage")
-    set(CMAKE_C_FLAGS "-g -Wall -W  --coverage")
+    set(CMAKE_CXX_FLAGS "-g -Wall")
+    set(CMAKE_C_FLAGS "-g -Wall -W")
     set(CMAKE_EXE_LINKER_FLAGS "-fprofile-arcs -ftest-coverage")
     add_compile_options(-DENABLE_TESTING)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,8 +64,8 @@ set(BM_INCLUDES
 include_directories(${BM_INCLUDES})
 
 if(ENABLE_TESTING)
-    set(CMAKE_CXX_FLAGS "-g -Wall")
-    set(CMAKE_C_FLAGS "-g -Wall -W")
+    set(CMAKE_CXX_FLAGS "-g -Wall --coverage")
+    set(CMAKE_C_FLAGS "-g -Wall -W  --coverage")
     set(CMAKE_EXE_LINKER_FLAGS "-fprofile-arcs -ftest-coverage")
     add_compile_options(-DENABLE_TESTING)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -63,6 +63,7 @@ function(create_gtest test_name  srcs)
         ${srcs}
         src/${test_name}_test.cpp
     )
+    gtest_discover_tests(${GTEST_NAME})
     # Generate artifacts for coverage report using lcov
     file(GLOB_RECURSE FILES "../*")
     foreach(FILE ${FILES})
@@ -76,7 +77,6 @@ function(create_gtest test_name  srcs)
             endif()
         endif()
     endforeach()
-    gtest_discover_tests(${GTEST_NAME})
 endfunction()
 
 # Linked List (LL) unit tests

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -405,8 +405,12 @@ gtest_discover_tests(bm_adin2111_test)
 set (TIME_REMAINING_SRCS
     # File we're testing
     ${COMMON_DIR}/util.c
-
-    # Stubs
-    # ${STUB_DIR}/bm_os_stub.c
 )
 create_gtest("time_remaining" "${TIME_REMAINING_SRCS}")
+
+# UTC From Date Time tests
+set (UTC_FROM_DATE_TIME_SRCS
+    # File we're testing
+    ${COMMON_DIR}/util.c
+)
+create_gtest("utc_from_date_time" "${UTC_FROM_DATE_TIME_SRCS}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,7 +69,7 @@ function(create_gtest test_name  srcs)
     foreach(FILE ${FILES})
         if (NOT FILE MATCHES "^test/")
             get_filename_component(FILENAME "${FILE}" NAME)
-            if (FILENAME MATCHES ".*${test_name}.*")
+            if (FILENAME MATCHES ".*${test_name}.c")
                 set_source_files_properties(${FILE} PROPERTIES
                     COMPILE_FLAGS
                     "-fprofile-arcs -ftest-coverage"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -64,19 +64,6 @@ function(create_gtest test_name  srcs)
         src/${test_name}_test.cpp
     )
     gtest_discover_tests(${GTEST_NAME})
-    # Generate artifacts for coverage report using lcov
-    # file(GLOB_RECURSE FILES "../*")
-    # foreach(FILE ${FILES})
-    #     if (NOT FILE MATCHES "^test/")
-    #         get_filename_component(FILENAME "${FILE}" NAME)
-    #         if (FILENAME MATCHES ".*${test_name}.*")
-    #             set_source_files_properties(${FILE} PROPERTIES
-    #                 COMPILE_FLAGS
-    #                 "-fprofile-arcs -ftest-coverage"
-    #             )
-    #         endif()
-    #     endif()
-    # endforeach()
 endfunction()
 
 # Linked List (LL) unit tests

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -414,3 +414,21 @@ set (UTC_FROM_DATE_TIME_SRCS
     ${COMMON_DIR}/util.c
 )
 create_gtest("utc_from_date_time" "${UTC_FROM_DATE_TIME_SRCS}")
+
+# Time Messsage tests
+set (TIME_MESSAGE_SRCS
+    # File we're testing
+    ${BCMP_DIR}/time.c
+
+    # Supporting Files
+    ${COMMON_DIR}/util.c
+    ${COMMON_DIR}/ll.c
+
+    # Stubs
+    ${STUB_DIR}/bm_os_stub.c
+    ${STUB_DIR}/packet_stub.c
+    ${STUB_DIR}/device_stub.c
+    ${STUB_DIR}/bcmp_stub.c
+    ${STUB_DIR}/bm_rtc_stub.c
+)
+create_gtest("time" "${TIME_MESSAGE_SRCS}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -65,16 +65,18 @@ function(create_gtest test_name  srcs)
     )
     gtest_discover_tests(${GTEST_NAME})
     # Generate artifacts for coverage report using lcov
-    file(GLOB_RECURSE FILES "../src/*")
-    foreach(FILE ${FILES})
-        get_filename_component(FILENAME "${FILE}" NAME)
-        if (FILENAME MATCHES ".*${test_name}.*")
-            set_source_files_properties(${FILE} PROPERTIES
-                COMPILE_FLAGS
-                "-fprofile-arcs -ftest-coverage"
-            )
-        endif()
-    endforeach()
+    # file(GLOB_RECURSE FILES "../*")
+    # foreach(FILE ${FILES})
+    #     if (NOT FILE MATCHES "^test/")
+    #         get_filename_component(FILENAME "${FILE}" NAME)
+    #         if (FILENAME MATCHES ".*${test_name}.*")
+    #             set_source_files_properties(${FILE} PROPERTIES
+    #                 COMPILE_FLAGS
+    #                 "-fprofile-arcs -ftest-coverage"
+    #             )
+    #         endif()
+    #     endif()
+    # endforeach()
 endfunction()
 
 # Linked List (LL) unit tests

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -400,3 +400,13 @@ target_include_directories(bm_adin2111_test PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/../network)
 target_link_libraries(bm_adin2111_test GTest::gtest_main)
 gtest_discover_tests(bm_adin2111_test)
+
+# Time remaining tests
+set (TIME_REMAINING_SRCS
+    # File we're testing
+    ${COMMON_DIR}/util.c
+
+    # Stubs
+    # ${STUB_DIR}/bm_os_stub.c
+)
+create_gtest("time_remaining" "${TIME_REMAINING_SRCS}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -388,19 +388,20 @@ set (BM_SERVICE_REQUEST_SRCS
 create_gtest("bm_service_request" "${BM_SERVICE_REQUEST_SRCS}")
 
 # ADIN2111 DRIVER TESTS
-set (ADIN2111_SRCS
-    # File we're testing
+add_executable(bm_adin2111_test
+    src/bm_adin2111_test.cpp
     ${ADIN2111_DIR}/bm_adin2111.c
-
-    # Supporting Files
     ${ADIN2111_DIR}/adin2111.c
     ${ADIN2111_DIR}/adi_fcs.c
     ${ADIN2111_DIR}/adi_mac.c
     ${ADIN2111_DIR}/adi_phy.c
     ${ADIN2111_DIR}/adi_spi_oa.c
-    ${COMMON_DIR}/aligned_malloc.c
-)
-create_gtest("bm_adin2111" "${ADIN2111_SRCS}")
+    ${COMMON_DIR}/aligned_malloc.c)
+target_include_directories(bm_adin2111_test PRIVATE
+    ${ADIN2111_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/../network)
+target_link_libraries(bm_adin2111_test GTest::gtest_main)
+gtest_discover_tests(bm_adin2111_test)
 
 # Time remaining tests
 set (TIME_REMAINING_SRCS

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -63,6 +63,19 @@ function(create_gtest test_name  srcs)
         ${srcs}
         src/${test_name}_test.cpp
     )
+    # Generate artifacts for coverage report using lcov
+    file(GLOB_RECURSE FILES "../*")
+    foreach(FILE ${FILES})
+        if (NOT FILE MATCHES "^test/")
+            get_filename_component(FILENAME "${FILE}" NAME)
+            if (FILENAME MATCHES ".*${test_name}.*")
+                set_source_files_properties(${FILE} PROPERTIES
+                    COMPILE_FLAGS
+                    "-fprofile-arcs -ftest-coverage"
+                )
+            endif()
+        endif()
+    endforeach()
     gtest_discover_tests(${GTEST_NAME})
 endfunction()
 
@@ -375,20 +388,19 @@ set (BM_SERVICE_REQUEST_SRCS
 create_gtest("bm_service_request" "${BM_SERVICE_REQUEST_SRCS}")
 
 # ADIN2111 DRIVER TESTS
-add_executable(bm_adin2111_test
-    src/bm_adin2111_test.cpp
+set (ADIN2111_SRCS
+    # File we're testing
     ${ADIN2111_DIR}/bm_adin2111.c
+
+    # Supporting Files
     ${ADIN2111_DIR}/adin2111.c
     ${ADIN2111_DIR}/adi_fcs.c
     ${ADIN2111_DIR}/adi_mac.c
     ${ADIN2111_DIR}/adi_phy.c
     ${ADIN2111_DIR}/adi_spi_oa.c
-    ${COMMON_DIR}/aligned_malloc.c)
-target_include_directories(bm_adin2111_test PRIVATE
-    ${ADIN2111_DIR}
-    ${CMAKE_CURRENT_LIST_DIR}/../network)
-target_link_libraries(bm_adin2111_test GTest::gtest_main)
-gtest_discover_tests(bm_adin2111_test)
+    ${COMMON_DIR}/aligned_malloc.c
+)
+create_gtest("bm_adin2111" "${ADIN2111_SRCS}")
 
 # Time remaining tests
 set (TIME_REMAINING_SRCS

--- a/test/mocks/mock_bm_rtc.h
+++ b/test/mocks/mock_bm_rtc.h
@@ -1,0 +1,17 @@
+#include "fff.h"
+#include "util.h"
+#include <stdint.h>
+
+typedef struct {
+  uint16_t year;
+  uint8_t month;
+  uint8_t day;
+  uint8_t hour;
+  uint8_t minute;
+  uint8_t second;
+  uint16_t ms;
+} RtcTimeAndDate;
+
+DECLARE_FAKE_VALUE_FUNC(BmErr, bm_rtc_set, const RtcTimeAndDate *);
+DECLARE_FAKE_VALUE_FUNC(BmErr, bm_rtc_get, RtcTimeAndDate *);
+DECLARE_FAKE_VALUE_FUNC(uint64_t, bm_rtc_get_micro_seconds, RtcTimeAndDate *);

--- a/test/src/lib_state_machine_test.cpp
+++ b/test/src/lib_state_machine_test.cpp
@@ -163,7 +163,7 @@ class LibStateMachineTest : public ::testing::Test {
 
 // Although lib_sm_run should be run in a for(;;) loop, while writing unit tests for our state machines
 // We should seperate out each call to run() to more granularly test what's going on.
-TEST_F(LibStateMachineTest, BasicPump)
+TEST_F(LibStateMachineTest, basic_pump)
 {
   // Check Initialization.
   lib_sm_init(&GLOBAL_CTX.sm_ctx, &states[STAGE_1], checkTransitions);

--- a/test/src/time_remaining_test.cpp
+++ b/test/src/time_remaining_test.cpp
@@ -1,0 +1,99 @@
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "util.h"
+}
+
+// The fixture for testing class Foo.
+class TimeRemaining : public ::testing::Test {
+ protected:
+  // You can remove any or all of the following functions if its body
+  // is empty.
+
+  TimeRemaining() {
+     // You can do set-up work for each test here.
+  }
+
+  ~TimeRemaining() override {
+     // You can do clean-up work that doesn't throw exceptions here.
+  }
+
+  // If the constructor and destructor are not enough for setting up
+  // and cleaning up each test, you can define the following methods:
+
+  void SetUp() override {
+     // Code here will be called immediately after the constructor (right
+     // before each test).
+  }
+
+  void TearDown() override {
+     // Code here will be called immediately after each test (right
+     // before the destructor).
+  }
+
+  // Objects declared here can be used by all tests in the test suite for Foo.
+};
+
+
+TEST_F(TimeRemaining, all_zeroes)
+{
+  uint32_t rem = time_remaining(0, 0, 0);
+  EXPECT_EQ(rem, 0);
+}
+
+TEST_F(TimeRemaining, basic_rem)
+{
+  uint32_t rem = time_remaining(0, 5, 10);
+  EXPECT_EQ(rem, 5);
+}
+
+TEST_F(TimeRemaining, basic_no_rem_exact)
+{
+  uint32_t rem = time_remaining(0, 10, 10);
+  EXPECT_EQ(rem, 0);
+}
+
+TEST_F(TimeRemaining, basic_no_rem_over)
+{
+  uint32_t rem = time_remaining(0, 15, 10);
+  EXPECT_EQ(rem, 0);
+}
+
+//
+// Test uint32_t overflow
+//
+TEST_F(TimeRemaining, big)
+{
+  uint32_t rem = time_remaining(UINT32_MAX - 10, UINT32_MAX - 5, 10);
+  EXPECT_EQ(rem, 5);
+}
+
+TEST_F(TimeRemaining, big_no_rem)
+{
+  uint32_t rem = time_remaining(UINT32_MAX - 10, UINT32_MAX, 10);
+  EXPECT_EQ(rem, 0);
+}
+
+TEST_F(TimeRemaining, big_some_rem_over)
+{
+  uint32_t rem = time_remaining(UINT32_MAX - 10, UINT32_MAX, 15);
+  EXPECT_EQ(rem, 5);
+}
+
+TEST_F(TimeRemaining, big_some_rem_over2)
+{
+  uint32_t rem = time_remaining(UINT32_MAX - 10, 3, 15);
+  EXPECT_EQ(rem, 1);
+}
+
+TEST_F(TimeRemaining, big_no_rem_over)
+{
+  uint32_t rem = time_remaining(UINT32_MAX - 10, 3, 10);
+  EXPECT_EQ(rem, 0);
+}
+
+TEST_F(TimeRemaining, big_no_rem_over2)
+{
+  uint32_t rem = time_remaining(UINT32_MAX - 10, 200, 15);
+  EXPECT_EQ(rem, 0);
+}

--- a/test/src/time_test.cpp
+++ b/test/src/time_test.cpp
@@ -1,0 +1,182 @@
+#include <gtest/gtest.h>
+#include <helpers.hpp>
+
+#include "fff.h"
+
+DEFINE_FFF_GLOBALS;
+
+extern "C" {
+#include "util.h"
+#include "messages/time.h"
+#include "mock_bcmp.h"
+#include "mock_bm_os.h"
+#include "mock_device.h"
+#include "mock_packet.h"
+#include "mock_bm_rtc.h"
+}
+
+class Time : public ::testing::Test {
+public:
+  rnd_gen RND;
+
+  private:
+  protected:
+    Time() {}
+    ~Time() override {}
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+TEST_F(Time, request_time)
+{
+  bm_rtc_get_micro_seconds_fake.return_val = 0;
+
+  BcmpSystemTimeHeader time_header = {
+      (uint64_t)RND.rnd_int(UINT64_MAX, UINT8_MAX),
+      (uint64_t)RND.rnd_int(UINT64_MAX, UINT8_MAX),
+  };
+  BcmpSystemTimeSet req_msg = {
+      time_header,
+  };
+  BcmpHeader header = {
+      .type = BcmpSystemTimeRequestMessage,
+  };
+  BcmpProcessData data = {0};
+  data.payload = (uint8_t *)&req_msg;
+  data.header = &header;
+
+  // Intialize processing callbacks
+  ASSERT_EQ(time_init(), BmOK);
+
+  // Test successful request process
+  bcmp_tx_fake.return_val = BmOK;
+  node_id_fake.return_val = time_header.target_node_id;
+  bm_rtc_get_fake.return_val = BmOK;
+  ASSERT_EQ(packet_process_invoke(BcmpSystemTimeRequestMessage, data), BmOK);
+  ASSERT_EQ(bcmp_tx_fake.call_count, 1);
+  ASSERT_EQ(bm_rtc_get_fake.call_count, 1);
+  RESET_FAKE(bcmp_tx);
+  RESET_FAKE(node_id);
+  RESET_FAKE(bm_rtc_get);
+
+  // Test request process with failure to transmit
+  bcmp_tx_fake.return_val = BmEBADMSG;
+  bm_rtc_get_fake.return_val = BmOK;
+  node_id_fake.return_val = time_header.target_node_id;
+  ASSERT_EQ(packet_process_invoke(BcmpSystemTimeRequestMessage, data), BmOK);
+  ASSERT_EQ(bcmp_tx_fake.call_count, 1);
+  ASSERT_EQ(bm_rtc_get_fake.call_count, 1);
+  RESET_FAKE(bcmp_tx);
+  RESET_FAKE(node_id);
+  RESET_FAKE(bm_rtc_get);
+
+  // Test request process with wrong node id - should forward
+  node_id_fake.return_val = 0;
+  ASSERT_EQ(packet_process_invoke(BcmpSystemTimeRequestMessage, data), BmOK);
+  ASSERT_EQ(bcmp_tx_fake.call_count, 0);
+  ASSERT_EQ(bcmp_ll_forward_fake.call_count, 1);
+  RESET_FAKE(node_id);
+
+  // Test request process with target id of 0
+  bcmp_tx_fake.return_val = BmOK;
+  node_id_fake.return_val = time_header.target_node_id;
+  req_msg.header.target_node_id = 0;
+  ASSERT_EQ(packet_process_invoke(BcmpSystemTimeRequestMessage, data), BmEINVAL);
+  ASSERT_EQ(bcmp_tx_fake.call_count, 0);
+
+  // Test failure to get time
+  bcmp_tx_fake.return_val = BmOK;
+  node_id_fake.return_val = time_header.target_node_id;
+  req_msg.header.target_node_id = time_header.target_node_id;
+  bm_rtc_get_fake.return_val = BmEINVAL;
+  ASSERT_EQ(packet_process_invoke(BcmpSystemTimeRequestMessage, data), BmOK);
+  ASSERT_EQ(bcmp_tx_fake.call_count, 0);
+  ASSERT_EQ(bm_rtc_get_fake.call_count, 1);
+  RESET_FAKE(node_id);
+  RESET_FAKE(bm_rtc_get);
+  RESET_FAKE(bcmp_tx);
+
+  packet_cleanup();
+}
+
+TEST_F(Time, time_response) {
+  BcmpSystemTimeHeader time_header = {
+      (uint64_t)RND.rnd_int(UINT64_MAX, UINT8_MAX),
+      (uint64_t)RND.rnd_int(UINT64_MAX, UINT8_MAX),
+  };
+  BcmpSystemTimeSet resp_msg = {
+      time_header,
+      0,
+  };
+  BcmpHeader header = {
+      .type = BcmpSystemTimeResponseMessage,
+  };
+  BcmpProcessData data = {0};
+  data.payload = (uint8_t *)&resp_msg;
+  data.header = &header;
+
+  // Used to check if the target node id is correct in both tests here
+  node_id_fake.return_val = time_header.target_node_id;
+
+  // Intialize processing callbacks
+  ASSERT_EQ(time_init(), BmOK);
+
+  // Test a successful response
+  ASSERT_EQ(packet_process_invoke(BcmpSystemTimeResponseMessage, data), BmOK);
+
+  // Test a response with the wrong target node id
+  resp_msg.header.target_node_id = 0;
+  ASSERT_EQ(packet_process_invoke(BcmpSystemTimeResponseMessage, data), BmEINVAL);
+  RESET_FAKE(node_id);
+
+  packet_cleanup();
+}
+
+TEST_F(Time, set_time) {
+  BcmpSystemTimeHeader header = {
+      (uint64_t)RND.rnd_int(UINT64_MAX, UINT8_MAX),
+      (uint64_t)RND.rnd_int(UINT64_MAX, UINT8_MAX),
+  };
+  BcmpSystemTimeSet set_msg = {
+      header,
+      0,
+  };
+  BcmpHeader bcmp_header = {
+      .type = BcmpSystemTimeSetMessage,
+  };
+  BcmpProcessData data = {0};
+  data.payload = (uint8_t *)&set_msg;
+  data.header = &bcmp_header;
+
+  // Use this node id for all the of the tests
+  node_id_fake.return_val = header.target_node_id;
+
+  // Intialize processing callbacks
+  ASSERT_EQ(time_init(), BmOK);
+
+  // Test successful set process
+  bcmp_tx_fake.return_val = BmOK;
+  bm_rtc_set_fake.return_val = BmOK;
+  ASSERT_EQ(packet_process_invoke(BcmpSystemTimeSetMessage, data), BmOK);
+  ASSERT_EQ(bcmp_tx_fake.call_count, 1);
+  ASSERT_EQ(bm_rtc_set_fake.call_count, 1);
+  RESET_FAKE(bm_rtc_set);
+  RESET_FAKE(bcmp_tx);
+
+  // Test set with failure to set time
+  bm_rtc_set_fake.return_val = BmEINVAL;
+  ASSERT_EQ(packet_process_invoke(BcmpSystemTimeSetMessage, data), BmOK);
+  ASSERT_EQ(bcmp_tx_fake.call_count, 0);
+  ASSERT_EQ(bm_rtc_set_fake.call_count, 1);
+  RESET_FAKE(bm_rtc_set);
+
+  // Test set with a node id of 0
+  bcmp_tx_fake.return_val = BmOK;
+  bm_rtc_set_fake.return_val = BmOK;
+  set_msg.header.target_node_id = 0;
+  ASSERT_EQ(packet_process_invoke(BcmpSystemTimeSetMessage, data), BmOK);
+  ASSERT_EQ(bcmp_tx_fake.call_count, 1);
+  ASSERT_EQ(bm_rtc_set_fake.call_count, 1);
+  RESET_FAKE(bm_rtc_set);
+  RESET_FAKE(bcmp_tx);
+}

--- a/test/src/utc_from_date_time_test.cpp
+++ b/test/src/utc_from_date_time_test.cpp
@@ -1,0 +1,220 @@
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "util.h"
+}
+#define MICROSECONDS_PER_SECOND (1000000)
+
+// The fixture for testing class Foo.
+class UTCFromDateTime : public ::testing::Test {
+ protected:
+  // You can remove any or all of the following functions if its body
+  // is empty.
+
+  UTCFromDateTime() {
+     // You can do set-up work for each test here.
+  }
+
+  ~UTCFromDateTime() override {
+     // You can do clean-up work that doesn't throw exceptions here.
+  }
+
+  // If the constructor and destructor are not enough for setting up
+  // and cleaning up each test, you can define the following methods:
+
+  void SetUp() override {
+     // Code here will be called immediately after the constructor (right
+     // before each test).
+  }
+
+  void TearDown() override {
+     // Code here will be called immediately after each test (right
+     // before the destructor).
+  }
+
+  // Objects declared here can be used by all tests in the test suite for Foo.
+};
+
+// Check the "beggining of time"
+TEST_F(UTCFromDateTime, start_of_time)
+{
+  uint32_t timestamp = utc_from_date_time(1970, 1, 1, 0, 0,0);
+  EXPECT_EQ(timestamp, 0);
+  UtcDateTime datetime;
+  uint64_t utc_us = static_cast<uint64_t>(timestamp) * MICROSECONDS_PER_SECOND;
+  date_time_from_utc(utc_us, &datetime);
+  EXPECT_EQ(datetime.year, 1970);
+  EXPECT_EQ(datetime.month, 1);
+  EXPECT_EQ(datetime.day, 1);
+  EXPECT_EQ(datetime.hour, 0);
+  EXPECT_EQ(datetime.min, 0);
+  EXPECT_EQ(datetime.sec, 0);
+  EXPECT_EQ(datetime.usec, 0);
+}
+
+// Check time in a leap year pre feb28
+TEST_F(UTCFromDateTime, sometime_in_2020)
+{
+  uint32_t timestamp = utc_from_date_time(2020, 2, 4, 9, 2,3);
+  EXPECT_EQ(timestamp, 1580806923);
+  UtcDateTime datetime;
+  uint64_t utc_us = static_cast<uint64_t>(timestamp) * MICROSECONDS_PER_SECOND;
+  date_time_from_utc(utc_us, &datetime);
+  EXPECT_EQ(datetime.year, 2020);
+  EXPECT_EQ(datetime.month, 2);
+  EXPECT_EQ(datetime.day, 4);
+  EXPECT_EQ(datetime.hour, 9);
+  EXPECT_EQ(datetime.min, 2);
+  EXPECT_EQ(datetime.sec, 3);
+  EXPECT_EQ(datetime.usec, 0);
+}
+
+// Check time in a non leap year after feb
+TEST_F(UTCFromDateTime, sometime_in_2021)
+{
+  uint32_t timestamp = utc_from_date_time(2021, 3, 4, 9, 2,3);
+  EXPECT_EQ(timestamp, 1614848523);
+  UtcDateTime datetime;
+  uint64_t utc_us = static_cast<uint64_t>(timestamp) * MICROSECONDS_PER_SECOND;
+  date_time_from_utc(utc_us, &datetime);
+  EXPECT_EQ(datetime.year, 2021);
+  EXPECT_EQ(datetime.month, 3);
+  EXPECT_EQ(datetime.day, 4);
+  EXPECT_EQ(datetime.hour, 9);
+  EXPECT_EQ(datetime.min, 2);
+  EXPECT_EQ(datetime.sec, 3);
+  EXPECT_EQ(datetime.usec, 0);
+}
+
+// Check time in a leap year after feb28
+TEST_F(UTCFromDateTime, sometime_in_2022)
+{
+  uint32_t timestamp = utc_from_date_time(2022, 3, 4, 9, 2,3);
+  EXPECT_EQ(timestamp, 1646384523);
+  UtcDateTime datetime;
+  uint64_t utc_us = static_cast<uint64_t>(timestamp) * MICROSECONDS_PER_SECOND;
+  date_time_from_utc(utc_us, &datetime);
+  EXPECT_EQ(datetime.year, 2022);
+  EXPECT_EQ(datetime.month, 3);
+  EXPECT_EQ(datetime.day, 4);
+  EXPECT_EQ(datetime.hour, 9);
+  EXPECT_EQ(datetime.min, 2);
+  EXPECT_EQ(datetime.sec, 3);
+  EXPECT_EQ(datetime.usec, 0);
+}
+
+// Last second before new year
+TEST_F(UTCFromDateTime, last_second_of_2023)
+{
+  uint32_t timestamp = utc_from_date_time(2023, 12, 31, 23, 59, 59);
+  EXPECT_EQ(timestamp, 1704067199);
+  UtcDateTime datetime;
+  uint64_t utc_us = static_cast<uint64_t>(timestamp) * MICROSECONDS_PER_SECOND;
+  date_time_from_utc(utc_us, &datetime);
+  EXPECT_EQ(datetime.year, 2023);
+  EXPECT_EQ(datetime.month, 12);
+  EXPECT_EQ(datetime.day, 31);
+  EXPECT_EQ(datetime.hour, 23);
+  EXPECT_EQ(datetime.min, 59);
+  EXPECT_EQ(datetime.sec, 59);
+  EXPECT_EQ(datetime.usec, 0);
+}
+
+// First second of the year!
+TEST_F(UTCFromDateTime, first_second_of_2024)
+{
+  uint32_t timestamp = utc_from_date_time(2024, 1, 1, 0, 0, 0);
+  EXPECT_EQ(timestamp, 1704067200);
+  UtcDateTime datetime;
+  uint64_t utc_us = static_cast<uint64_t>(timestamp) * MICROSECONDS_PER_SECOND;
+  date_time_from_utc(utc_us, &datetime);
+  EXPECT_EQ(datetime.year, 2024);
+  EXPECT_EQ(datetime.month, 1);
+  EXPECT_EQ(datetime.day, 1);
+  EXPECT_EQ(datetime.hour, 0);
+  EXPECT_EQ(datetime.min, 0);
+  EXPECT_EQ(datetime.sec, 0);
+  EXPECT_EQ(datetime.usec, 0);
+}
+
+// Another leap year check
+TEST_F(UTCFromDateTime, feb_28_2024)
+{
+  uint32_t timestamp = utc_from_date_time(2024, 2, 28, 23, 59, 59);
+  EXPECT_EQ(timestamp, 1709164799);
+  UtcDateTime datetime;
+  uint64_t utc_us = static_cast<uint64_t>(timestamp) * MICROSECONDS_PER_SECOND;
+  date_time_from_utc(utc_us, &datetime);
+  EXPECT_EQ(datetime.year, 2024);
+  EXPECT_EQ(datetime.month, 2);
+  EXPECT_EQ(datetime.day, 28);
+  EXPECT_EQ(datetime.hour, 23);
+  EXPECT_EQ(datetime.min, 59);
+  EXPECT_EQ(datetime.sec, 59);
+  EXPECT_EQ(datetime.usec, 0);
+}
+
+// Another leap year check
+TEST_F(UTCFromDateTime, feb_29_2024)
+{
+  uint32_t timestamp = utc_from_date_time(2024, 2, 29, 0, 0, 0);
+  EXPECT_EQ(timestamp, 1709164800);
+  UtcDateTime datetime;
+  uint64_t utc_us = static_cast<uint64_t>(timestamp) * MICROSECONDS_PER_SECOND;
+  date_time_from_utc(utc_us, &datetime);
+  EXPECT_EQ(datetime.year, 2024);
+  EXPECT_EQ(datetime.month, 2);
+  EXPECT_EQ(datetime.day, 29);
+  EXPECT_EQ(datetime.hour, 0);
+  EXPECT_EQ(datetime.min, 0);
+  EXPECT_EQ(datetime.sec, 0);
+  EXPECT_EQ(datetime.usec, 0);
+}
+
+TEST_F(UTCFromDateTime, microseconds_max_test)
+{
+  uint32_t timestamp = utc_from_date_time(2024, 2, 29, 0, 0, 0);
+  EXPECT_EQ(timestamp, 1709164800);
+  UtcDateTime datetime;
+  uint64_t utc_us = static_cast<uint64_t>(timestamp) * MICROSECONDS_PER_SECOND + (MICROSECONDS_PER_SECOND-1);
+  date_time_from_utc(utc_us, &datetime);
+  EXPECT_EQ(datetime.year, 2024);
+  EXPECT_EQ(datetime.month, 2);
+  EXPECT_EQ(datetime.day, 29);
+  EXPECT_EQ(datetime.hour, 0);
+  EXPECT_EQ(datetime.min, 0);
+  EXPECT_EQ(datetime.sec, 0);
+  EXPECT_EQ(datetime.usec, 999999);
+}
+
+TEST_F(UTCFromDateTime, millis_test)
+{
+  uint32_t timestamp = utc_from_date_time(2024, 2, 29, 0, 0, 0);
+  EXPECT_EQ(timestamp, 1709164800);
+  UtcDateTime datetime;
+  uint64_t utc_us = static_cast<uint64_t>(timestamp) * MICROSECONDS_PER_SECOND + (11000);
+  date_time_from_utc(utc_us, &datetime);
+  EXPECT_EQ(datetime.year, 2024);
+  EXPECT_EQ(datetime.month, 2);
+  EXPECT_EQ(datetime.day, 29);
+  EXPECT_EQ(datetime.hour, 0);
+  EXPECT_EQ(datetime.min, 0);
+  EXPECT_EQ(datetime.sec, 0);
+  EXPECT_EQ(datetime.usec, 11000);
+}
+
+TEST_F(UTCFromDateTime, check_2038)
+{
+  uint32_t timestamp = utc_from_date_time(2038, 1, 19, 0, 0, 0);
+  EXPECT_EQ(timestamp, 2147472000);
+  UtcDateTime datetime;
+  uint64_t utc_us = static_cast<uint64_t>(timestamp) * MICROSECONDS_PER_SECOND;
+  date_time_from_utc(utc_us, &datetime);
+  EXPECT_EQ(datetime.year, 2038);
+  EXPECT_EQ(datetime.month, 1);
+  EXPECT_EQ(datetime.day, 19);
+  EXPECT_EQ(datetime.hour, 0);
+  EXPECT_EQ(datetime.min, 0);
+  EXPECT_EQ(datetime.sec, 0);
+  EXPECT_EQ(datetime.usec, 0);
+}

--- a/test/stubs/bm_rtc_stub.c
+++ b/test/stubs/bm_rtc_stub.c
@@ -1,0 +1,5 @@
+#include "mock_bm_rtc.h"
+
+DEFINE_FAKE_VALUE_FUNC(BmErr, bm_rtc_set, const RtcTimeAndDate *);
+DEFINE_FAKE_VALUE_FUNC(BmErr, bm_rtc_get, RtcTimeAndDate *);
+DEFINE_FAKE_VALUE_FUNC(uint64_t, bm_rtc_get_micro_seconds, RtcTimeAndDate *);


### PR DESCRIPTION
Brings over time_generic and UTC_from_date_time unit tests from bm_protocol. These are both in util.h/.c now so would it make more sense to have a big util_test.c file? or keep the different functions in their own tests?

Also created new bcmp time tests.