### PR TITLE
Config abstraction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ execute_process(
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
 )
 
-set(COMPILE_FLAGS
+add_compile_definitions(
     -DCBOR_CUSTOM_ALLOC_INCLUDE="tinycbor_alloc.h"
     -DCBOR_PARSER_MAX_RECURSIONS=10
 )
@@ -72,15 +72,7 @@ if(ENABLE_TESTING)
     enable_testing()
     add_subdirectory("test")
 else()
-    set(BM_SOURCES
-        ${CMAKE_CURRENT_LIST_DIR}/third_party/tinycbor/src/cborparser.c
-        ${CMAKE_CURRENT_LIST_DIR}/third_party/tinycbor/src/cborencoder_float.c
-        ${CMAKE_CURRENT_LIST_DIR}/third_party/tinycbor/src/cborencoder.c
-        ${CMAKE_CURRENT_LIST_DIR}/third_party/tinycbor/src/cborerrorstrings.c
-        ${CMAKE_CURRENT_LIST_DIR}/third_party/tinycbor/src/cborvalidation.c
-        ${CMAKE_CURRENT_LIST_DIR}/third_party/crc/crc16.c
-        ${CMAKE_CURRENT_LIST_DIR}/third_party/crc/crc32.c
-    )
+    set(BM_SOURCES "")
 
     # Ensure integrator called the functions necessary to configure bristlemouth
     set(ERROR_MESSAGE "")
@@ -115,6 +107,7 @@ else()
     add_subdirectory(common)
     add_subdirectory(bm_common_messages)
     add_subdirectory(network)
+    add_subdirectory(third_party)
     add_subdirectory(drivers/adin2111)
 
     target_link_libraries(bmcore PUBLIC
@@ -123,5 +116,6 @@ else()
         middleware
         bmmessages
         bmnetwork
+        bmthirdparty
     )
 endif()

--- a/bcmp/CMakeLists.txt
+++ b/bcmp/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SOURCES
     resource_discovery.c
     time.c
     topology.c
+    configuration.c
 )
 
 add_library(bcmp ${SOURCES})

--- a/bcmp/bm_configs_generic.h
+++ b/bcmp/bm_configs_generic.h
@@ -6,40 +6,4 @@
 #include "util.h"
 #include <stdint.h>
 
-#define BM_MAX_KEY_LEN_BYTES 32
-#define BM_MAX_NUM_KV 50
-#define BM_MAX_KEY_LEN_BYTES 32
-#define BM_MAX_STR_LEN_BYTES 50
-#define BM_MAX_CONFIG_BUFFER_SIZE_BYTES 50
-#define BM_CONFIG_VERSION 0
-
-typedef enum {
-  UINT32,
-  INT32,
-  FLOAT,
-  STR,
-  BYTES,
-  ARRAY,
-} GenericConfigDataTypes;
-
-typedef struct {
-  char keyBuffer[BM_MAX_KEY_LEN_BYTES];
-  size_t keyLen;
-  GenericConfigDataTypes valueType;
-} __attribute__((packed, aligned(1))) GenericConfigKey;
-
-const GenericConfigKey *
-bcmp_config_get_stored_keys(uint8_t *num_stored_keys,
-                            BmConfigPartition partition);
-bool bcmp_remove_key(const char *key, size_t key_len,
-                     BmConfigPartition partition);
-bool bcmp_config_needs_commit(BmConfigPartition partition);
-bool bcmp_commit_config(BmConfigPartition partition);
-bool bcmp_set_config(const char *key, size_t key_len, uint8_t *value,
-                     size_t value_len, BmConfigPartition partition);
-bool bcmp_get_config(const char *key, size_t key_len, uint8_t *value,
-                     size_t *value_len, BmConfigPartition partition);
-bool bm_cbor_type_to_config_type(const CborValue *value,
-                                 GenericConfigDataTypes *configType);
-
 #endif // __BM_CONFIGS_GENERIC_H__

--- a/bcmp/bm_configs_generic.h
+++ b/bcmp/bm_configs_generic.h
@@ -6,4 +6,10 @@
 #include "util.h"
 #include <stdint.h>
 
+bool bm_config_read(BmConfigPartition partition, uint32_t offset,
+                    uint8_t *buffer, size_t length, uint32_t timeout_ms);
+bool bm_config_write(BmConfigPartition partition, uint32_t offset,
+                     uint8_t *buffer, size_t length, uint32_t timeout_ms);
+void bm_config_reset(void);
+
 #endif // __BM_CONFIGS_GENERIC_H__

--- a/bcmp/bm_configs_generic.h
+++ b/bcmp/bm_configs_generic.h
@@ -1,9 +1,8 @@
 #ifndef __BM_CONFIGS_GENERIC_H__
 #define __BM_CONFIGS_GENERIC_H__
 
-#include "cbor.h"
-#include "messages.h"
-#include "util.h"
+#include "configuration.h"
+#include <stddef.h>
 #include <stdint.h>
 
 bool bm_config_read(BmConfigPartition partition, uint32_t offset,

--- a/bcmp/configuration.c
+++ b/bcmp/configuration.c
@@ -1,0 +1,769 @@
+#include "configuration.h"
+#include "bm_configs_generic.h"
+#include "crc.h"
+#include <stdio.h>
+#ifndef CBOR_CUSTOM_ALLOC_INCLUDE
+#error "CBOR_CUSTOM_ALLOC_INCLUDE must be defined!"
+#endif // CBOR_CUSTOM_ALLOC_INCLUDE
+#ifndef CBOR_PARSER_MAX_RECURSIONS
+#error "CBOR_PARSER_MAX_RECURSIONS must be defined!"
+#endif // CBOR_PARSER_MAX_RECURSIONS
+#define RAM_CONFIG_BUFFER_SIZE (10 * 1024)
+
+struct ConfigInfo {
+  uint8_t ram_buffer[RAM_CONFIG_BUFFER_SIZE];
+  bool needs_commit;
+};
+
+static struct ConfigInfo CONFIGS[BM_CFG_PARTITION_COUNT];
+
+static bool find_key_idx(BmConfigPartition partition, const char *key,
+                         size_t len, uint8_t *idx) {
+  ConfigPartition *config_partition =
+      (ConfigPartition *)CONFIGS[partition].ram_buffer;
+  bool ret = false;
+
+  for (int i = 0; i < config_partition->header.numKeys; i++) {
+    if (strncmp(key, config_partition->keys[i].keyBuffer, len) == 0) {
+      *idx = i;
+      ret = true;
+      break;
+    }
+  }
+
+  return ret;
+}
+
+static bool prepare_cbor_encoder(BmConfigPartition partition, const char *key,
+                                 size_t key_len, CborEncoder *encoder,
+                                 uint8_t *key_idx, bool *key_exists) {
+  bool ret = false;
+  ConfigPartition *config_partition =
+      (ConfigPartition *)CONFIGS[partition].ram_buffer;
+
+  if (key) {
+    do {
+      if (key_len > MAX_KEY_LEN_BYTES) {
+        break;
+      }
+      if (config_partition->header.numKeys >= MAX_NUM_KV) {
+        break;
+      }
+      *key_exists = find_key_idx(partition, key, key_len, key_idx);
+      if (!*key_exists) {
+        *key_idx = config_partition->header.numKeys;
+      }
+      if (snprintf(config_partition->keys[*key_idx].keyBuffer,
+                   sizeof(config_partition->keys[*key_idx].keyBuffer), "%s",
+                   key) < 0) {
+        break;
+      }
+      cbor_encoder_init(encoder, config_partition->values[*key_idx].valueBuffer,
+                        sizeof(config_partition->values[*key_idx].valueBuffer),
+                        0);
+      ret = true;
+    } while (0);
+  }
+
+  return ret;
+}
+
+static bool prepare_cbor_parser(BmConfigPartition partition, const char *key,
+                                size_t key_len, CborValue *it,
+                                CborParser *parser) {
+  bool ret = false;
+  uint8_t key_idx;
+  ConfigPartition *config_partition =
+      (ConfigPartition *)CONFIGS[partition].ram_buffer;
+
+  if (key) {
+    do {
+      if (key_len > MAX_KEY_LEN_BYTES) {
+        break;
+      }
+      if (!find_key_idx(partition, key, key_len, &key_idx)) {
+        break;
+      }
+      if (cbor_parser_init(
+              config_partition->values[key_idx].valueBuffer,
+              sizeof(config_partition->values[key_idx].valueBuffer), 0, parser,
+              it) != CborNoError) {
+        break;
+      }
+      ret = true;
+    } while (0);
+  }
+
+  return ret;
+}
+
+static bool load_and_verify_nvm_config(ConfigPartition *config_partition,
+                                       BmConfigPartition partition) {
+  bool ret = false;
+
+  do {
+    if (!bm_config_read(partition, CONFIG_START_OFFSET_IN_BYTES,
+                        (uint8_t *)config_partition, sizeof(ConfigPartition),
+                        CONFIG_LOAD_TIMEOUT_MS)) {
+      break;
+    }
+    uint32_t partition_crc32 = crc32_ieee(
+        (const uint8_t *)&config_partition->header.version,
+        (sizeof(ConfigPartition) - sizeof(config_partition->header.crc32)));
+    if (config_partition->header.crc32 != partition_crc32) {
+      break;
+    }
+    ret = true;
+  } while (0);
+  return ret;
+}
+
+void config_init(void) {
+  for (uint8_t i = 0; i < BM_CFG_PARTITION_COUNT; i++) {
+    ConfigPartition *config_partition =
+        (ConfigPartition *)CONFIGS[i].ram_buffer;
+    if (!load_and_verify_nvm_config(config_partition, (BmConfigPartition)i)) {
+      printf("Unable to load configs from flash.");
+      config_partition->header.numKeys = 0;
+      config_partition->header.version = CONFIG_VERSION;
+      // TODO: Once we have default configs, load these into flash.
+    } else {
+      printf("Succesfully loaded configs from flash.");
+    }
+  }
+}
+
+/*!
+* Get uint64 config
+* \param key[in] - null terminated key
+* \param value[out] - value
+* \returns - true if success, false otherwise.
+*/
+bool get_config_uint(BmConfigPartition partition, const char *key,
+                     size_t key_len, uint32_t *value) {
+  bool ret = false;
+
+  CborValue it;
+  CborParser parser;
+
+  if (key) {
+    do {
+      if (!prepare_cbor_parser(partition, key, key_len, &it, &parser)) {
+        break;
+      }
+      uint64_t temp;
+      if (!cbor_value_is_unsigned_integer(&it)) {
+        break;
+      }
+      if (cbor_value_get_uint64(&it, &temp) != CborNoError) {
+        break;
+      }
+      *value = (uint32_t)temp;
+      ret = true;
+    } while (0);
+  }
+  return ret;
+}
+
+/*!
+* Get int32 config
+* \param key[in] - null terminated key
+* \param value[out] - value
+* \returns - true if success, false otherwise.
+*/
+bool get_config_int(BmConfigPartition partition, const char *key,
+                    size_t key_len, int32_t *value) {
+  bool ret = false;
+  CborValue it;
+  CborParser parser;
+
+  if (key) {
+    do {
+      if (!prepare_cbor_parser(partition, key, key_len, &it, &parser)) {
+        break;
+      }
+      int64_t temp;
+      if (!cbor_value_is_integer(&it)) {
+        break;
+      }
+      if (cbor_value_get_int64(&it, &temp) != CborNoError) {
+        break;
+      }
+      *value = (int32_t)temp;
+      ret = true;
+    } while (0);
+  }
+
+  return ret;
+}
+
+/*!
+* Get float config
+* \param key[in] - null terminated key
+* \param value[out] - value
+* \returns - true if success, false otherwise.
+*/
+bool get_config_float(BmConfigPartition partition, const char *key,
+                      size_t key_len, float *value) {
+  bool ret = false;
+  CborValue it;
+  CborParser parser;
+
+  if (key) {
+    do {
+      if (!prepare_cbor_parser(partition, key, key_len, &it, &parser)) {
+        break;
+      }
+      float temp;
+      if (!cbor_value_is_float(&it)) {
+        break;
+      }
+      if (cbor_value_get_float(&it, &temp) != CborNoError) {
+        break;
+      }
+      *value = temp;
+      ret = true;
+    } while (0);
+  }
+
+  return ret;
+}
+
+/*!
+* Get str config
+* \param key[in] - null terminated key
+* \param value[out] - value (non null terminated)
+* \param value_len[in/out] - in: buffer size, out:bytes len
+* \returns - true if success, false otherwise.
+*/
+bool get_config_string(BmConfigPartition partition, const char *key,
+                       size_t key_len, char *value, size_t *value_len) {
+  bool ret = false;
+
+  CborValue it;
+  CborParser parser;
+
+  if (key && value) {
+    do {
+      if (!prepare_cbor_parser(partition, key, key_len, &it, &parser)) {
+        break;
+      }
+      if (!cbor_value_is_text_string(&it)) {
+        break;
+      }
+      if (cbor_value_copy_text_string(&it, value, value_len, NULL) !=
+          CborNoError) {
+        break;
+      }
+      ret = true;
+    } while (0);
+  }
+
+  return ret;
+}
+
+/*!
+* Get bytes config
+* \param key[in] - null terminated key
+* \param value[out] - value
+* \param value_len[in/out] - in: buffer size, out:bytes len
+* \returns - true if success, false otherwise.
+*/
+bool get_config_buffer(BmConfigPartition partition, const char *key,
+                       size_t key_len, uint8_t *value, size_t *value_len) {
+  bool ret = false;
+
+  CborValue it;
+  CborParser parser;
+
+  if (key && value) {
+    do {
+      if (!prepare_cbor_parser(partition, key, key_len, &it, &parser)) {
+        break;
+      }
+      if (!cbor_value_is_byte_string(&it)) {
+        break;
+      }
+      if (cbor_value_copy_byte_string(&it, value, value_len, NULL) !=
+          CborNoError) {
+        break;
+      }
+      ret = true;
+    } while (0);
+  }
+
+  return ret;
+}
+
+/*!
+* Get the cbor encoded buffer for a given key.
+* \param key[in] - null terminated key
+* \param value[out] - value buffer
+* \param value_len[in/out] -  in: buffer size, out :buffer len
+* \returns - true if success, false otherwise.
+*/
+bool get_config_cbor(BmConfigPartition partition, const char *key,
+                     size_t key_len, uint8_t *value, size_t *value_len) {
+  bool ret = false;
+  ConfigPartition *config_partition =
+      (ConfigPartition *)CONFIGS[partition].ram_buffer;
+  CborValue it;
+  CborParser parser;
+  uint8_t key_idx;
+
+  if (key && value) {
+    do {
+      if (!prepare_cbor_parser(partition, key, key_len, &it, &parser)) {
+        break;
+      }
+      if (!cbor_value_is_valid(&it)) {
+        break;
+      }
+      if (!find_key_idx(partition, key, key_len, &key_idx)) {
+        break;
+      }
+      size_t buffer_size =
+          sizeof(config_partition->values[key_idx].valueBuffer);
+      if (*value_len < buffer_size || value_len == 0) {
+        break;
+      }
+      memcpy(value, config_partition->values[key_idx].valueBuffer, buffer_size);
+      *value_len = buffer_size;
+      ret = true;
+    } while (0);
+  }
+
+  return ret;
+}
+
+/*!
+* sets uint32 config
+* \param key[in] - null terminated key
+* \param value[in] - value
+* \returns - true if success, false otherwise.
+*/
+bool set_config_uint(BmConfigPartition partition, const char *key,
+                     size_t key_len, uint32_t value) {
+  bool ret = false;
+  ConfigPartition *config_partition =
+      (ConfigPartition *)CONFIGS[partition].ram_buffer;
+  CborEncoder encoder;
+  uint8_t key_idx;
+  bool key_exists;
+
+  if (key) {
+    do {
+      if (!prepare_cbor_encoder(partition, key, key_len, &encoder, &key_idx,
+                                &key_exists)) {
+        break;
+      }
+      if (cbor_encode_uint(&encoder, value) != CborNoError) {
+        break;
+      }
+      config_partition->keys[key_idx].valueType = UINT32;
+      config_partition->keys[key_idx].keyLen = key_len;
+      if (!key_exists) {
+        config_partition->header.numKeys++;
+      }
+      CONFIGS[partition].needs_commit = true;
+      ret = true;
+    } while (0);
+  }
+
+  return ret;
+}
+
+/*!
+* sets int32 config
+* \param key[in] -  null terminated key
+* \param value[in] - value
+* \returns - true if success, false otherwise.
+*/
+bool set_config_int(BmConfigPartition partition, const char *key,
+                    size_t key_len, int32_t value) {
+  bool ret = false;
+  ConfigPartition *config_partition =
+      (ConfigPartition *)CONFIGS[partition].ram_buffer;
+  CborEncoder encoder;
+  uint8_t key_idx;
+  bool key_exists;
+
+  if (key) {
+    do {
+      if (!prepare_cbor_encoder(partition, key, key_len, &encoder, &key_idx,
+                                &key_exists)) {
+        break;
+      }
+      if (cbor_encode_int(&encoder, value) != CborNoError) {
+        break;
+      }
+      config_partition->keys[key_idx].valueType = INT32;
+      config_partition->keys[key_idx].keyLen = key_len;
+      if (!key_exists) {
+        config_partition->header.numKeys++;
+      }
+      CONFIGS[partition].needs_commit = true;
+      ret = true;
+    } while (0);
+  }
+
+  return ret;
+}
+
+/*!
+* sets float config
+* \param key[in] -  null terminated key
+* \param value[in] - value
+* \returns - true if success, false otherwise.
+*/
+bool set_config_float(BmConfigPartition partition, const char *key,
+                      size_t key_len, float value) {
+  bool ret = false;
+  ConfigPartition *config_partition =
+      (ConfigPartition *)CONFIGS[partition].ram_buffer;
+  CborEncoder encoder;
+  uint8_t key_idx;
+  bool key_exists;
+
+  if (key) {
+    do {
+      if (!prepare_cbor_encoder(partition, key, key_len, &encoder, &key_idx,
+                                &key_exists)) {
+        break;
+      }
+      if (cbor_encode_float(&encoder, value) != CborNoError) {
+        break;
+      }
+      config_partition->keys[key_idx].valueType = FLOAT;
+      config_partition->keys[key_idx].keyLen = key_len;
+      if (!key_exists) {
+        config_partition->header.numKeys++;
+      }
+      CONFIGS[partition].needs_commit = true;
+      ret = true;
+    } while (0);
+  }
+
+  return ret;
+}
+
+/*!
+* sets a null-terminated str config
+* \param key[in] -  null terminated key
+* \param value[in] - value
+* \returns - true if success, false otherwise.
+*/
+bool set_config_string(BmConfigPartition partition, const char *key,
+                       size_t key_len, const char *value, size_t value_len) {
+  bool ret = false;
+  ConfigPartition *config_partition =
+      (ConfigPartition *)CONFIGS[partition].ram_buffer;
+  CborEncoder encoder;
+  uint8_t key_idx;
+  bool key_exists;
+
+  if (key) {
+    do {
+      if (!prepare_cbor_encoder(partition, key, key_len, &encoder, &key_idx,
+                                &key_exists)) {
+        break;
+      }
+      if (cbor_encode_text_string(&encoder, value, value_len) != CborNoError) {
+        break;
+      }
+      config_partition->keys[key_idx].valueType = STR;
+      config_partition->keys[key_idx].keyLen = key_len;
+      if (!key_exists) {
+        config_partition->header.numKeys++;
+      }
+      CONFIGS[partition].needs_commit = true;
+      ret = true;
+    } while (0);
+  }
+
+  return ret;
+}
+
+/*!
+* sets bytes config
+* \param key[in] -  null terminated key
+* \param value[in] - value
+* \param value_len[in] - bytes len
+* \returns - true if success, false otherwise.
+*/
+bool set_config_buffer(BmConfigPartition partition, const char *key,
+                       size_t key_len, const uint8_t *value, size_t value_len) {
+  bool ret = false;
+  ConfigPartition *config_partition =
+      (ConfigPartition *)CONFIGS[partition].ram_buffer;
+  CborEncoder encoder;
+  uint8_t key_idx;
+  bool key_exists;
+
+  if (key) {
+    do {
+      if (!prepare_cbor_encoder(partition, key, key_len, &encoder, &key_idx,
+                                &key_exists)) {
+        break;
+      }
+      if (cbor_encode_byte_string(&encoder, value, value_len) != CborNoError) {
+        break;
+      }
+      config_partition->keys[key_idx].valueType = BYTES;
+      config_partition->keys[key_idx].keyLen = key_len;
+      if (!key_exists) {
+        config_partition->header.numKeys++;
+      }
+      CONFIGS[partition].needs_commit = true;
+      ret = true;
+    } while (0);
+  }
+
+  return ret;
+}
+
+/*!
+* Sets any cbor conifguration to a given key,
+* \param key[in] -  null terminated key
+* \param value[in] - value buffer
+* \param value_len[in] - buffer len
+* \returns - true if success, false otherwise.
+*/
+bool set_config_cbor(BmConfigPartition partition, const char *key,
+                     size_t key_len, uint8_t *value, size_t value_len) {
+  CborValue it;
+  CborParser parser;
+  uint8_t key_idx;
+  bool ret = false;
+  ConfigPartition *config_partition =
+      (ConfigPartition *)CONFIGS[partition].ram_buffer;
+
+  if (key && value) {
+    do {
+      if (key_len > MAX_KEY_LEN_BYTES) {
+        break;
+      }
+      if (value_len > MAX_CONFIG_BUFFER_SIZE_BYTES || value_len == 0) {
+        break;
+      }
+      if (cbor_parser_init(value, value_len, 0, &parser, &it) != CborNoError) {
+        break;
+      }
+      if (!cbor_value_is_valid(&it)) {
+        break;
+      }
+      if (!find_key_idx(partition, key, key_len, &key_idx)) {
+        if (config_partition->header.numKeys >= MAX_NUM_KV) {
+          break;
+        }
+        key_idx = config_partition->header.numKeys;
+        if (snprintf(config_partition->keys[key_idx].keyBuffer,
+                     sizeof(config_partition->keys[key_idx].keyBuffer), "%s",
+                     key) < 0) {
+          break;
+        }
+      }
+      ConfigDataTypes type;
+      if (!cbor_type_to_config(&it, &type)) {
+        break;
+      }
+      config_partition->keys[key_idx].valueType = type;
+      config_partition->keys[key_idx].keyLen = key_len;
+      memcpy(config_partition->values[key_idx].valueBuffer, value, value_len);
+      if (key_idx == config_partition->header.numKeys) {
+        config_partition->header.numKeys++;
+      }
+      CONFIGS[partition].needs_commit = true;
+      ret = true;
+    } while (0);
+  }
+
+  return ret;
+}
+
+/*!
+* Sets any cbor conifguration to a given key,
+* \param cbor[in] -  cbor type to convert from
+* \param config_type[out] - config type to convert to
+* \returns - true if success, false otherwise.
+*/
+bool cbor_type_to_config(const CborValue *value, ConfigDataTypes *config_type) {
+  bool ret = true;
+  do {
+    if (cbor_value_is_integer(value)) {
+      if (cbor_value_is_unsigned_integer(value)) {
+        *config_type = UINT32;
+        break;
+      } else {
+        *config_type = INT32;
+        break;
+      }
+    } else if (cbor_value_is_byte_string(value)) {
+      *config_type = BYTES;
+      break;
+    } else if (cbor_value_is_text_string(value)) {
+      *config_type = STR;
+      break;
+    } else if (cbor_value_is_float(value)) {
+      *config_type = FLOAT;
+      break;
+    } else if (cbor_value_is_array(value)) {
+      *config_type = ARRAY;
+      break;
+    }
+    ret = false;
+  } while (0);
+  return ret;
+}
+
+/*!
+* Gets a list of the keys stored in the configuration.
+* \param num_stored_key[out] - number of keys stored
+* \returns - map of keys
+*/
+const ConfigKey *get_stored_keys(BmConfigPartition partition,
+                                 uint8_t *num_stored_keys) {
+  ConfigPartition *config_partition =
+      (ConfigPartition *)CONFIGS[partition].ram_buffer;
+  *num_stored_keys = config_partition->header.numKeys;
+  return config_partition->keys;
+}
+
+/*!
+* Remove a key/value from the store.
+* \param key[in] - null terminated key
+* \returns - true if successful, false otherwise.
+*/
+bool remove_key(BmConfigPartition partition, const char *key, size_t key_len) {
+  bool ret = false;
+  ConfigPartition *config_partition =
+      (ConfigPartition *)CONFIGS[partition].ram_buffer;
+  uint8_t key_idx;
+
+  if (key) {
+    do {
+      if (!find_key_idx(partition, key, key_len, &key_idx)) {
+        break;
+      }
+      if (config_partition->header.numKeys - 1 >
+          key_idx) { // if there are keys after, we need to move them up.
+        memmove(&config_partition->keys[key_idx],
+                &config_partition->keys[key_idx + 1],
+                (config_partition->header.numKeys - 1 - key_idx) *
+                    sizeof(ConfigKey)); // shift keys
+        memmove(&config_partition->values[key_idx],
+                &config_partition->values[key_idx + 1],
+                (config_partition->header.numKeys - 1 - key_idx) *
+                    sizeof(ConfigValue)); // shift values
+      }
+      config_partition->header.numKeys--;
+      CONFIGS[partition].needs_commit = true;
+      ret = true;
+    } while (0);
+  }
+
+  return ret;
+}
+
+const char *data_type_enum_to_str(ConfigDataTypes type) {
+  const char *ret = NULL;
+
+  switch (type) {
+  case UINT32:
+    ret = "uint32";
+    break;
+  case INT32:
+    ret = "int32";
+    break;
+  case FLOAT:
+    ret = "float";
+    break;
+  case STR:
+    ret = "str";
+    break;
+  case BYTES:
+    ret = "bytes";
+    break;
+  case ARRAY:
+    ret = "array";
+    break;
+  }
+
+  return ret;
+}
+
+bool save_config(BmConfigPartition partition, bool restart) {
+  bool ret = false;
+  ConfigPartition *config_partition =
+      (ConfigPartition *)CONFIGS[partition].ram_buffer;
+
+  do {
+    config_partition->header.crc32 = crc32_ieee(
+        (const uint8_t *)&config_partition->header.version,
+        (sizeof(ConfigPartition) - sizeof(config_partition->header.crc32)));
+    if (!bm_config_write(partition, CONFIG_START_OFFSET_IN_BYTES,
+                         (uint8_t *)config_partition, sizeof(ConfigPartition),
+                         CONFIG_LOAD_TIMEOUT_MS)) {
+      break;
+    }
+    if (restart) {
+      bm_config_reset();
+    }
+    ret = true;
+  } while (0);
+
+  return ret;
+}
+
+bool get_value_size(BmConfigPartition partition, const char *key,
+                    size_t key_len, size_t *size) {
+  bool ret = false;
+  CborValue it;
+  CborParser parser;
+
+  if (key) {
+    do {
+      if (!prepare_cbor_parser(partition, key, key_len, &it, &parser)) {
+        break;
+      }
+      ConfigDataTypes config_type;
+      if (!cbor_type_to_config(&it, &config_type)) {
+        break;
+      }
+      switch (config_type) {
+      case UINT32: {
+        *size = sizeof(uint32_t);
+        break;
+      }
+      case INT32: {
+        *size = sizeof(int32_t);
+        break;
+      }
+      case FLOAT: {
+        *size = sizeof(float);
+        break;
+      }
+      case STR:
+      case BYTES: {
+        if (cbor_value_get_string_length(&it, size) != CborNoError) {
+          return false;
+        }
+        break;
+      }
+      case ARRAY: {
+        if (cbor_value_get_array_length(&it, size) != CborNoError) {
+          return false;
+        }
+        break;
+      }
+      }
+      ret = true;
+    } while (0);
+  }
+
+  return ret;
+}
+
+bool needs_commit(BmConfigPartition partition) {
+  return CONFIGS[partition].needs_commit;
+}

--- a/bcmp/configuration.c
+++ b/bcmp/configuration.c
@@ -3,7 +3,7 @@
 #include "crc.h"
 #include <stdio.h>
 #ifndef CBOR_CUSTOM_ALLOC_INCLUDE
-#error "CBOR_CUSTOM_ALLOC_INCLUDE must be defined!"
+#error "CBOR_CUSTOM_ALLOC_INCLUDE must be defined!"configuration.c
 #endif // CBOR_CUSTOM_ALLOC_INCLUDE
 #ifndef CBOR_PARSER_MAX_RECURSIONS
 #error "CBOR_PARSER_MAX_RECURSIONS must be defined!"

--- a/bcmp/configuration.h
+++ b/bcmp/configuration.h
@@ -1,0 +1,92 @@
+#pragma once
+#include "cbor.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define CONFIG_START_OFFSET_IN_BYTES 0
+#define CONFIG_LOAD_TIMEOUT_MS 5000
+
+#define MAX_NUM_KV 50
+#define MAX_KEY_LEN_BYTES 32
+#define MAX_STR_LEN_BYTES 50
+#define MAX_CONFIG_BUFFER_SIZE_BYTES 50
+#define CONFIG_VERSION 0 // FIXME: Put this in the default config file.
+
+typedef enum {
+  BM_CFG_PARTITION_USER,
+  BM_CFG_PARTITION_SYSTEM,
+  BM_CFG_PARTITION_HARDWARE,
+  BM_CFG_PARTITION_COUNT
+} BmConfigPartition;
+
+typedef enum {
+  UINT32,
+  INT32,
+  FLOAT,
+  STR,
+  BYTES,
+  ARRAY,
+} ConfigDataTypes;
+
+typedef struct {
+  uint32_t crc32;
+  uint32_t version;
+  uint8_t numKeys;
+} __attribute__((packed, aligned(1))) ConfigPartitionHeader;
+
+typedef struct {
+  char keyBuffer[MAX_KEY_LEN_BYTES];
+  size_t keyLen;
+  ConfigDataTypes valueType;
+} __attribute__((packed, aligned(1))) ConfigKey;
+
+typedef struct {
+  uint8_t valueBuffer[MAX_CONFIG_BUFFER_SIZE_BYTES];
+} __attribute__((packed, aligned(1))) ConfigValue;
+
+typedef struct {
+  ConfigPartitionHeader header;
+  ConfigKey keys[MAX_NUM_KV];
+  ConfigValue values[MAX_NUM_KV];
+} __attribute__((packed, aligned(1))) ConfigPartition;
+
+void config_init(void);
+bool get_config_uint(BmConfigPartition partition, const char *key,
+                     size_t key_len, uint32_t *value);
+bool get_config_int(BmConfigPartition partition, const char *key,
+                    size_t key_len, int32_t *value);
+bool get_config_float(BmConfigPartition partition, const char *key,
+                      size_t key_len, float *value);
+bool get_config_string(BmConfigPartition partition, const char *key,
+                       size_t key_len, char *value, size_t *value_len);
+bool get_config_buffer(BmConfigPartition partition, const char *key,
+                       size_t key_len, uint8_t *value, size_t *value_len);
+bool get_config_cbor(BmConfigPartition partition, const char *key,
+                     size_t key_len, uint8_t *value, size_t *value_len);
+bool set_config_uint(BmConfigPartition partition, const char *key,
+                     size_t key_len, uint32_t value);
+bool set_config_int(BmConfigPartition partition, const char *key,
+                    size_t key_len, int32_t value);
+bool set_config_float(BmConfigPartition partition, const char *key,
+                      size_t key_len, float value);
+bool set_config_string(BmConfigPartition partition, const char *key,
+                       size_t key_len, const char *value, size_t value_len);
+bool set_config_buffer(BmConfigPartition partition, const char *key,
+                       size_t key_len, const uint8_t *value, size_t value_len);
+bool set_config_cbor(BmConfigPartition partition, const char *key,
+                     size_t key_len, uint8_t *value, size_t value_len);
+const ConfigKey *get_stored_keys(BmConfigPartition partition,
+                                 uint8_t *num_stored_keys);
+bool remove_key(BmConfigPartition partition, const char *key, size_t key_len);
+const char *data_type_enum_to_str(ConfigDataTypes type);
+bool save_config(BmConfigPartition partition, bool restart);
+bool get_value_size(BmConfigPartition partition, const char *key,
+                    size_t key_len, size_t *size);
+bool needs_commit(BmConfigPartition partition);
+bool cbor_type_to_config(const CborValue *value, ConfigDataTypes *configType);
+
+#ifdef __cplusplus
+}
+#endif

--- a/bcmp/configuration.h
+++ b/bcmp/configuration.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "bm_common_structs.h"
 #include "cbor.h"
 
 #ifdef __cplusplus
@@ -13,13 +14,6 @@ extern "C" {
 #define MAX_STR_LEN_BYTES 50
 #define MAX_CONFIG_BUFFER_SIZE_BYTES 50
 #define CONFIG_VERSION 0 // FIXME: Put this in the default config file.
-
-typedef enum {
-  BM_CFG_PARTITION_USER,
-  BM_CFG_PARTITION_SYSTEM,
-  BM_CFG_PARTITION_HARDWARE,
-  BM_CFG_PARTITION_COUNT
-} BmConfigPartition;
 
 typedef enum {
   UINT32,

--- a/bcmp/messages.h
+++ b/bcmp/messages.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "configuration.h"
 #include "dfu_message_structs.h"
 
 typedef struct {
@@ -305,65 +306,58 @@ typedef struct {
 // TODO move this to DFU specific stuff
 // DFU stuff goes below
 typedef struct {
- BmDfuFrameHeader header;
- BmDfuEventImgInfo info;
+  BmDfuFrameHeader header;
+  BmDfuEventImgInfo info;
 } __attribute__((packed)) BcmpDfuStart;
 
 typedef struct {
- BmDfuFrameHeader header;
- BmDfuEventChunkRequest chunk_req;
+  BmDfuFrameHeader header;
+  BmDfuEventChunkRequest chunk_req;
 } __attribute__((packed)) BcmpDfuPayloadReq;
 
 typedef struct {
- BmDfuFrameHeader header;
- BmDfuEventImageChunk chunk;
+  BmDfuFrameHeader header;
+  BmDfuEventImageChunk chunk;
 } __attribute__((packed)) BcmpDfuPayload;
 
 typedef struct {
- BmDfuFrameHeader header;
- BmDfuEventResult result;
+  BmDfuFrameHeader header;
+  BmDfuEventResult result;
 } __attribute__((packed)) BcmpDfuEnd;
 
 typedef struct {
- BmDfuFrameHeader header;
- BmDfuEventResult ack;
+  BmDfuFrameHeader header;
+  BmDfuEventResult ack;
 } __attribute__((packed)) BcmpDfuAck;
 
 typedef struct {
- BmDfuFrameHeader header;
- BmDfuEventResult err;
+  BmDfuFrameHeader header;
+  BmDfuEventResult err;
 } __attribute__((packed)) BcmpDfuAbort;
 
 typedef struct {
- BmDfuFrameHeader header;
- BmDfuEventAddress addr;
+  BmDfuFrameHeader header;
+  BmDfuEventAddress addr;
 } __attribute__((packed)) BcmpDfuHeartbeat;
 
 typedef struct {
- BmDfuFrameHeader header;
- BmDfuEventAddress addr;
+  BmDfuFrameHeader header;
+  BmDfuEventAddress addr;
 } __attribute__((packed)) BcmpDfuRebootReq;
 
 typedef struct {
- BmDfuFrameHeader header;
- BmDfuEventAddress addr;
+  BmDfuFrameHeader header;
+  BmDfuEventAddress addr;
 } __attribute__((packed)) BcmpDfuReboot;
 
 typedef struct {
- BmDfuFrameHeader header;
- BmDfuEventAddress addr;
+  BmDfuFrameHeader header;
+  BmDfuEventAddress addr;
 } __attribute__((packed)) BcmpDfuBootComplete;
 
 /////////////////////////////
 /* CONFIGURATION*/
 /////////////////////////////
-typedef enum {
-  BM_CFG_PARTITION_USER,
-  BM_CFG_PARTITION_SYSTEM,
-  BM_CFG_PARTITION_HARDWARE,
-  BM_CFG_PARTITION_COUNT
-} BmConfigPartition;
-
 typedef struct {
   // Node ID of the target node for which the request is being made.
   uint64_t target_node_id;
@@ -457,7 +451,6 @@ typedef struct {
   // Key string
   char key[0];
 } __attribute__((packed)) BmConfigDeleteKeyResponse;
-
 
 typedef enum {
   BcmpAckMessage = 0x00,

--- a/bcmp/messages.h
+++ b/bcmp/messages.h
@@ -361,6 +361,7 @@ typedef enum {
   BM_CFG_PARTITION_USER,
   BM_CFG_PARTITION_SYSTEM,
   BM_CFG_PARTITION_HARDWARE,
+  BM_CFG_PARTITION_COUNT
 } BmConfigPartition;
 
 typedef struct {

--- a/bcmp/messages/config.h
+++ b/bcmp/messages/config.h
@@ -1,6 +1,7 @@
 #include "bm_configs_generic.h"
 #include "messages.h"
 #include "util.h"
+#include "configuration.h"
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -21,7 +22,7 @@ bool bcmp_config_status_request(uint64_t target_node_id,
                                 BmErr (*reply_cb)(uint8_t *));
 bool bcmp_config_status_response(uint64_t target_node_id,
                                  BmConfigPartition partition, bool commited,
-                                 uint8_t num_keys, const GenericConfigKey *keys,
+                                 uint8_t num_keys, const ConfigKey *keys,
                                  BmErr *err, uint16_t seq_num);
 bool bcmp_config_del_key(uint64_t target_node_id, BmConfigPartition partition,
                          size_t key_len, const char *key,

--- a/common/bm_common_structs.h
+++ b/common/bm_common_structs.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+  BM_CFG_PARTITION_USER,
+  BM_CFG_PARTITION_SYSTEM,
+  BM_CFG_PARTITION_HARDWARE,
+  BM_CFG_PARTITION_COUNT
+} BmConfigPartition;
+
+typedef struct {
+  // fw version
+  uint8_t major;
+  uint8_t minor;
+  uint8_t revision;
+  uint32_t gitSHA;
+} __attribute__((packed)) BmFwVersion;
+
+typedef struct {
+  // Partition id
+  BmConfigPartition partition;
+  // Partion crc
+  uint32_t crc32;
+} __attribute__((packed)) BmConfigCrc;
+
+typedef struct {
+  // crc of the this message (excluding itself)
+  uint32_t network_crc32;
+  // Config crc
+  BmConfigCrc config_crc;
+  // fw info
+  BmFwVersion fw_info;
+  // Number of nodes in the topology
+  uint16_t num_nodes;
+  // Size of the map in bytes
+  uint16_t map_size_bytes;
+  // Node list (node size uint64_t) and cbor config map
+  uint8_t node_list_and_cbor_config_map[0];
+} __attribute__((packed)) BmNetworkInfo;
+
+typedef enum {
+  BM_COMMON_LOG_LEVEL_NONE = 0,
+  BM_COMMON_LOG_LEVEL_FATAL = 1,
+  BM_COMMON_LOG_LEVEL_ERROR = 2,
+  BM_COMMON_LOG_LEVEL_WARNING = 3,
+  BM_COMMON_LOG_LEVEL_INFO = 4,
+  BM_COMMON_LOG_LEVEL_DEBUG = 5,
+} BmLogLevel;
+
+typedef struct {
+  // Log level
+  BmLogLevel level;
+  // String length of the message (without terminator)
+  uint32_t message_length;
+  // print header (true) or not (false)
+  bool print_header;
+  // timestamp UTC
+  uint64_t timestamp_utc_s;
+  // Message string
+  char message[0];
+} __attribute__((packed)) BmLog;
+
+#ifdef __cplusplus
+}
+#endif

--- a/middleware/CMakeLists.txt
+++ b/middleware/CMakeLists.txt
@@ -15,4 +15,4 @@ target_include_directories(middleware PUBLIC
     .
 )
 
-target_link_libraries(middleware PRIVATE bmcommon bcmp bmmessages)
+target_link_libraries(middleware PRIVATE bmcommon bcmp bmmessages bmthirdparty)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -296,6 +296,7 @@ set (CBOR_SEVICE_HELPER_SRCS
     ${THIRD_PARTY_DIR}/tinycbor/src/cborencoder.c
     ${THIRD_PARTY_DIR}/tinycbor/src/cborerrorstrings.c
     ${THIRD_PARTY_DIR}/tinycbor/src/cborvalidation.c
+    ${BCMP_DIR}/configuration.c
 
     # Stubs
     ${STUB_DIR}/bm_os_stub.c
@@ -384,6 +385,25 @@ set (BM_SERVICE_REQUEST_SRCS
     ${STUB_DIR}/device_stub.c
 )
 create_gtest("bm_service_request" "${BM_SERVICE_REQUEST_SRCS}")
+
+# CONFIGURATION TESTS
+set (CONFIGURATION_SRCS
+    # File we're testing
+    ${BCMP_DIR}/configuration.c
+
+    # Supporting Files
+    ${COMMON_DIR}/util.c
+
+    # Stubs
+    ${STUB_DIR}/bm_os_stub.c
+    ${THIRD_PARTY_DIR}/tinycbor/src/cborparser.c
+    ${THIRD_PARTY_DIR}/tinycbor/src/cborencoder_float.c
+    ${THIRD_PARTY_DIR}/tinycbor/src/cborencoder.c
+    ${THIRD_PARTY_DIR}/tinycbor/src/cborerrorstrings.c
+    ${THIRD_PARTY_DIR}/tinycbor/src/cborvalidation.c
+    ${THIRD_PARTY_DIR}/crc/crc32.c
+)
+create_gtest("configuration" "${CONFIGURATION_SRCS}")
 
 # ADIN2111 DRIVER TESTS
 add_executable(bm_adin2111_test

--- a/test/mocks/mock_configuration.h
+++ b/test/mocks/mock_configuration.h
@@ -1,0 +1,39 @@
+#include "configuration.h"
+#include "fff.h"
+
+DECLARE_FAKE_VOID_FUNC(config_init);
+DECLARE_FAKE_VALUE_FUNC(bool, get_config_uint, BmConfigPartition, const char *,
+                        size_t, uint32_t *);
+DECLARE_FAKE_VALUE_FUNC(bool, get_config_int, BmConfigPartition, const char *,
+                        size_t, int32_t *);
+DECLARE_FAKE_VALUE_FUNC(bool, get_config_float, BmConfigPartition, const char *,
+                        size_t, float *);
+DECLARE_FAKE_VALUE_FUNC(bool, get_config_string, BmConfigPartition,
+                        const char *, size_t, char *, size_t *);
+DECLARE_FAKE_VALUE_FUNC(bool, get_config_buffer, BmConfigPartition,
+                        const char *, size_t, uint8_t *, size_t *);
+DECLARE_FAKE_VALUE_FUNC(bool, get_config_cbor, BmConfigPartition, const char *,
+                        size_t, uint8_t *, size_t *);
+DECLARE_FAKE_VALUE_FUNC(bool, set_config_uint, BmConfigPartition, const char *,
+                        size_t, uint32_t);
+DECLARE_FAKE_VALUE_FUNC(bool, set_config_int, BmConfigPartition, const char *,
+                        size_t, int32_t);
+DECLARE_FAKE_VALUE_FUNC(bool, set_config_float, BmConfigPartition, const char *,
+                        size_t, float);
+DECLARE_FAKE_VALUE_FUNC(bool, set_config_string, BmConfigPartition,
+                        const char *, size_t, const char *, size_t);
+DECLARE_FAKE_VALUE_FUNC(bool, set_config_buffer, BmConfigPartition,
+                        const char *, size_t, const uint8_t *, size_t);
+DECLARE_FAKE_VALUE_FUNC(bool, set_config_cbor, BmConfigPartition, const char *,
+                        size_t, uint8_t *, size_t);
+DECLARE_FAKE_VALUE_FUNC(const ConfigKey *, get_stored_keys, BmConfigPartition,
+                        uint8_t *);
+DECLARE_FAKE_VALUE_FUNC(bool, remove_key, BmConfigPartition, const char *,
+                        size_t);
+DECLARE_FAKE_VALUE_FUNC(const char *, data_type_enum_to_str, ConfigDataTypes);
+DECLARE_FAKE_VALUE_FUNC(bool, save_config, BmConfigPartition, bool);
+DECLARE_FAKE_VALUE_FUNC(bool, get_value_size, BmConfigPartition, const char *,
+                        size_t, size_t *);
+DECLARE_FAKE_VALUE_FUNC(bool, needs_commit, BmConfigPartition);
+DECLARE_FAKE_VALUE_FUNC(bool, cbor_type_to_config, const CborValue *,
+                        ConfigDataTypes *);

--- a/test/src/cbor_service_helper_test.cpp
+++ b/test/src/cbor_service_helper_test.cpp
@@ -11,191 +11,86 @@ extern "C" {
 #include "mock_bm_os.h"
 }
 
-static GenericConfigKey keys[BM_MAX_NUM_KV];
-static uint8_t values[BM_MAX_NUM_KV][BM_MAX_STR_LEN_BYTES];
-static uint8_t key_idx = 0;
+bool bm_config_read(BmConfigPartition partition, uint32_t offset,
+                    uint8_t *buffer, size_t length, uint32_t timeout_ms) {
+  bool ret = false;
 
-bool find_key_idx(const char *key, size_t len, uint8_t &idx) {
-  bool rval = false;
-  for (int i = 0; i < key_idx; i++) {
-    if (strncmp(key, keys[i].keyBuffer, len) == 0) {
-      idx = i;
-      rval = true;
-      break;
-    }
+  switch (partition) {
+  case BM_CFG_PARTITION_USER:
+  case BM_CFG_PARTITION_SYSTEM:
+  case BM_CFG_PARTITION_HARDWARE:
+    ret = true;
+    break;
+  default:
+    break;
   }
-  return rval;
-}
 
-bool prepare_cbor_parser(const char *key, size_t key_len, CborValue &it,
-                         CborParser &parser) {
-  bool retval = false;
-  uint8_t idx;
-  do {
-    if (key_len > BM_MAX_KEY_LEN_BYTES) {
-      break;
-    }
-    if (!find_key_idx(key, key_len, idx)) {
-      break;
-    }
-    if (cbor_parser_init(values[idx], sizeof(values[idx]), 0, &parser, &it) !=
-        CborNoError) {
-      break;
-    }
-    retval = true;
-  } while (0);
-  return retval;
+  return ret;
 }
+bool bm_config_write(BmConfigPartition partition, uint32_t offset,
+                     uint8_t *buffer, size_t length, uint32_t timeout_ms) {
+  bool ret = false;
 
-bool cbor_type_to_config_type(const CborValue *value,
-                              ConfigDataTypes &configType) {
-  bool rval = true;
-  do {
-    if (cbor_value_is_integer(value)) {
-      if (cbor_value_is_unsigned_integer(value)) {
-        configType = UINT32;
-        break;
-      } else {
-        configType = INT32;
-        break;
-      }
-    } else if (cbor_value_is_byte_string(value)) {
-      configType = BYTES;
-      break;
-    } else if (cbor_value_is_text_string(value)) {
-      configType = STR;
-      break;
-    } else if (cbor_value_is_float(value)) {
-      configType = FLOAT;
-      break;
-    } else if (cbor_value_is_array(value)) {
-      configType = ARRAY;
-      break;
-    }
-    rval = false;
-  } while (0);
-  return rval;
+  switch (partition) {
+  case BM_CFG_PARTITION_USER:
+  case BM_CFG_PARTITION_SYSTEM:
+  case BM_CFG_PARTITION_HARDWARE:
+    ret = true;
+    break;
+  default:
+    break;
+  }
+
+  return ret;
 }
-
-const GenericConfigKey *
-bcmp_config_get_stored_keys(uint8_t *num_keys, BmConfigPartition partition) {
-  (void)partition;
-  *num_keys = key_idx;
-  return (const GenericConfigKey *)keys;
-}
-
-bool bcmp_set_config(const char *key, size_t key_len, uint8_t *value,
-                     size_t value_len, BmConfigPartition partition) {
-  (void)partition;
-  CborValue it;
-  CborParser parser;
-  bool rval = false;
-  do {
-    if (key_len > BM_MAX_KEY_LEN_BYTES) {
-      break;
-    }
-    if (value_len > BM_MAX_CONFIG_BUFFER_SIZE_BYTES || value_len == 0) {
-      break;
-    }
-    for (size_t i = 0; i < value_len; i++) {
-    }
-    if (cbor_parser_init(value, value_len, 0, &parser, &it) != CborNoError) {
-      break;
-    }
-    if (!cbor_value_is_valid(&it)) {
-      break;
-    }
-    if (snprintf(keys[key_idx].keyBuffer, sizeof(keys[key_idx].keyBuffer), "%s",
-                 key) < 0) {
-      break;
-    }
-    ConfigDataTypes type;
-    if (!cbor_type_to_config_type(&it, type)) {
-      break;
-    }
-    keys[key_idx].valueType = type;
-    keys[key_idx].keyLen = key_len;
-    memcpy(values[key_idx], value, value_len);
-    key_idx++;
-    rval = true;
-  } while (0);
-  return rval;
-}
-
-bool bcmp_get_config(const char *key, size_t key_len, uint8_t *value,
-                     size_t *value_len, BmConfigPartition partition) {
-  (void)partition;
-  bool rval = false;
-
-  CborValue it;
-  CborParser parser;
-  uint8_t idx;
-  do {
-    if (!prepare_cbor_parser(key, key_len, it, parser)) {
-      break;
-    }
-    if (!cbor_value_is_valid(&it)) {
-      break;
-    }
-    if (!find_key_idx(key, key_len, idx)) {
-      break;
-    }
-    size_t buffer_size = sizeof(values[idx]);
-    if (*value_len < buffer_size || *value_len == 0) {
-      break;
-    }
-    memcpy(value, values[idx], buffer_size);
-    *value_len = buffer_size;
-    rval = true;
-  } while (0);
-  return rval;
-}
+void bm_config_reset(void) {}
 
 class CborServiceHelper : public ::testing::Test {
 protected:
   CborServiceHelper() {}
   ~CborServiceHelper() override {}
+  void setUp(void) { config_init(); }
 };
 
 TEST_F(CborServiceHelper, cbor_map) {
   CborEncoder encoder;
-  uint8_t cbor_buf[BM_MAX_STR_LEN_BYTES];
+  uint8_t cbor_buf[MAX_STR_LEN_BYTES];
 
   uint32_t foo = 42;
-  memset(cbor_buf, 0, BM_MAX_STR_LEN_BYTES);
-  cbor_encoder_init(&encoder, cbor_buf, BM_MAX_STR_LEN_BYTES, 0);
+  memset(cbor_buf, 0, MAX_STR_LEN_BYTES);
+  cbor_encoder_init(&encoder, cbor_buf, MAX_STR_LEN_BYTES, 0);
   cbor_encode_uint(&encoder, foo);
-  bcmp_set_config("foo", strlen("foo"), cbor_buf, BM_MAX_STR_LEN_BYTES,
-                  BM_CFG_PARTITION_SYSTEM);
+  set_config_cbor(BM_CFG_PARTITION_SYSTEM, "foo", strlen("foo"), cbor_buf,
+                  MAX_STR_LEN_BYTES);
 
   int32_t bar = -1000;
-  memset(cbor_buf, 0, BM_MAX_STR_LEN_BYTES);
-  cbor_encoder_init(&encoder, cbor_buf, BM_MAX_STR_LEN_BYTES, 0);
+  memset(cbor_buf, 0, MAX_STR_LEN_BYTES);
+  cbor_encoder_init(&encoder, cbor_buf, MAX_STR_LEN_BYTES, 0);
   cbor_encode_int(&encoder, bar);
-  bcmp_set_config("bar", strlen("bar"), cbor_buf, BM_MAX_STR_LEN_BYTES,
-                  BM_CFG_PARTITION_SYSTEM);
+  set_config_cbor(BM_CFG_PARTITION_SYSTEM, "bar", strlen("bar"), cbor_buf,
+                  MAX_STR_LEN_BYTES);
 
   float baz = 3.14159;
-  memset(cbor_buf, 0, BM_MAX_STR_LEN_BYTES);
-  cbor_encoder_init(&encoder, cbor_buf, BM_MAX_STR_LEN_BYTES, 0);
+  memset(cbor_buf, 0, MAX_STR_LEN_BYTES);
+  cbor_encoder_init(&encoder, cbor_buf, MAX_STR_LEN_BYTES, 0);
   cbor_encode_float(&encoder, baz);
-  bcmp_set_config("baz", strlen("baz"), cbor_buf, BM_MAX_STR_LEN_BYTES,
-                  BM_CFG_PARTITION_SYSTEM);
+  set_config_cbor(BM_CFG_PARTITION_SYSTEM, "baz", strlen("baz"), cbor_buf,
+                  MAX_STR_LEN_BYTES);
 
   const char *silly = "The quick brown fox jumps over the lazy dog";
-  memset(cbor_buf, 0, BM_MAX_STR_LEN_BYTES);
-  cbor_encoder_init(&encoder, cbor_buf, BM_MAX_STR_LEN_BYTES, 0);
+  memset(cbor_buf, 0, MAX_STR_LEN_BYTES);
+  cbor_encoder_init(&encoder, cbor_buf, MAX_STR_LEN_BYTES, 0);
   cbor_encode_text_stringz(&encoder, silly);
-  bcmp_set_config("silly", strlen("silly"), cbor_buf, BM_MAX_STR_LEN_BYTES,
-                  BM_CFG_PARTITION_SYSTEM);
+  set_config_cbor(BM_CFG_PARTITION_SYSTEM, "silly", strlen("silly"), cbor_buf,
+                  MAX_STR_LEN_BYTES);
 
   uint8_t bytes[] = {0xde, 0xad, 0xbe, 0xef, 0x5a,
                      0xad, 0xda, 0xad, 0xb0, 0xdd};
-  memset(cbor_buf, 0, BM_MAX_STR_LEN_BYTES);
-  cbor_encoder_init(&encoder, cbor_buf, BM_MAX_STR_LEN_BYTES, 0);
+  memset(cbor_buf, 0, MAX_STR_LEN_BYTES);
+  cbor_encoder_init(&encoder, cbor_buf, MAX_STR_LEN_BYTES, 0);
   cbor_encode_byte_string(&encoder, bytes, array_size(bytes));
-  bcmp_set_config("bytes", strlen("bytes"), cbor_buf, BM_MAX_STR_LEN_BYTES,
-                  BM_CFG_PARTITION_SYSTEM);
+  set_config_cbor(BM_CFG_PARTITION_SYSTEM, "bytes", strlen("bytes"), cbor_buf,
+                  MAX_STR_LEN_BYTES);
 
   size_t buffer_size = 0;
   uint8_t *buffer = services_cbor_as_map(&buffer_size, BM_CFG_PARTITION_SYSTEM);

--- a/test/src/cbor_service_helper_test.cpp
+++ b/test/src/cbor_service_helper_test.cpp
@@ -48,7 +48,7 @@ bool prepare_cbor_parser(const char *key, size_t key_len, CborValue &it,
 }
 
 bool cbor_type_to_config_type(const CborValue *value,
-                              GenericConfigDataTypes &configType) {
+                              ConfigDataTypes &configType) {
   bool rval = true;
   do {
     if (cbor_value_is_integer(value)) {
@@ -109,7 +109,7 @@ bool bcmp_set_config(const char *key, size_t key_len, uint8_t *value,
                  key) < 0) {
       break;
     }
-    GenericConfigDataTypes type;
+    ConfigDataTypes type;
     if (!cbor_type_to_config_type(&it, type)) {
       break;
     }

--- a/test/src/configuration_test.cpp
+++ b/test/src/configuration_test.cpp
@@ -1,0 +1,338 @@
+#include "gtest/gtest.h"
+
+#include "fff.h"
+
+extern "C" {
+#include "bm_configs_generic.h"
+#include "configuration.h"
+}
+
+DEFINE_FFF_GLOBALS;
+
+bool bm_config_read(BmConfigPartition partition, uint32_t offset,
+                    uint8_t *buffer, size_t length, uint32_t timeout_ms) {
+  bool ret = false;
+
+  switch (partition) {
+  case BM_CFG_PARTITION_USER:
+  case BM_CFG_PARTITION_SYSTEM:
+  case BM_CFG_PARTITION_HARDWARE:
+    ret = true;
+    break;
+  default:
+    break;
+  }
+
+  return ret;
+}
+bool bm_config_write(BmConfigPartition partition, uint32_t offset,
+                     uint8_t *buffer, size_t length, uint32_t timeout_ms) {
+  bool ret = false;
+
+  switch (partition) {
+  case BM_CFG_PARTITION_USER:
+  case BM_CFG_PARTITION_SYSTEM:
+  case BM_CFG_PARTITION_HARDWARE:
+    ret = true;
+    break;
+  default:
+    break;
+  }
+
+  return ret;
+}
+void bm_config_reset(void) {}
+
+class ConfigurationTest : public ::testing::Test {
+protected:
+  ConfigurationTest() {}
+
+  ~ConfigurationTest() override {}
+
+  void SetUp() override {}
+  void TearDown() override {}
+  // Objects declared here can be used by all tests in the test suite for Foo.
+};
+
+TEST_F(ConfigurationTest, BasicTest) {
+  config_init();
+
+  uint8_t num_keys;
+  const ConfigKey *key_list = NULL;
+  key_list = get_stored_keys(BM_CFG_PARTITION_SYSTEM, &num_keys);
+  EXPECT_EQ(num_keys, 0);
+  EXPECT_EQ((key_list != NULL), true);
+
+  //   uint32_t
+  uint32_t foo = 42;
+  uint32_t result_foo = 0;
+  EXPECT_EQ(set_config_uint(BM_CFG_PARTITION_SYSTEM, "foo", strlen("foo"), foo),
+            true);
+  EXPECT_EQ(get_config_uint(BM_CFG_PARTITION_SYSTEM, "foo", strlen("foo"),
+                            &result_foo),
+            true);
+  EXPECT_EQ(foo, result_foo);
+  key_list = get_stored_keys(BM_CFG_PARTITION_SYSTEM, &num_keys);
+  EXPECT_EQ(num_keys, 1);
+  EXPECT_EQ(strncmp("foo", key_list[0].keyBuffer, sizeof("foo")), 0);
+
+  // Second set. (overwrite)
+  foo = 999;
+  EXPECT_EQ(set_config_uint(BM_CFG_PARTITION_SYSTEM, "foo", strlen("foo"), foo),
+            true);
+  EXPECT_EQ(get_config_uint(BM_CFG_PARTITION_SYSTEM, "foo", strlen("foo"),
+                            &result_foo),
+            true);
+  EXPECT_EQ(foo, result_foo);
+  key_list = get_stored_keys(BM_CFG_PARTITION_SYSTEM, &num_keys);
+  EXPECT_EQ(num_keys, 1);
+  EXPECT_EQ(strncmp("foo", key_list[0].keyBuffer, sizeof("foo")), 0);
+
+  // int32_t
+  int32_t bar = -1000;
+  int32_t result_bar = 0;
+  EXPECT_EQ(set_config_int(BM_CFG_PARTITION_SYSTEM, "bar", strlen("bar"), bar),
+            true);
+  EXPECT_EQ(get_config_int(BM_CFG_PARTITION_SYSTEM, "bar", strlen("bar"),
+                           &result_bar),
+            true);
+  EXPECT_EQ(get_config_uint(BM_CFG_PARTITION_SYSTEM, "foo", strlen("foo"),
+                            &result_foo),
+            true);
+  EXPECT_EQ(foo, result_foo);
+  EXPECT_EQ(bar, result_bar);
+  key_list = get_stored_keys(BM_CFG_PARTITION_SYSTEM, &num_keys);
+  EXPECT_EQ(num_keys, 2);
+  EXPECT_EQ(strncmp("bar", key_list[1].keyBuffer, sizeof("bar")), 0);
+  EXPECT_EQ(strncmp("foo", key_list[0].keyBuffer, sizeof("foo")), 0);
+
+  //  float
+  float baz = 3.14159;
+  float result_baz = 0;
+  EXPECT_EQ(
+      set_config_float(BM_CFG_PARTITION_SYSTEM, "baz", strlen("baz"), baz),
+      true);
+  EXPECT_EQ(get_config_float(BM_CFG_PARTITION_SYSTEM, "baz", strlen("baz"),
+                             &result_baz),
+            true);
+  EXPECT_EQ(baz, result_baz);
+  key_list = get_stored_keys(BM_CFG_PARTITION_SYSTEM, &num_keys);
+  EXPECT_EQ(num_keys, 3);
+  EXPECT_EQ(strncmp("baz", key_list[2].keyBuffer, sizeof("baz")), 0);
+  EXPECT_EQ(strncmp("bar", key_list[1].keyBuffer, sizeof("bar")), 0);
+  EXPECT_EQ(strncmp("foo", key_list[0].keyBuffer, sizeof("foo")), 0);
+
+  // str
+  const char *silly = "The quick brown fox jumps over the lazy dog";
+  char result_silly[100];
+  size_t size = sizeof(result_silly);
+  EXPECT_EQ(set_config_string(BM_CFG_PARTITION_SYSTEM, "silly", strlen("silly"),
+                              silly, strlen(silly)),
+            true);
+  EXPECT_EQ(get_config_string(BM_CFG_PARTITION_SYSTEM, "silly", strlen("silly"),
+                              result_silly, &size),
+            true);
+  EXPECT_EQ(size, strlen(silly));
+  EXPECT_EQ(strncmp(silly, result_silly, strlen(silly)), 0);
+  key_list = get_stored_keys(BM_CFG_PARTITION_SYSTEM, &num_keys);
+  EXPECT_EQ(num_keys, 4);
+  EXPECT_EQ(strncmp("silly", key_list[3].keyBuffer, sizeof("silly")), 0);
+  EXPECT_EQ(strncmp("baz", key_list[2].keyBuffer, sizeof("baz")), 0);
+  EXPECT_EQ(strncmp("bar", key_list[1].keyBuffer, sizeof("bar")), 0);
+  EXPECT_EQ(strncmp("foo", key_list[0].keyBuffer, sizeof("foo")), 0);
+
+  // Bytes
+  uint8_t bytes[] = {0xde, 0xad, 0xbe, 0xef, 0x5a,
+                     0xad, 0xda, 0xad, 0xb0, 0xdd};
+  uint8_t result_bytes[10];
+  size = sizeof(result_bytes);
+  EXPECT_EQ(set_config_buffer(BM_CFG_PARTITION_SYSTEM, "bytes", strlen("bytes"),
+                              bytes, sizeof(bytes)),
+            true);
+  EXPECT_EQ(get_config_buffer(BM_CFG_PARTITION_SYSTEM, "bytes", strlen("bytes"),
+                              result_bytes, &size),
+            true);
+  EXPECT_EQ(size, sizeof(bytes));
+  EXPECT_EQ(memcmp(bytes, result_bytes, size), 0);
+  key_list = get_stored_keys(BM_CFG_PARTITION_SYSTEM, &num_keys);
+  EXPECT_EQ(num_keys, 5);
+  EXPECT_EQ(strncmp("bytes", key_list[4].keyBuffer, sizeof("bytes")), 0);
+  EXPECT_EQ(strncmp("silly", key_list[3].keyBuffer, sizeof("silly")), 0);
+  EXPECT_EQ(strncmp("baz", key_list[2].keyBuffer, sizeof("baz")), 0);
+  EXPECT_EQ(strncmp("bar", key_list[1].keyBuffer, sizeof("bar")), 0);
+  EXPECT_EQ(strncmp("foo", key_list[0].keyBuffer, sizeof("foo")), 0);
+
+  // Remove key
+  EXPECT_EQ(remove_key(BM_CFG_PARTITION_SYSTEM, "foo", strlen("foo")), true);
+  EXPECT_EQ(get_config_uint(BM_CFG_PARTITION_SYSTEM, "foo", strlen("foo"),
+                            &result_foo),
+            false);
+  key_list = get_stored_keys(BM_CFG_PARTITION_SYSTEM, &num_keys);
+  EXPECT_EQ(num_keys, 4);
+  EXPECT_EQ(strncmp("bytes", key_list[3].keyBuffer, sizeof("bytes")), 0);
+  EXPECT_EQ(strncmp("silly", key_list[2].keyBuffer, sizeof("silly")), 0);
+  EXPECT_EQ(strncmp("baz", key_list[1].keyBuffer, sizeof("baz")), 0);
+  EXPECT_EQ(strncmp("bar", key_list[0].keyBuffer, sizeof("bar")), 0);
+  EXPECT_EQ(get_config_int(BM_CFG_PARTITION_SYSTEM, "bar", strlen("bar"),
+                           &result_bar),
+            true);
+  EXPECT_EQ(bar, result_bar);
+  EXPECT_EQ(get_config_float(BM_CFG_PARTITION_SYSTEM, "baz", strlen("baz"),
+                             &result_baz),
+            true);
+  EXPECT_EQ(baz, result_baz);
+  size = sizeof(result_silly);
+  EXPECT_EQ(get_config_string(BM_CFG_PARTITION_SYSTEM, "silly", strlen("silly"),
+                              result_silly, &size),
+            true);
+  EXPECT_EQ(size, strlen(silly));
+  EXPECT_EQ(strncmp(silly, result_silly, strlen(silly)), 0);
+  size = sizeof(result_bytes);
+  EXPECT_EQ(get_config_buffer(BM_CFG_PARTITION_SYSTEM, "bytes", strlen("bytes"),
+                              result_bytes, &size),
+            true);
+  EXPECT_EQ(size, sizeof(bytes));
+  EXPECT_EQ(memcmp(bytes, result_bytes, size), 0);
+}
+
+TEST_F(ConfigurationTest, NoKeyFound) {
+  config_init();
+  uint32_t result_foo = 0;
+  EXPECT_EQ(get_config_uint(BM_CFG_PARTITION_SYSTEM, "foo", strlen("foo"),
+                            &result_foo),
+            false);
+  uint32_t foo = 42;
+  EXPECT_EQ(set_config_uint(BM_CFG_PARTITION_SYSTEM, "foo", strlen("foo"), foo),
+            true);
+  EXPECT_EQ(get_config_uint(BM_CFG_PARTITION_SYSTEM, "baz", strlen("baz"),
+                            &result_foo),
+            false);
+}
+
+TEST_F(ConfigurationTest, TooMuchThingy) {
+  config_init();
+
+  const char *silly = "The quick brown fox jumps over the lazy dog The quick "
+                      "brown fox jumps over the lazy dog";
+  EXPECT_EQ(set_config_string(BM_CFG_PARTITION_SYSTEM, "silly", strlen("silly"),
+                              silly, strlen(silly)),
+            false);
+  uint8_t bytes[100];
+  memset(bytes, 0xa5, sizeof(bytes));
+  EXPECT_EQ(set_config_buffer(BM_CFG_PARTITION_SYSTEM, "bytes", strlen("bytes"),
+                              bytes, sizeof(bytes)),
+            false);
+}
+
+//TEST_F(ConfigurationTest, TooLittleStorage)
+//{
+//  const ext_flash_partition_t test_configuration = {
+//      .fa_off = 4096,
+//      .fa_size = 10000,
+//  };
+//  uint8_t small_storage;
+//  NvmPartition testPartition(_storage, test_configuration);
+//  EXPECT_DEATH(Configuration config(testPartition,&small_storage,sizeof(small_storage)), "");
+//}
+
+TEST_F(ConfigurationTest, NoKeyToRemove) {
+  config_init();
+  EXPECT_EQ(remove_key(BM_CFG_PARTITION_SYSTEM, "foo", strlen("foo")), false);
+}
+
+TEST_F(ConfigurationTest, cborGetSet) {
+  uint8_t cborBuffer[MAX_STR_LEN_BYTES];
+  config_init();
+  uint8_t num_keys;
+  const ConfigKey *key_list = NULL;
+  key_list = get_stored_keys(BM_CFG_PARTITION_SYSTEM, &num_keys);
+  EXPECT_EQ(num_keys, 0);
+  EXPECT_EQ((key_list != NULL), true);
+
+  uint32_t foo = 42;
+  uint32_t result_foo = 0;
+  EXPECT_EQ(set_config_uint(BM_CFG_PARTITION_SYSTEM, "foo", strlen("foo"), foo),
+            true);
+  EXPECT_EQ(get_config_uint(BM_CFG_PARTITION_SYSTEM, "foo", strlen("foo"),
+                            &result_foo),
+            true);
+  EXPECT_EQ(foo, result_foo);
+  key_list = get_stored_keys(BM_CFG_PARTITION_SYSTEM, &num_keys);
+  EXPECT_EQ(num_keys, 1);
+  EXPECT_EQ(strncmp("foo", key_list[0].keyBuffer, sizeof("foo")), 0);
+  size_t buffer_size = sizeof(cborBuffer);
+  EXPECT_EQ(get_config_cbor(BM_CFG_PARTITION_SYSTEM, "foo", strlen("foo"),
+                            cborBuffer, &buffer_size),
+            true);
+  EXPECT_EQ(set_config_cbor(BM_CFG_PARTITION_SYSTEM, "bar", strlen("foo"),
+                            cborBuffer, buffer_size),
+            true);
+  key_list = get_stored_keys(BM_CFG_PARTITION_SYSTEM, &num_keys);
+  EXPECT_EQ(num_keys, 2);
+  uint32_t result_bar;
+  EXPECT_EQ(get_config_uint(BM_CFG_PARTITION_SYSTEM, "bar", strlen("bar"),
+                            &result_bar),
+            true);
+  EXPECT_EQ(foo, result_bar);
+  size_t bar_size;
+  EXPECT_EQ(
+      get_value_size(BM_CFG_PARTITION_SYSTEM, "bar", strlen("bar"), &bar_size),
+      true);
+  EXPECT_EQ(bar_size, sizeof(foo));
+
+  buffer_size = sizeof(cborBuffer);
+  const char *silly = "The quick brown fox jumps over the lazy dog";
+  EXPECT_EQ(set_config_string(BM_CFG_PARTITION_SYSTEM, "silly", strlen("silly"),
+                              silly, strlen(silly)),
+            true);
+  EXPECT_EQ(get_config_cbor(BM_CFG_PARTITION_SYSTEM, "silly", strlen("silly"),
+                            cborBuffer, &buffer_size),
+            true);
+  EXPECT_EQ(set_config_cbor(BM_CFG_PARTITION_SYSTEM, "bar", strlen("bar"),
+                            cborBuffer, buffer_size),
+            true);
+  key_list = get_stored_keys(BM_CFG_PARTITION_SYSTEM, &num_keys);
+  EXPECT_EQ(num_keys, 3);
+  char silly_bar[100];
+  size_t size = sizeof(silly_bar);
+  EXPECT_EQ(get_config_string(BM_CFG_PARTITION_SYSTEM, "bar", strlen("bar"),
+                              silly_bar, &size),
+            true);
+  EXPECT_EQ(strncmp(silly, silly_bar, strlen(silly)), 0);
+  EXPECT_EQ(
+      get_value_size(BM_CFG_PARTITION_SYSTEM, "bar", strlen("bar"), &bar_size),
+      true);
+  EXPECT_EQ(bar_size, strlen(silly));
+}
+
+TEST_F(ConfigurationTest, BadCborGetSet) {
+  uint8_t cborBuffer[MAX_STR_LEN_BYTES];
+  size_t buffer_size = sizeof(cborBuffer);
+  memset(cborBuffer, 0xFF, buffer_size);
+  config_init();
+  uint8_t num_keys;
+  const ConfigKey *key_list = NULL;
+  key_list = get_stored_keys(BM_CFG_PARTITION_SYSTEM, &num_keys);
+  EXPECT_EQ(num_keys, 0);
+  EXPECT_EQ((key_list != NULL), true);
+  EXPECT_EQ(get_config_cbor(BM_CFG_PARTITION_SYSTEM, "foo", strlen("foo"),
+                            cborBuffer, &buffer_size),
+            false); // Key doesn't exist.
+  EXPECT_EQ(set_config_cbor(BM_CFG_PARTITION_SYSTEM, "foo", strlen("foo"),
+                            cborBuffer, buffer_size),
+            false); // Invalid cbor buffer.
+  uint32_t foo = 42;
+  EXPECT_EQ(set_config_uint(BM_CFG_PARTITION_SYSTEM, "foo", strlen("foo"), foo),
+            true);
+  EXPECT_EQ(get_config_cbor(BM_CFG_PARTITION_SYSTEM, "foo", strlen("foo"),
+                            cborBuffer, &buffer_size),
+            true);
+  EXPECT_EQ(
+      set_config_cbor(BM_CFG_PARTITION_SYSTEM,
+                      "a super long key string that shouldn't work",
+                      strlen("a super long key string that shouldn't work"),
+                      cborBuffer, buffer_size),
+      false); // key string too long.
+  key_list = get_stored_keys(BM_CFG_PARTITION_SYSTEM, &num_keys);
+  EXPECT_EQ(num_keys, 1);
+}

--- a/test/stubs/configuration_stub.c
+++ b/test/stubs/configuration_stub.c
@@ -1,0 +1,38 @@
+#include "mock_configuration.h"
+
+DEFINE_FAKE_VOID_FUNC(config_init);
+DEFINE_FAKE_VALUE_FUNC(bool, get_config_uint, BmConfigPartition, const char *,
+                       size_t, uint32_t *);
+DEFINE_FAKE_VALUE_FUNC(bool, get_config_int, BmConfigPartition, const char *,
+                       size_t, int32_t *);
+DEFINE_FAKE_VALUE_FUNC(bool, get_config_float, BmConfigPartition, const char *,
+                       size_t, float *);
+DEFINE_FAKE_VALUE_FUNC(bool, get_config_string, BmConfigPartition, const char *,
+                       size_t, char *, size_t *);
+DEFINE_FAKE_VALUE_FUNC(bool, get_config_buffer, BmConfigPartition, const char *,
+                       size_t, uint8_t *, size_t *);
+DEFINE_FAKE_VALUE_FUNC(bool, get_config_cbor, BmConfigPartition, const char *,
+                       size_t, uint8_t *, size_t *);
+DEFINE_FAKE_VALUE_FUNC(bool, set_config_uint, BmConfigPartition, const char *,
+                       size_t, uint32_t);
+DEFINE_FAKE_VALUE_FUNC(bool, set_config_int, BmConfigPartition, const char *,
+                       size_t, int32_t);
+DEFINE_FAKE_VALUE_FUNC(bool, set_config_float, BmConfigPartition, const char *,
+                       size_t, float);
+DEFINE_FAKE_VALUE_FUNC(bool, set_config_string, BmConfigPartition, const char *,
+                       size_t, const char *, size_t);
+DEFINE_FAKE_VALUE_FUNC(bool, set_config_buffer, BmConfigPartition, const char *,
+                       size_t, const uint8_t *, size_t);
+DEFINE_FAKE_VALUE_FUNC(bool, set_config_cbor, BmConfigPartition, const char *,
+                       size_t, uint8_t *, size_t);
+DEFINE_FAKE_VALUE_FUNC(const ConfigKey *, get_stored_keys, BmConfigPartition,
+                       uint8_t *);
+DEFINE_FAKE_VALUE_FUNC(bool, remove_key, BmConfigPartition, const char *,
+                       size_t);
+DEFINE_FAKE_VALUE_FUNC(const char *, data_type_enum_to_str, ConfigDataTypes);
+DEFINE_FAKE_VALUE_FUNC(bool, save_config, BmConfigPartition, bool);
+DEFINE_FAKE_VALUE_FUNC(bool, get_value_size, BmConfigPartition, const char *,
+                       size_t, size_t *);
+DEFINE_FAKE_VALUE_FUNC(bool, needs_commit, BmConfigPartition);
+DEFINE_FAKE_VALUE_FUNC(bool, cbor_type_to_config, const CborValue *,
+                       ConfigDataTypes *);

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(SOURCES
+    tinycbor/src/cborparser.c
+    tinycbor/src/cborencoder_float.c
+    tinycbor/src/cborencoder.c
+    tinycbor/src/cborerrorstrings.c
+    tinycbor/src/cborvalidation.c
+    tinycbor/src/cborpretty.c
+    crc/crc16.c
+    crc/crc32.c
+)
+
+add_library(bmthirdparty ${SOURCES})
+
+target_include_directories(bmthirdparty PUBLIC
+    .
+)


### PR DESCRIPTION
Migrates the configuration files over to `bm_core` as well as  unit tests.
Makes a third party library as other libraries in `bm_core` are reliant on these files (middleware), if this is not added, some funky linking would have to occur between bmcore library and middleware library.