### PR TITLE
Rename NetworkInterface to NetworkDevice

### DIFF
--- a/drivers/adin2111/bm_adin2111.c
+++ b/drivers/adin2111/bm_adin2111.c
@@ -267,12 +267,12 @@ end:
   return err;
 }
 
-/// Build a generic NetworkInterface out of a concrete Adin2111
-NetworkInterface prep_adin2111_netif(Adin2111 *self) {
+/// Build a generic NetworkDevice out of a concrete Adin2111
+NetworkDevice prep_adin2111_netif(Adin2111 *self) {
   // Create the vtable once and attach a pointer to it every time
-  static NetworkInterfaceTrait const trait = {.send = adin2111_netif_send_,
+  static NetworkDeviceTrait const trait = {.send = adin2111_netif_send_,
                                               .enable = adin2111_netif_enable_,
                                               .disable =
                                                   adin2111_netif_disable_};
-  return (NetworkInterface){.trait = &trait, .self = self};
+  return (NetworkDevice){.trait = &trait, .self = self};
 }

--- a/drivers/adin2111/bm_adin2111.h
+++ b/drivers/adin2111/bm_adin2111.h
@@ -1,12 +1,12 @@
 #include "adin2111.h"
-#include "network_interface.h"
+#include "network_device.h"
 #include "util.h"
 
 #define ADIN2111_PORT_MASK (3U)
 
 typedef struct {
   void *device_handle;
-  NetworkInterfaceCallbacks const *callbacks;
+  NetworkDeviceCallbacks const *callbacks;
 } Adin2111;
 
 #ifdef __cplusplus
@@ -14,7 +14,7 @@ extern "C" {
 #endif
 
 BmErr adin2111_init(Adin2111 *self);
-NetworkInterface prep_adin2111_netif(Adin2111 *self);
+NetworkDevice prep_adin2111_netif(Adin2111 *self);
 
 #ifdef __cplusplus
 }

--- a/network/network_device.h
+++ b/network/network_device.h
@@ -4,16 +4,16 @@ typedef struct {
   void (*power)(bool on);
   void (*link_change)(uint8_t port_index, bool is_up);
   size_t (*receive)(uint8_t port_index, uint8_t *data, size_t length);
-} NetworkInterfaceCallbacks;
+} NetworkDeviceCallbacks;
 
 typedef struct {
   BmErr (*const send)(void *self, uint8_t *data, size_t length,
                       uint8_t port_mask);
   BmErr (*const enable)(void *self);
   BmErr (*const disable)(void *self);
-} NetworkInterfaceTrait;
+} NetworkDeviceTrait;
 
 typedef struct {
   void *self;
-  NetworkInterfaceTrait const *trait;
-} NetworkInterface;
+  NetworkDeviceTrait const *trait;
+} NetworkDevice;

--- a/test/src/bm_adin2111_test.cpp
+++ b/test/src/bm_adin2111_test.cpp
@@ -26,12 +26,12 @@ FAKE_VOID_FUNC(netif_power_cb, bool);
 FAKE_VOID_FUNC(link_changed_on_port, uint8_t, bool);
 FAKE_VALUE_FUNC(size_t, received_data_on_port, uint8_t, uint8_t *, size_t);
 
-static NetworkInterfaceCallbacks const callbacks = {
+static NetworkDeviceCallbacks const callbacks = {
     .power = netif_power_cb,
     .link_change = link_changed_on_port,
     .receive = received_data_on_port};
 
-static NetworkInterface setup(void) {
+static NetworkDevice setup(void) {
   static Adin2111 adin = {.device_handle = nullptr, .callbacks = &callbacks};
 
   // We can only call adin2111_init once per execution (test suite)
@@ -48,14 +48,14 @@ static NetworkInterface setup(void) {
 }
 
 TEST(Adin2111, send) {
-  NetworkInterface netif = setup();
+  NetworkDevice netif = setup();
   BmErr err = netif.trait->send(netif.self, (unsigned char *)"hello", 5,
                                 ADIN2111_PORT_MASK);
   EXPECT_EQ(err, BmOK);
 }
 
 TEST(Adin2111, enable) {
-  NetworkInterface netif = setup();
+  NetworkDevice netif = setup();
   // Expect the same BmENODEV error as in init
   // because init calls enable internally.
   // On a real device, this should return BmOK,
@@ -65,7 +65,7 @@ TEST(Adin2111, enable) {
 }
 
 TEST(Adin2111, disable) {
-  NetworkInterface netif = setup();
+  NetworkDevice netif = setup();
   // SEGFAULT because PHY is NULL, because no real SPI transactions
   EXPECT_DEATH(netif.trait->disable(netif.self), "");
 }


### PR DESCRIPTION
This avoids conflicts with lwip's netif and prevents confusion