### PR TITLE
L2 and BCMP use the new adin driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ set(COMPILE_FLAGS
 set(BM_INCLUDES
     ${CMAKE_CURRENT_LIST_DIR}/bcmp
     ${CMAKE_CURRENT_LIST_DIR}/common
+    ${CMAKE_CURRENT_LIST_DIR}/drivers/adin2111
     ${CMAKE_CURRENT_LIST_DIR}/middleware
     ${CMAKE_CURRENT_LIST_DIR}/network
     ${CMAKE_CURRENT_LIST_DIR}/third_party

--- a/bcmp/bcmp.c
+++ b/bcmp/bcmp.c
@@ -89,13 +89,30 @@ static void bcmp_thread(void *parameters) {
 }
 
 /*!
+  @brief BCMP link change event callback
+
+  @param port - system port in which the link change occurred
+  @param state - 0 for down 1 for up
+*/
+void bcmp_link_change(uint8_t port, bool state) {
+  (void)port; // Not using the port for now
+  if (state) {
+    // Send heartbeat since we just connected to someone and (re)start the
+    // heartbeat timer
+    bcmp_send_heartbeat(bcmp_heartbeat_s);
+    bm_timer_start(CTX.heartbeat_timer, 10);
+  }
+}
+
+/*!
   @brief BCMP initialization
 
   @param *netif lwip network interface to use
   @return none
 */
-BmErr bcmp_init(void) {
+BmErr bcmp_init(NetworkDevice *network_device) {
   CTX.queue = bm_queue_create(bcmp_evt_queue_len, sizeof(BcmpQueueItem));
+  network_device->callbacks.link_change = bcmp_link_change;
 
   bcmp_heartbeat_init();
   ping_init();
@@ -201,20 +218,4 @@ BmErr bcmp_ll_forward(BcmpHeader *header, void *payload, uint32_t size,
     }
   }
   return err;
-}
-
-/*!
-  @brief BCMP link change event callback
-
-  @param port - system port in which the link change occurred
-  @param state - 0 for down 1 for up
-*/
-void bcmp_link_change(uint8_t port, bool state) {
-  (void)port; // Not using the port for now
-  if (state) {
-    // Send heartbeat since we just connected to someone and (re)start the
-    // heartbeat timer
-    bcmp_send_heartbeat(bcmp_heartbeat_s);
-    bm_timer_start(CTX.heartbeat_timer, 10);
-  }
 }

--- a/bcmp/bcmp.c
+++ b/bcmp/bcmp.c
@@ -110,9 +110,9 @@ void bcmp_link_change(uint8_t port, bool state) {
   @param *netif lwip network interface to use
   @return none
 */
-BmErr bcmp_init(NetworkDevice *network_device) {
+BmErr bcmp_init(NetworkDevice network_device) {
   CTX.queue = bm_queue_create(bcmp_evt_queue_len, sizeof(BcmpQueueItem));
-  network_device->callbacks.link_change = bcmp_link_change;
+  network_device.callbacks->link_change = bcmp_link_change;
 
   bcmp_heartbeat_init();
   ping_init();

--- a/bcmp/bcmp.c
+++ b/bcmp/bcmp.c
@@ -119,7 +119,7 @@ BmErr bcmp_init(NetworkDevice network_device) {
   time_init();
   bm_dfu_init();
   bcmp_config_init();
-  bcmp_topology_init();
+  bcmp_topology_init(network_device.trait->num_ports());
   bcmp_device_info_init();
   bcmp_resource_discovery_init();
 

--- a/bcmp/bcmp.h
+++ b/bcmp/bcmp.h
@@ -27,7 +27,7 @@ typedef struct {
   uint32_t size;
 } BcmpQueueItem;
 
-BmErr bcmp_init(NetworkDevice *network_device);
+BmErr bcmp_init(NetworkDevice network_device);
 void *bcmp_get_queue(void);
 BmErr bcmp_tx(const void *dst, BcmpMessageType type, uint8_t *data,
               uint16_t size, uint32_t seq_num,

--- a/bcmp/bcmp.h
+++ b/bcmp/bcmp.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "messages.h"
+#include "network_device.h"
 #include "util.h"
 #include <stdbool.h>
 #include <stdint.h>
@@ -14,7 +15,6 @@
 #define ipv6_header_length (40)
 // 1500 MTU minus ipv6 header
 #define max_payload_len (bcmp_max_payload_size_bytes - ipv6_header_length)
-#define IpProtoBcmp (0xBC)
 
 typedef enum {
   BcmpEventRx,
@@ -27,11 +27,10 @@ typedef struct {
   uint32_t size;
 } BcmpQueueItem;
 
-BmErr bcmp_init(void);
+BmErr bcmp_init(NetworkDevice *network_device);
 void *bcmp_get_queue(void);
 BmErr bcmp_tx(const void *dst, BcmpMessageType type, uint8_t *data,
               uint16_t size, uint32_t seq_num,
               BmErr (*reply_cb)(uint8_t *payload));
 BmErr bcmp_ll_forward(BcmpHeader *header, void *data, uint32_t size,
                       uint8_t ingress_port);
-void bcmp_link_change(uint8_t port, bool state);

--- a/bcmp/messages/topology.h
+++ b/bcmp/messages/topology.h
@@ -38,7 +38,7 @@ void network_topology_print(NetworkTopology *network_topology);
 // Neighbor table request defines, used to create the network topology
 BmErr bcmp_request_neighbor_table(uint64_t target_node_id, const void *addr);
 
-BmErr bcmp_topology_init(void);
+BmErr bcmp_topology_init(uint8_t num_ports);
 // Topology task defines
 BmErr bcmp_topology_start(const BcmpTopoCb callback);
 

--- a/bcmp/topology.c
+++ b/bcmp/topology.c
@@ -37,6 +37,7 @@ typedef struct {
   NetworkTopology *network_topology;
   bool in_progress;
   BcmpTopoCb callback;
+  uint8_t num_ports;
 } BcmpTopoContext;
 
 static BcmpTopoContext CTX;
@@ -95,7 +96,7 @@ static void process_start_topology_event(void) {
   // here we will need to kick off the topo process by looking at our own neighbors and then sending out a request
   CTX.network_topology = new_network_topology();
 
-  static const uint8_t num_ports = ADIN2111_PORT_NUM;
+  const uint8_t num_ports = CTX.num_ports;
 
   // Check our neighbors
   uint8_t num_neighbors = 0;
@@ -208,7 +209,7 @@ BmErr bcmp_request_neighbor_table(uint64_t target_node_id, const void *addr) {
   @ret ERR_OK if successful
 */
 static BmErr bcmp_send_neighbor_table(void *addr) {
-  static const uint8_t num_ports = ADIN2111_PORT_NUM;
+  const uint8_t num_ports = CTX.num_ports;
   BmErr err = BmENOMEM;
 
   // Check our neighbors
@@ -430,7 +431,8 @@ static void bcmp_topology_thread(void *parameters) {
   @return BmOK on success
   @return BmErr on failure
 */
-BmErr bcmp_topology_init(void) {
+BmErr bcmp_topology_init(uint8_t num_ports) {
+  CTX.num_ports = num_ports;
   BmErr err = BmOK;
   BcmpPacketCfg neighbor_request = {
       false,

--- a/bcmp/topology.c
+++ b/bcmp/topology.c
@@ -95,8 +95,7 @@ static void process_start_topology_event(void) {
   // here we will need to kick off the topo process by looking at our own neighbors and then sending out a request
   CTX.network_topology = new_network_topology();
 
-  static uint8_t num_ports = 0;
-  num_ports = bm_l2_get_num_ports();
+  static const uint8_t num_ports = ADIN2111_PORT_NUM;
 
   // Check our neighbors
   uint8_t num_neighbors = 0;
@@ -209,8 +208,7 @@ BmErr bcmp_request_neighbor_table(uint64_t target_node_id, const void *addr) {
   @ret ERR_OK if successful
 */
 static BmErr bcmp_send_neighbor_table(void *addr) {
-  static uint8_t num_ports = 0;
-  num_ports = bm_l2_get_num_ports();
+  static const uint8_t num_ports = ADIN2111_PORT_NUM;
   BmErr err = BmENOMEM;
 
   // Check our neighbors
@@ -508,8 +506,7 @@ static void network_topology_clear(NetworkTopology *network_topology) {
   }
 }
 
-static void
-network_topology_move_to_front(NetworkTopology *network_topology) {
+static void network_topology_move_to_front(NetworkTopology *network_topology) {
   if (network_topology && network_topology->length) {
     network_topology->cursor = network_topology->front;
     network_topology->index = 0;

--- a/drivers/adin2111/bm_adin2111.c
+++ b/drivers/adin2111/bm_adin2111.c
@@ -59,7 +59,7 @@ static void link_change_callback_(void *device_handle, uint32_t event,
 }
 
 // Start up and enable the ADIN2111 hardware
-static BmErr adin2111_netif_enable(Adin2111 *self) {
+static BmErr adin2111_netdevice_enable(Adin2111 *self) {
   BmErr err = BmOK;
 
   if (!self) {
@@ -121,12 +121,12 @@ end:
 }
 
 // Trait wrapper function to convert self from void* to Adin2111*
-inline static BmErr adin2111_netif_enable_(void *self) {
-  return adin2111_netif_enable(self);
+inline static BmErr adin2111_netdevice_enable_(void *self) {
+  return adin2111_netdevice_enable(self);
 }
 
 // Shut down and disable the ADIN2111 hardware
-static BmErr adin2111_netif_disable(Adin2111 *self) {
+static BmErr adin2111_netdevice_disable(Adin2111 *self) {
   BmErr err = BmOK;
 
   if (!self) {
@@ -151,8 +151,8 @@ end:
 }
 
 // Trait wrapper function to convert self from void* to Adin2111*
-inline static BmErr adin2111_netif_disable_(void *self) {
-  return adin2111_netif_disable(self);
+inline static BmErr adin2111_netdevice_disable_(void *self) {
+  return adin2111_netdevice_disable(self);
 }
 
 // After a TX buffer is sent, it gets freed here
@@ -175,8 +175,8 @@ static void tx_complete(void *device_param, uint32_t event,
 }
 
 // Allocate buffers for sending, copy the given data, and submit to the driver
-static BmErr adin2111_netif_send(Adin2111 *self, uint8_t *data, size_t length,
-                                 uint8_t port_mask) {
+static BmErr adin2111_netdevice_send(Adin2111 *self, uint8_t *data,
+                                     size_t length, uint8_t port_mask) {
   BmErr err = BmOK;
   adi_eth_BufDesc_t *buffer_description = bm_malloc(sizeof(adi_eth_BufDesc_t));
   if (!buffer_description) {
@@ -205,9 +205,9 @@ end:
 }
 
 // Trait wrapper function to convert self from void* to Adin2111*
-static inline BmErr adin2111_netif_send_(void *self, uint8_t *data,
-                                         size_t length, uint8_t port_mask) {
-  return adin2111_netif_send(self, data, length, port_mask);
+static inline BmErr adin2111_netdevice_send_(void *self, uint8_t *data,
+                                             size_t length, uint8_t port_mask) {
+  return adin2111_netdevice_send(self, data, length, port_mask);
 }
 
 // Called by the driver on received data
@@ -261,18 +261,18 @@ BmErr adin2111_init(Adin2111 *self) {
     buffer_description->cbFunc = receive_callback_;
   }
 
-  err = adin2111_netif_enable_(self);
+  err = adin2111_netdevice_enable_(self);
 
 end:
   return err;
 }
 
 /// Build a generic NetworkDevice out of a concrete Adin2111
-NetworkDevice prep_adin2111_netif(Adin2111 *self) {
+NetworkDevice create_adin2111_network_device(Adin2111 *self) {
   // Create the vtable once and attach a pointer to it every time
-  static NetworkDeviceTrait const trait = {.send = adin2111_netif_send_,
-                                              .enable = adin2111_netif_enable_,
-                                              .disable =
-                                                  adin2111_netif_disable_};
+  static NetworkDeviceTrait const trait = {.send = adin2111_netdevice_send_,
+                                           .enable = adin2111_netdevice_enable_,
+                                           .disable =
+                                               adin2111_netdevice_disable_};
   return (NetworkDevice){.trait = &trait, .self = self};
 }

--- a/drivers/adin2111/bm_adin2111.c
+++ b/drivers/adin2111/bm_adin2111.c
@@ -218,11 +218,14 @@ static void receive_callback_(void *device, uint32_t event,
   }
 }
 
+static inline uint8_t adin2111_num_ports(void) { return ADIN2111_PORT_NUM; }
+
 static void create_network_device(void) {
   static NetworkDeviceTrait const trait = {.send = adin2111_netdevice_send_,
                                            .enable = adin2111_netdevice_enable_,
                                            .disable =
-                                               adin2111_netdevice_disable_};
+                                               adin2111_netdevice_disable_,
+                                           .num_ports = adin2111_num_ports};
   static NetworkDeviceCallbacks callbacks = {0};
   NETWORK_DEVICE.self = NULL;
   NETWORK_DEVICE.trait = &trait;

--- a/drivers/adin2111/bm_adin2111.h
+++ b/drivers/adin2111/bm_adin2111.h
@@ -9,7 +9,6 @@
 
 typedef struct {
   void *device_handle;
-  NetworkDeviceCallbacks const *callbacks;
 } Adin2111;
 
 #ifdef __cplusplus

--- a/drivers/adin2111/bm_adin2111.h
+++ b/drivers/adin2111/bm_adin2111.h
@@ -7,16 +7,12 @@
 
 #define ADIN2111_PORT_MASK (3U)
 
-typedef struct {
-  void *device_handle;
-} Adin2111;
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-BmErr adin2111_init(Adin2111 *self);
-NetworkDevice create_adin2111_network_device(Adin2111 *self);
+BmErr adin2111_init(void);
+NetworkDevice create_adin2111_network_device(void);
 
 #ifdef __cplusplus
 }

--- a/drivers/adin2111/bm_adin2111.h
+++ b/drivers/adin2111/bm_adin2111.h
@@ -14,7 +14,7 @@ extern "C" {
 #endif
 
 BmErr adin2111_init(Adin2111 *self);
-NetworkDevice prep_adin2111_netif(Adin2111 *self);
+NetworkDevice create_adin2111_network_device(Adin2111 *self);
 
 #ifdef __cplusplus
 }

--- a/drivers/adin2111/bm_adin2111.h
+++ b/drivers/adin2111/bm_adin2111.h
@@ -12,7 +12,7 @@ extern "C" {
 #endif
 
 BmErr adin2111_init(void);
-NetworkDevice create_adin2111_network_device(void);
+NetworkDevice adin2111_network_device(void);
 
 #ifdef __cplusplus
 }

--- a/drivers/adin2111/bm_adin2111.h
+++ b/drivers/adin2111/bm_adin2111.h
@@ -1,3 +1,6 @@
+#ifndef __BM_ADIN2111_H__
+#define __BM_ADIN2111_H__
+
 #include "adin2111.h"
 #include "network_device.h"
 #include "util.h"
@@ -19,3 +22,5 @@ NetworkDevice create_adin2111_network_device(Adin2111 *self);
 #ifdef __cplusplus
 }
 #endif
+
+#endif // __BM_ADIN2111_H__

--- a/network/l2.c
+++ b/network/l2.c
@@ -33,10 +33,6 @@
 typedef enum {
   L2Tx,
   L2Rx,
-  L2LinkUp,
-  L2LinkDown,
-  L2SetNetifUp,
-  L2SetNetifDown,
 } BmL2QueueType;
 
 typedef struct {

--- a/network/l2.c
+++ b/network/l2.c
@@ -30,12 +30,6 @@
 
 #define evt_queue_len (32)
 
-typedef struct {
-  BmNetDevCfg cfg;
-  uint8_t start_port_idx;
-  uint8_t num_ports_mask;
-} BmNetdevCtx;
-
 typedef enum {
   L2Tx,
   L2Rx,
@@ -54,52 +48,13 @@ typedef struct {
 } L2QueueElement;
 
 typedef struct {
-  BmNetdevCtx *devices;
-  BmL2ModuleLinkChangeCb link_change_cb;
-  uint8_t available_ports_mask;
-  uint8_t available_port_mask_idx;
+  NetworkDevice *network_device;
   uint8_t enabled_port_mask;
-  uint8_t num_devices;
   BmQueue evt_queue;
   BmTaskHandle task_handle;
 } BmL2Ctx;
 
 static BmL2Ctx CTX = {0};
-
-/*!
-  @brief Obtain The Index Of A Device By Its Handle
-
-  @param device_handle handle of device to get index for
-
-  @return index of device if found
-  @return -1 if not found
- */
-static int32_t bm_l2_get_device_index(const void *device_handle) {
-  int32_t rval = -1;
-
-  for (int32_t idx = 0; idx < CTX.num_devices; idx++) {
-    if (device_handle == CTX.devices[idx].cfg.device_handle) {
-      rval = idx;
-    }
-  }
-
-  return rval;
-}
-
-/*!
-  @brief Turn Port Count To Bit Mask
-
-  @param count number of ports
-
-  @return bitmask of number of ports
- */
-static uint8_t port_count_to_bit_mask(uint8_t count) {
-  uint8_t ret = 0;
-  for (uint8_t i = 0; i < count; i++) {
-    ret |= 1 << i;
-  }
-  return ret;
-}
 
 /*!
   @brief L2 TX Function
@@ -168,28 +123,18 @@ static BmErr bm_l2_rx(void *device_handle, uint8_t *payload,
 /*!
   @brief Process TX Event
 
-  @details Receive message from L2 queue and send over all
-           network interfaces (if there are multiple), the specific port
-           to use is stored in the tx_event data structure
+  @details Receive message from L2 queue and send to the network device,
+           the specific ports to use are stored in the tx_evt data structure
 
   @param *tx_evt tx event with buffer, port, and other information
 */
 static void bm_l2_process_tx_evt(L2QueueElement *tx_evt) {
-  uint8_t mask_idx = 0;
-
-  if (tx_evt) {
-    for (uint32_t idx = 0; idx < CTX.num_devices; idx++) {
-      if (CTX.devices[idx].cfg.tx_cb) {
-        BmErr retv = CTX.devices[idx].cfg.tx_cb(
-            CTX.devices[idx].cfg.device_handle,
-            (uint8_t *)bm_l2_get_payload(tx_evt->buf), tx_evt->length,
-            (tx_evt->port_mask >> mask_idx) & CTX.devices[idx].num_ports_mask,
-            CTX.devices[idx].start_port_idx);
-        mask_idx += CTX.devices[idx].cfg.num_ports;
-        if (retv != BmOK) {
-          bm_debug("Failed to submit TX buffer\n");
-        }
-      }
+  if (tx_evt && CTX.network_device) {
+    uint8_t *payload = (uint8_t *)bm_l2_get_payload(tx_evt->buf);
+    BmErr err = CTX.network_device->trait->send(
+        CTX.network_device->self, payload, tx_evt->length, tx_evt->port_mask);
+    if (err != BmOK) {
+      bm_debug("Failed to send TX buffer to network\n");
     }
     bm_l2_free(tx_evt->buf);
   }
@@ -206,108 +151,23 @@ static void bm_l2_process_tx_evt(L2QueueElement *tx_evt) {
 */
 static void bm_l2_process_rx_evt(L2QueueElement *rx_evt) {
   if (rx_evt) {
-    uint8_t rx_port_mask = 0;
-    uint8_t device_idx = bm_l2_get_device_index(rx_evt->device_handle);
-    if (CTX.devices[device_idx].cfg.device_handle) {
-      rx_port_mask =
-          ((rx_evt->port_mask & CTX.devices[device_idx].num_ports_mask)
-           << CTX.devices[device_idx].start_port_idx);
-      // We need to code the RX Port into the IPV6 address passed up the stack
-      add_ingress_port(((uint8_t *)bm_l2_get_payload(rx_evt->buf)),
-                       rx_port_mask);
+    uint8_t *payload = (uint8_t *)bm_l2_get_payload(rx_evt->buf);
 
-      if (is_global_multicast(bm_l2_get_payload(rx_evt->buf))) {
-        uint8_t new_port_mask = CTX.available_ports_mask & ~(rx_port_mask);
-        bm_l2_tx(rx_evt->buf, rx_evt->length, new_port_mask);
-      }
+    // We need to code the RX Port into the IPV6 address passed up the stack
+    add_ingress_port(payload, rx_evt->port_mask);
 
-      /* TODO: This is the place where routing and filtering functions would happen, to prevent passing the
+    if (is_global_multicast(payload)) {
+      uint8_t new_port_mask = ADIN2111_PORT_MASK & ~(rx_evt->port_mask);
+      bm_l2_tx(rx_evt->buf, rx_evt->length, new_port_mask);
+    }
+
+    /* TODO: This is the place where routing and filtering functions would happen, to prevent passing the
        packet to net_if->input() if unnecessary, as well as forwarding routed multicast data to interested
        neighbors and user devices. */
 
-      // Submit packet to ip stack.
-      // Upper level RX Callback is responsible for freeing the packet
-      bm_l2_submit(rx_evt->buf, rx_evt->length);
-    }
-  }
-}
-
-/*!
-  @brief Link change callback function called from eth driver
-         whenever the state of a link changes
-
-  @param *device_handle eth driver handle
-  @param port (device specific) port that changed
-  @param state up/down
-*/
-static void link_change_cb(void *device_handle, uint8_t port, bool state) {
-
-  L2QueueElement link_change_evt = {device_handle, port, NULL, L2LinkDown, 0};
-  if (state) {
-    link_change_evt.type = L2LinkUp;
-  }
-
-  if (device_handle) {
-    // Schedule link change event
-    bm_queue_send(CTX.evt_queue, &link_change_evt, 10);
-  }
-}
-
-/*!
-  @brief Handle link change event
-
-  @param *device_handle eth driver handle
-  @param port (device specific) port that changed
-  @param state up/down
-
-  @return none
-*/
-static void handle_link_change(const void *device_handle, uint8_t port,
-                               bool state) {
-  if (device_handle) {
-    for (uint8_t device = 0; device < CTX.num_devices; device++) {
-      if (device_handle == CTX.devices[device].cfg.device_handle) {
-        // Get the overall port number
-        uint8_t port_idx = CTX.devices[device].start_port_idx + port;
-        // Keep track of what ports are enabled/disabled so we don't try and send messages
-        // out through them
-        uint8_t port_mask = 1 << (port_idx);
-        if (state) {
-          CTX.enabled_port_mask |= port_mask;
-        } else {
-          CTX.enabled_port_mask &= ~port_mask;
-        }
-
-        if (CTX.link_change_cb) {
-          CTX.link_change_cb(port_idx, state);
-        } else {
-          bm_debug("port%u %s\n", port_idx, state ? "up" : "down");
-        }
-      }
-    }
-  }
-}
-
-/*!
-  @brief Handle netif set event
-
-  @param device_handle eth driver handle
-  @param on true to turn the interface on, false to turn the interface off.
-*/
-static void bm_l2_process_netif_evt(const void *device_handle, bool on) {
-  for (uint8_t device = 0; device < CTX.num_devices; device++) {
-    if (device_handle == CTX.devices[device].cfg.device_handle) {
-      if (CTX.devices[device].cfg.power_cb) {
-        if (CTX.devices[device].cfg.power_cb(
-                (void *)device_handle, on, CTX.devices[device].cfg.port_mask) ==
-            0) {
-          bm_debug("Powered device %d : %s\n", device, (on) ? "on" : "off");
-        } else {
-          bm_debug("Failed to power device %d : %s\n", device,
-                   (on) ? "on" : "off");
-        }
-      }
-    }
+    // Submit packet to ip stack.
+    // Upper level RX Callback is responsible for freeing the packet
+    bm_l2_submit(rx_evt->buf, rx_evt->length);
   }
 }
 
@@ -331,24 +191,6 @@ static void bm_l2_thread(void *parameters) {
         bm_l2_process_rx_evt(&event);
         break;
       }
-      case L2LinkUp: {
-        handle_link_change(event.device_handle, event.port_mask, true);
-        break;
-      }
-      case L2LinkDown: {
-        handle_link_change(event.device_handle, event.port_mask, false);
-        break;
-      }
-      case L2SetNetifUp: {
-        bm_l2_process_netif_evt(event.device_handle, true);
-        bm_l2_set_netif(true);
-        break;
-      }
-      case L2SetNetifDown: {
-        bm_l2_set_netif(false);
-        bm_l2_process_netif_evt(event.device_handle, false);
-        break;
-      }
       default: {
       }
       }
@@ -362,9 +204,6 @@ static void bm_l2_thread(void *parameters) {
   @details Frees and deinitializes all things L2
  */
 void bm_l2_deinit(void) {
-  if (CTX.devices) {
-    bm_free(CTX.devices);
-  }
   if (CTX.evt_queue) {
     bm_queue_delete(CTX.evt_queue);
   }
@@ -376,50 +215,14 @@ void bm_l2_deinit(void) {
 
 /*!
   @brief Initialize L2 layer
-
-  @details bm_l2_deinit must be called before this is called again to free
-           resources
-
-  @param cb link change callback that will be called when the ethernet driver
-            changes the link status
-  @param cfg pointer to array of network device configurations
-  @param count number of network device configurations
-
-  @return BmOK if successful
-  @return BmErr if unsuccessful
+  @details bm_l2_deinit must be called before this is called again to free resources
+  @param netif The already-initialized network interface
+  @return BmOK if successful, an error otherwise
  */
-BmErr bm_l2_init(BmL2ModuleLinkChangeCb cb, const BmNetDevCfg *cfg,
-                 uint8_t count) {
-  BmErr err = BmENODEV;
-  uint32_t size_devices = sizeof(BmNetdevCtx) * count;
-
-  CTX.link_change_cb = cb;
-
-  /* Reset context variables */
-  CTX.available_ports_mask = 0;
-  CTX.available_port_mask_idx = 0;
-
-  if (cfg && size_devices) {
-    CTX.num_devices = count;
-    CTX.devices = (BmNetdevCtx *)bm_malloc(size_devices);
-    memset(CTX.devices, 0, size_devices);
-    for (uint32_t idx = 0; idx < count; idx++) {
-      // Only assign variables if there is a device handle and the device
-      // can be initialized
-      if (cfg[idx].device_handle && cfg[idx].init_cb &&
-          cfg[idx].init_cb(cfg[idx].device_handle, bm_l2_rx, link_change_cb,
-                           cfg[idx].port_mask) == BmOK) {
-        CTX.devices[idx].cfg = cfg[idx];
-        CTX.devices[idx].start_port_idx = CTX.available_port_mask_idx;
-        CTX.devices[idx].num_ports_mask =
-            port_count_to_bit_mask(CTX.devices[idx].cfg.num_ports);
-        CTX.available_ports_mask |=
-            (CTX.devices[idx].num_ports_mask << CTX.available_port_mask_idx);
-        CTX.available_port_mask_idx += CTX.devices[idx].cfg.num_ports;
-      } else {
-        bm_debug("Failed to init module at index %d\n", idx);
-      }
-    }
+BmErr bm_l2_init(NetworkDevice *network_device) {
+  BmErr err = BmEINVAL;
+  if (network_device != NULL) {
+    CTX.network_device = network_device;
     CTX.evt_queue = bm_queue_create(evt_queue_len, sizeof(L2QueueElement));
     if (CTX.evt_queue) {
       err = bm_task_create(bm_l2_thread, "L2 TX Thread", 2048, NULL,
@@ -428,7 +231,6 @@ BmErr bm_l2_init(BmL2ModuleLinkChangeCb cb, const BmNetDevCfg *cfg,
       err = BmENOMEM;
     }
   }
-
   return err;
 }
 
@@ -443,7 +245,7 @@ BmErr bm_l2_init(BmL2ModuleLinkChangeCb cb, const BmNetDevCfg *cfg,
 */
 BmErr bm_l2_link_output(void *buf, uint32_t length) {
   // by default, send to all ports
-  uint8_t port_mask = CTX.available_ports_mask;
+  uint8_t port_mask = ADIN2111_PORT_MASK;
 
   // if the application set an egress port, send only to that port
   static const size_t bcmp_egress_port_offset_in_dest_addr = 13;
@@ -452,7 +254,7 @@ BmErr bm_l2_link_output(void *buf, uint32_t length) {
   uint8_t *eth_frame = (uint8_t *)bm_l2_get_payload(buf);
   uint8_t egress_port = eth_frame[egress_idx];
 
-  if (egress_port > 0 && egress_port <= CTX.available_port_mask_idx) {
+  if (egress_port > 0 && egress_port <= ADIN2111_PORT_NUM) {
     port_mask = 1 << (egress_port - 1);
   }
 
@@ -460,43 +262,6 @@ BmErr bm_l2_link_output(void *buf, uint32_t length) {
   eth_frame[egress_idx] = 0;
 
   return bm_l2_tx(buf, length, port_mask);
-}
-
-/*!
-  @brief Get the total number of ports
-
-  @return number of ports
-*/
-uint8_t bm_l2_get_num_ports(void) { return CTX.available_port_mask_idx; }
-
-/*!
- @brief Get The Total Number Of Devices
-
- @return number of devices
- */
-uint8_t bm_l2_get_num_devices(void) { return CTX.num_devices; }
-
-/*!
-  @brief Get the raw device handle for a specific port
-
-  @param dev_idx port index to get the handle from
-  @param *device_handle pointer to variable to store device handle in
-  @param *start_port_idx pointer to variable to store the start port for this device
-
-  @return true if successful
-  @return false if unsuccessful
-*/
-bool bm_l2_get_device_handle(uint8_t dev_idx, void **device_handle,
-                             uint32_t *start_port_idx) {
-  bool rval = false;
-
-  if (device_handle && start_port_idx && dev_idx < CTX.num_devices) {
-    *device_handle = CTX.devices[dev_idx].cfg.device_handle;
-    *start_port_idx = CTX.devices[dev_idx].start_port_idx;
-    rval = true;
-  }
-
-  return rval;
 }
 
 /*!
@@ -512,23 +277,24 @@ bool bm_l2_get_port_state(uint8_t port) {
 }
 
 /*!
-  @brief Public api to set a particular network device on/off
-
-  @param device_handle eth driver handle
+  @brief Public api to set the network interface on/off
   @param on - true to turn the interface on, false to turn the interface off.
 */
-BmErr bm_l2_netif_set_power(void *device_handle, bool on) {
+BmErr bm_l2_netif_set_power(bool on) {
   BmErr err = BmEINVAL;
-  L2QueueElement pwr_evt = {device_handle, 0, NULL, L2SetNetifDown, 0};
-
-  if (device_handle) {
-    if (on) {
-      pwr_evt.type = L2SetNetifUp;
-    }
-
-    // Schedule netif pwr event
-    err = bm_queue_send(CTX.evt_queue, &pwr_evt, 10);
+  NetworkDevice *device = CTX.network_device;
+  if (device == NULL) {
+    goto end;
   }
 
+  if (on) {
+    bm_err_check(err, device->trait->enable(device->self));
+    bm_err_check(err, bm_l2_set_netif(true));
+  } else {
+    bm_err_check(err, bm_l2_set_netif(false));
+    bm_err_check(err, device->trait->disable(device->self));
+  }
+
+end:
   return err;
 }

--- a/network/l2.c
+++ b/network/l2.c
@@ -43,7 +43,7 @@ typedef struct {
 } L2QueueElement;
 
 typedef struct {
-  NetworkDevice *network_device;
+  NetworkDevice network_device;
   uint8_t enabled_port_mask;
   BmQueue evt_queue;
   BmTaskHandle task_handle;
@@ -115,8 +115,8 @@ static void bm_l2_rx(uint8_t port_mask, uint8_t *data, size_t length) {
 static void bm_l2_process_tx_evt(L2QueueElement *tx_evt) {
   if (tx_evt) {
     uint8_t *payload = (uint8_t *)bm_l2_get_payload(tx_evt->buf);
-    BmErr err = CTX.network_device->trait->send(
-        CTX.network_device->self, payload, tx_evt->length, tx_evt->port_mask);
+    BmErr err = CTX.network_device.trait->send(
+        CTX.network_device.self, payload, tx_evt->length, tx_evt->port_mask);
     if (err != BmOK) {
       bm_debug("Failed to send TX buffer to network\n");
     }
@@ -203,9 +203,9 @@ void bm_l2_deinit(void) {
   @param netif The already-initialized network interface
   @return BmOK if successful, an error otherwise
  */
-BmErr bm_l2_init(NetworkDevice *network_device) {
+BmErr bm_l2_init(NetworkDevice network_device) {
   BmErr err = BmEINVAL;
-  network_device->callbacks.receive = bm_l2_rx;
+  network_device.callbacks->receive = bm_l2_rx;
   CTX.network_device = network_device;
   CTX.evt_queue = bm_queue_create(evt_queue_len, sizeof(L2QueueElement));
   if (CTX.evt_queue) {
@@ -265,13 +265,13 @@ bool bm_l2_get_port_state(uint8_t port) {
 */
 BmErr bm_l2_netif_set_power(bool on) {
   BmErr err = BmOK;
-  NetworkDevice *device = CTX.network_device;
+  NetworkDevice device = CTX.network_device;
   if (on) {
-    bm_err_check(err, device->trait->enable(device->self));
+    bm_err_check(err, device.trait->enable(device.self));
     bm_err_check(err, bm_l2_set_netif(true));
   } else {
     bm_err_check(err, bm_l2_set_netif(false));
-    bm_err_check(err, device->trait->disable(device->self));
+    bm_err_check(err, device.trait->disable(device.self));
   }
   return err;
 }

--- a/network/l2.h
+++ b/network/l2.h
@@ -19,7 +19,7 @@ extern "C" {
 
 BmErr bm_l2_link_output(void *buf, uint32_t length);
 void bm_l2_deinit(void);
-BmErr bm_l2_init(NetworkDevice network_device);
+BmErr bm_l2_init(NetworkDevice *network_device);
 bool bm_l2_get_port_state(uint8_t port);
 BmErr bm_l2_netif_set_power(bool on);
 

--- a/network/l2.h
+++ b/network/l2.h
@@ -17,19 +17,6 @@ extern "C" {
 #define egress_port_idx 4
 #define ingress_port_idx 5
 
-typedef void (*BmL2ModuleLinkChangeCb)(uint8_t port, bool state);
-typedef void (*BmL2DeviceLinkChangeCb)(void *device_handle, uint8_t port,
-                                       bool state);
-typedef BmErr (*BmL2TxCb)(void *device_handle, uint8_t *buff, uint16_t size,
-                          uint8_t port_mask, uint8_t port_offset);
-typedef BmErr (*BmL2RxCb)(void *device_handle, uint8_t *payload, uint16_t size,
-                          uint8_t port_mask);
-typedef BmErr (*BmL2InitCb)(void *device_handle, BmL2RxCb rx_cb,
-                            BmL2DeviceLinkChangeCb link_change_cb,
-                            uint8_t port_mask);
-typedef BmErr (*BmL2PowerDownCb)(const void *device_handle, bool on,
-                                 uint8_t port_mask);
-
 BmErr bm_l2_link_output(void *buf, uint32_t length);
 void bm_l2_deinit(void);
 BmErr bm_l2_init(NetworkDevice network_device);

--- a/network/l2.h
+++ b/network/l2.h
@@ -19,7 +19,7 @@ extern "C" {
 
 BmErr bm_l2_link_output(void *buf, uint32_t length);
 void bm_l2_deinit(void);
-BmErr bm_l2_init(NetworkDevice *network_device);
+BmErr bm_l2_init(NetworkDevice network_device);
 bool bm_l2_get_port_state(uint8_t port);
 BmErr bm_l2_netif_set_power(bool on);
 

--- a/network/l2.h
+++ b/network/l2.h
@@ -32,7 +32,7 @@ typedef BmErr (*BmL2PowerDownCb)(const void *device_handle, bool on,
 
 BmErr bm_l2_link_output(void *buf, uint32_t length);
 void bm_l2_deinit(void);
-BmErr bm_l2_init(NetworkDevice *network_device);
+BmErr bm_l2_init(NetworkDevice network_device);
 bool bm_l2_get_port_state(uint8_t port);
 BmErr bm_l2_netif_set_power(bool on);
 

--- a/network/l2.h
+++ b/network/l2.h
@@ -1,3 +1,4 @@
+#include "bm_adin2111.h"
 #include "util.h"
 #include <stdbool.h>
 #include <stdint.h>
@@ -29,26 +30,11 @@ typedef BmErr (*BmL2InitCb)(void *device_handle, BmL2RxCb rx_cb,
 typedef BmErr (*BmL2PowerDownCb)(const void *device_handle, bool on,
                                  uint8_t port_mask);
 
-typedef struct {
-  void *device_handle;
-  uint8_t port_mask;
-  uint8_t num_ports;
-  BmL2InitCb init_cb;
-  BmL2PowerDownCb power_cb;
-  BmL2TxCb tx_cb;
-} BmNetDevCfg;
-
 BmErr bm_l2_link_output(void *buf, uint32_t length);
 void bm_l2_deinit(void);
-BmErr bm_l2_init(BmL2ModuleLinkChangeCb cb, const BmNetDevCfg *cfg,
-                 uint8_t count);
-
-bool bm_l2_get_device_handle(uint8_t dev_idx, void **device_handle,
-                             uint32_t *start_port_idx);
-uint8_t bm_l2_get_num_ports(void);
-uint8_t bm_l2_get_num_devices(void);
+BmErr bm_l2_init(NetworkDevice *network_device);
 bool bm_l2_get_port_state(uint8_t port);
-BmErr bm_l2_netif_set_power(void *device_handle, bool on);
+BmErr bm_l2_netif_set_power(bool on);
 
 #ifdef __cplusplus
 }

--- a/network/network_device.h
+++ b/network/network_device.h
@@ -19,7 +19,7 @@ typedef struct {
 typedef struct {
   void *self;
   NetworkDeviceTrait const *trait;
-  NetworkDeviceCallbacks callbacks;
+  NetworkDeviceCallbacks *callbacks;
 } NetworkDevice;
 
 #endif // __NETWORK_DEVICE_H__

--- a/network/network_device.h
+++ b/network/network_device.h
@@ -3,7 +3,7 @@
 typedef struct {
   void (*power)(bool on);
   void (*link_change)(uint8_t port_index, bool is_up);
-  size_t (*receive)(uint8_t port_index, uint8_t *data, size_t length);
+  void (*receive)(uint8_t port_mask, uint8_t *data, size_t length);
 } NetworkDeviceCallbacks;
 
 typedef struct {
@@ -16,4 +16,5 @@ typedef struct {
 typedef struct {
   void *self;
   NetworkDeviceTrait const *trait;
+  NetworkDeviceCallbacks callbacks;
 } NetworkDevice;

--- a/network/network_device.h
+++ b/network/network_device.h
@@ -1,3 +1,6 @@
+#ifndef __NETWORK_DEVICE_H__
+#define __NETWORK_DEVICE_H__
+
 #include "util.h"
 
 typedef struct {
@@ -18,3 +21,5 @@ typedef struct {
   NetworkDeviceTrait const *trait;
   NetworkDeviceCallbacks callbacks;
 } NetworkDevice;
+
+#endif // __NETWORK_DEVICE_H__

--- a/network/network_device.h
+++ b/network/network_device.h
@@ -14,6 +14,7 @@ typedef struct {
                       uint8_t port_mask);
   BmErr (*const enable)(void *self);
   BmErr (*const disable)(void *self);
+  uint8_t (*const num_ports)(void);
 } NetworkDeviceTrait;
 
 typedef struct {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -394,7 +394,8 @@ add_executable(bm_adin2111_test
     ${ADIN2111_DIR}/adi_mac.c
     ${ADIN2111_DIR}/adi_phy.c
     ${ADIN2111_DIR}/adi_spi_oa.c
-    ${COMMON_DIR}/aligned_malloc.c)
+    ${COMMON_DIR}/aligned_malloc.c
+    ${STUB_DIR}/bm_adin2111_stub.c)
 target_include_directories(bm_adin2111_test PRIVATE
     ${ADIN2111_DIR}
     ${CMAKE_CURRENT_LIST_DIR}/../network)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -261,6 +261,7 @@ set (L2_SRCS
     # Stubs
     ${STUB_DIR}/bm_os_stub.c
     ${STUB_DIR}/bm_ip_stub.c
+    ${STUB_DIR}/bm_adin2111_stub.c
 )
 create_gtest("l2" "${L2_SRCS}")
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -140,6 +140,7 @@ set (BCMP_SRCS
     ${STUB_DIR}/neighbors_stub.c
     ${STUB_DIR}/topology_stub.c
     ${STUB_DIR}/bm_ip_stub.c
+    ${STUB_DIR}/bm_adin2111_stub.c
 )
 create_gtest("bcmp" "${BCMP_SRCS}")
 

--- a/test/mocks/mock_bcmp.h
+++ b/test/mocks/mock_bcmp.h
@@ -5,7 +5,7 @@
 
 typedef BmErr (*BcmpReplyCb)(uint8_t *);
 
-DECLARE_FAKE_VALUE_FUNC(BmErr, bcmp_init, NetworkDevice *);
+DECLARE_FAKE_VALUE_FUNC(BmErr, bcmp_init, NetworkDevice);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bcmp_tx, const void *, BcmpMessageType,
                         uint8_t *, uint16_t, uint32_t, BcmpReplyCb)
 DECLARE_FAKE_VALUE_FUNC(BmErr, bcmp_ll_forward, BcmpHeader *, void *, uint32_t,

--- a/test/mocks/mock_bcmp.h
+++ b/test/mocks/mock_bcmp.h
@@ -5,7 +5,7 @@
 
 typedef BmErr (*BcmpReplyCb)(uint8_t *);
 
-DECLARE_FAKE_VALUE_FUNC(BmErr, bcmp_init);
+DECLARE_FAKE_VALUE_FUNC(BmErr, bcmp_init, NetworkDevice *);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bcmp_tx, const void *, BcmpMessageType,
                         uint8_t *, uint16_t, uint32_t, BcmpReplyCb)
 DECLARE_FAKE_VALUE_FUNC(BmErr, bcmp_ll_forward, BcmpHeader *, void *, uint32_t,

--- a/test/mocks/mock_bm_adin2111.h
+++ b/test/mocks/mock_bm_adin2111.h
@@ -7,8 +7,7 @@ extern "C" {
 
 DECLARE_FAKE_VOID_FUNC(network_device_power_cb, bool);
 DECLARE_FAKE_VOID_FUNC(link_changed_on_port, uint8_t, bool);
-DECLARE_FAKE_VALUE_FUNC(size_t, received_data_on_port, uint8_t, uint8_t *,
-                        size_t);
+DECLARE_FAKE_VOID_FUNC(received_data_on_port, uint8_t, uint8_t *, size_t);
 
 DECLARE_FAKE_VALUE_FUNC(BmErr, netdevice_send, void *, uint8_t *, size_t,
                         uint8_t);

--- a/test/mocks/mock_bm_adin2111.h
+++ b/test/mocks/mock_bm_adin2111.h
@@ -14,11 +14,6 @@ DECLARE_FAKE_VALUE_FUNC(BmErr, netdevice_send, void *, uint8_t *, size_t,
 DECLARE_FAKE_VALUE_FUNC(BmErr, netdevice_enable, void *);
 DECLARE_FAKE_VALUE_FUNC(BmErr, netdevice_disable, void *);
 
-NetworkDeviceCallbacks const fake_netdevice_callbacks = {
-    .power = network_device_power_cb,
-    .link_change = link_changed_on_port,
-    .receive = received_data_on_port};
-
 NetworkDevice create_mock_network_device(void);
 
 #ifdef __cplusplus

--- a/test/mocks/mock_bm_adin2111.h
+++ b/test/mocks/mock_bm_adin2111.h
@@ -13,6 +13,7 @@ DECLARE_FAKE_VALUE_FUNC(BmErr, netdevice_send, void *, uint8_t *, size_t,
                         uint8_t);
 DECLARE_FAKE_VALUE_FUNC(BmErr, netdevice_enable, void *);
 DECLARE_FAKE_VALUE_FUNC(BmErr, netdevice_disable, void *);
+DECLARE_FAKE_VALUE_FUNC(uint8_t, netdevice_num_ports);
 
 NetworkDevice create_mock_network_device(void);
 

--- a/test/mocks/mock_bm_adin2111.h
+++ b/test/mocks/mock_bm_adin2111.h
@@ -1,0 +1,27 @@
+#include "bm_adin2111.h"
+#include "fff.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+DECLARE_FAKE_VOID_FUNC(network_device_power_cb, bool);
+DECLARE_FAKE_VOID_FUNC(link_changed_on_port, uint8_t, bool);
+DECLARE_FAKE_VALUE_FUNC(size_t, received_data_on_port, uint8_t, uint8_t *,
+                        size_t);
+
+DECLARE_FAKE_VALUE_FUNC(BmErr, netdevice_send, void *, uint8_t *, size_t,
+                        uint8_t);
+DECLARE_FAKE_VALUE_FUNC(BmErr, netdevice_enable, void *);
+DECLARE_FAKE_VALUE_FUNC(BmErr, netdevice_disable, void *);
+
+NetworkDeviceCallbacks const fake_netdevice_callbacks = {
+    .power = network_device_power_cb,
+    .link_change = link_changed_on_port,
+    .receive = received_data_on_port};
+
+NetworkDevice create_mock_network_device(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/test/mocks/mock_l2.h
+++ b/test/mocks/mock_l2.h
@@ -4,6 +4,6 @@
 
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_l2_link_output, void *, uint32_t);
 DECLARE_FAKE_VOID_FUNC(bm_l2_deinit)
-DECLARE_FAKE_VALUE_FUNC(BmErr, bm_l2_init, NetworkDevice);
+DECLARE_FAKE_VALUE_FUNC(BmErr, bm_l2_init, NetworkDevice *);
 DECLARE_FAKE_VALUE_FUNC(bool, bm_l2_get_port_state, uint8_t);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_l2_netif_set_power, bool);

--- a/test/mocks/mock_l2.h
+++ b/test/mocks/mock_l2.h
@@ -4,12 +4,6 @@
 
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_l2_link_output, void *, uint32_t);
 DECLARE_FAKE_VOID_FUNC(bm_l2_deinit)
-DECLARE_FAKE_VALUE_FUNC(BmErr, bm_l2_init, BmL2ModuleLinkChangeCb,
-                        const BmNetDevCfg *, uint8_t);
-
-DECLARE_FAKE_VALUE_FUNC(bool, bm_l2_get_device_handle, uint8_t, void **,
-                        uint32_t *);
-DECLARE_FAKE_VALUE_FUNC(uint8_t, bm_l2_get_num_ports);
-DECLARE_FAKE_VALUE_FUNC(uint8_t, bm_l2_get_num_devices);
+DECLARE_FAKE_VALUE_FUNC(BmErr, bm_l2_init, NetworkDevice *);
 DECLARE_FAKE_VALUE_FUNC(bool, bm_l2_get_port_state, uint8_t);
-DECLARE_FAKE_VALUE_FUNC(BmErr, bm_l2_netif_set_power, void *, bool);
+DECLARE_FAKE_VALUE_FUNC(BmErr, bm_l2_netif_set_power, bool);

--- a/test/mocks/mock_l2.h
+++ b/test/mocks/mock_l2.h
@@ -4,6 +4,6 @@
 
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_l2_link_output, void *, uint32_t);
 DECLARE_FAKE_VOID_FUNC(bm_l2_deinit)
-DECLARE_FAKE_VALUE_FUNC(BmErr, bm_l2_init, NetworkDevice *);
+DECLARE_FAKE_VALUE_FUNC(BmErr, bm_l2_init, NetworkDevice);
 DECLARE_FAKE_VALUE_FUNC(bool, bm_l2_get_port_state, uint8_t);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_l2_netif_set_power, bool);

--- a/test/src/bcmp_test.cpp
+++ b/test/src/bcmp_test.cpp
@@ -37,7 +37,8 @@ protected:
 TEST_F(Bcmp, init) {
   // Test success
   bm_task_create_fake.return_val = BmOK;
-  ASSERT_EQ(bcmp_init(), BmOK);
+  NetworkDevice network_device = {0};
+  ASSERT_EQ(bcmp_init(&network_device), BmOK);
   ASSERT_EQ(bcmp_heartbeat_init_fake.call_count, 1);
   ASSERT_EQ(ping_init_fake.call_count, 1);
   ASSERT_EQ(bm_dfu_init_fake.call_count, 1);
@@ -58,7 +59,7 @@ TEST_F(Bcmp, init) {
 
   // Test failure
   bm_task_create_fake.return_val = BmENOMEM;
-  ASSERT_EQ(bcmp_init(), BmENOMEM);
+  ASSERT_EQ(bcmp_init(&network_device), BmENOMEM);
   ASSERT_EQ(bcmp_heartbeat_init_fake.call_count, 1);
   ASSERT_EQ(ping_init_fake.call_count, 1);
   ASSERT_EQ(bm_dfu_init_fake.call_count, 1);
@@ -167,6 +168,9 @@ TEST_F(Bcmp, bcmp_ll_forward) {
 
   bm_free(data);
 }
+
+// Testing a private function, not in the header, but also not static linkage
+extern "C" void bcmp_link_change(uint8_t port, bool state);
 
 TEST_F(Bcmp, bcmp_link_change) {
   bcmp_link_change(1, false);

--- a/test/src/bcmp_test.cpp
+++ b/test/src/bcmp_test.cpp
@@ -7,6 +7,7 @@ DEFINE_FFF_GLOBALS;
 
 extern "C" {
 #include "bcmp.h"
+#include "mock_bm_adin2111.h"
 #include "mock_bm_ip.h"
 #include "mock_bm_os.h"
 #include "mock_config.h"
@@ -37,8 +38,8 @@ protected:
 TEST_F(Bcmp, init) {
   // Test success
   bm_task_create_fake.return_val = BmOK;
-  NetworkDevice network_device = {0};
-  ASSERT_EQ(bcmp_init(&network_device), BmOK);
+  NetworkDevice network_device = create_mock_network_device();
+  ASSERT_EQ(bcmp_init(network_device), BmOK);
   ASSERT_EQ(bcmp_heartbeat_init_fake.call_count, 1);
   ASSERT_EQ(ping_init_fake.call_count, 1);
   ASSERT_EQ(bm_dfu_init_fake.call_count, 1);
@@ -59,7 +60,7 @@ TEST_F(Bcmp, init) {
 
   // Test failure
   bm_task_create_fake.return_val = BmENOMEM;
-  ASSERT_EQ(bcmp_init(&network_device), BmENOMEM);
+  ASSERT_EQ(bcmp_init(network_device), BmENOMEM);
   ASSERT_EQ(bcmp_heartbeat_init_fake.call_count, 1);
   ASSERT_EQ(ping_init_fake.call_count, 1);
   ASSERT_EQ(bm_dfu_init_fake.call_count, 1);

--- a/test/src/bm_adin2111_test.cpp
+++ b/test/src/bm_adin2111_test.cpp
@@ -47,3 +47,14 @@ TEST(Adin2111, disable) {
   // SEGFAULT because PHY is NULL, because no real SPI transactions
   EXPECT_DEATH(device.trait->disable(device.self), "");
 }
+
+TEST(Adin2111, set_power_cb_before_init) {
+  NetworkDevice device = adin2111_network_device();
+  device.callbacks->power = network_device_power_cb;
+  RESET_FAKE(network_device_power_cb);
+  EXPECT_EQ(network_device_power_cb_fake.call_count, 0);
+  adin2111_init();
+  // Called twice because we first turn the adin on,
+  // then when we get SPI errors, we turn it off
+  EXPECT_EQ(network_device_power_cb_fake.call_count, 2);
+}

--- a/test/src/bm_adin2111_test.cpp
+++ b/test/src/bm_adin2111_test.cpp
@@ -48,6 +48,11 @@ TEST(Adin2111, disable) {
   EXPECT_DEATH(device.trait->disable(device.self), "");
 }
 
+TEST(Adin2111, num_ports) {
+  NetworkDevice device = setup();
+  EXPECT_EQ(device.trait->num_ports(), ADIN2111_PORT_NUM);
+}
+
 TEST(Adin2111, set_power_cb_before_init) {
   NetworkDevice device = adin2111_network_device();
   device.callbacks->power = network_device_power_cb;

--- a/test/src/bm_adin2111_test.cpp
+++ b/test/src/bm_adin2111_test.cpp
@@ -23,8 +23,7 @@ FAKE_VOID_FUNC(__disable_irq);
 FAKE_VOID_FUNC(__enable_irq);
 
 static NetworkDevice setup() {
-  static Adin2111 adin = {.device_handle = NULL,
-                          .callbacks = &fake_netdevice_callbacks};
+  static Adin2111 adin = {.device_handle = NULL};
 
   // We can only call adin2111_init once per execution (test suite)
   // because the device memory in the driver is static.

--- a/test/src/bm_adin2111_test.cpp
+++ b/test/src/bm_adin2111_test.cpp
@@ -7,6 +7,7 @@ DEFINE_FFF_GLOBALS;
 extern "C" {
 void *bm_malloc(size_t size) { return malloc(size); }
 void bm_free(void *p) { free(p); }
+NetworkDevice create_fake_network_device(void);
 }
 
 FAKE_VALUE_FUNC(uint32_t, HAL_DisableIrq);
@@ -22,50 +23,25 @@ FAKE_VALUE_FUNC(long unsigned int, __REV, long unsigned int);
 FAKE_VOID_FUNC(__disable_irq);
 FAKE_VOID_FUNC(__enable_irq);
 
-FAKE_VOID_FUNC(netif_power_cb, bool);
-FAKE_VOID_FUNC(link_changed_on_port, uint8_t, bool);
-FAKE_VALUE_FUNC(size_t, received_data_on_port, uint8_t, uint8_t *, size_t);
-
-static NetworkDeviceCallbacks const callbacks = {
-    .power = netif_power_cb,
-    .link_change = link_changed_on_port,
-    .receive = received_data_on_port};
-
-static NetworkDevice setup(void) {
-  static Adin2111 adin = {.device_handle = nullptr, .callbacks = &callbacks};
-
-  // We can only call adin2111_init once per execution (test suite)
-  // because the device memory in the driver is static.
-  if (adin.device_handle == nullptr) {
-    BmErr err = adin2111_init(&adin);
-
-    // It would take a lot of mocking to pretend SPI transactions work.
-    // On a real device, this should return BmOK.
-    EXPECT_EQ(err, BmENODEV);
-  }
-
-  return prep_adin2111_netif(&adin);
-}
-
 TEST(Adin2111, send) {
-  NetworkDevice netif = setup();
-  BmErr err = netif.trait->send(netif.self, (unsigned char *)"hello", 5,
-                                ADIN2111_PORT_MASK);
+  NetworkDevice device = create_fake_network_device();
+  BmErr err = device.trait->send(device.self, (unsigned char *)"hello", 5,
+                                 ADIN2111_PORT_MASK);
   EXPECT_EQ(err, BmOK);
 }
 
 TEST(Adin2111, enable) {
-  NetworkDevice netif = setup();
+  NetworkDevice device = create_fake_network_device();
   // Expect the same BmENODEV error as in init
   // because init calls enable internally.
   // On a real device, this should return BmOK,
   // but we don't have the SPI transactions mocked.
-  BmErr err = netif.trait->enable(netif.self);
+  BmErr err = device.trait->enable(device.self);
   EXPECT_EQ(err, BmENODEV);
 }
 
 TEST(Adin2111, disable) {
-  NetworkDevice netif = setup();
+  NetworkDevice device = create_fake_network_device();
   // SEGFAULT because PHY is NULL, because no real SPI transactions
-  EXPECT_DEATH(netif.trait->disable(netif.self), "");
+  EXPECT_DEATH(device.trait->disable(device.self), "");
 }

--- a/test/src/bm_adin2111_test.cpp
+++ b/test/src/bm_adin2111_test.cpp
@@ -23,16 +23,8 @@ FAKE_VOID_FUNC(__disable_irq);
 FAKE_VOID_FUNC(__enable_irq);
 
 static NetworkDevice setup() {
-  static Adin2111 adin = {.device_handle = NULL};
-
-  // We can only call adin2111_init once per execution (test suite)
-  // because the device memory in the driver is static.
-  // On a real device, this should return BmOK,
-  // but we don't have the SPI transactions mocked.
-  if (adin.device_handle == NULL) {
-    adin2111_init(&adin);
-  }
-  return create_adin2111_network_device(&adin);
+  adin2111_init();
+  return create_adin2111_network_device();
 }
 
 TEST(Adin2111, send) {

--- a/test/src/bm_adin2111_test.cpp
+++ b/test/src/bm_adin2111_test.cpp
@@ -24,7 +24,7 @@ FAKE_VOID_FUNC(__enable_irq);
 
 static NetworkDevice setup() {
   adin2111_init();
-  return create_adin2111_network_device();
+  return adin2111_network_device();
 }
 
 TEST(Adin2111, send) {

--- a/test/src/l2_test.cpp
+++ b/test/src/l2_test.cpp
@@ -11,16 +11,8 @@ extern "C" {
 #include "l2.h"
 #include "mock_bm_ip.h"
 #include "mock_bm_os.h"
+#include "mock_bm_adin2111.h"
 }
-
-FAKE_VALUE_FUNC(NetworkDevice, create_mock_network_device);
-FAKE_VALUE_FUNC(BmErr, fake_netdevice_enable, void *);
-FAKE_VALUE_FUNC(BmErr, fake_netdevice_disable, void *);
-
-static NetworkDeviceTrait const fake_netdevice_trait = {
-    .send = NULL,
-    .enable = fake_netdevice_enable,
-    .disable = fake_netdevice_disable};
 
 #define port_per_device 2
 #define egress_port_offset 51
@@ -44,10 +36,8 @@ protected:
   NetworkDevice network_device;
 
   void SetUp() override {
-    create_mock_network_device_fake.return_val = {
-        .self = &adin, .trait = &fake_netdevice_trait};
-    fake_netdevice_enable_fake.return_val = BmOK;
-    fake_netdevice_disable_fake.return_val = BmOK;
+    netdevice_enable_fake.return_val = BmOK;
+    netdevice_disable_fake.return_val = BmOK;
     network_device = create_mock_network_device();
     init_count = 0;
     bm_queue_create_fake.return_val =

--- a/test/src/l2_test.cpp
+++ b/test/src/l2_test.cpp
@@ -42,7 +42,7 @@ protected:
     bm_queue_create_fake.return_val =
         (void *)RND.rnd_int(UINT32_MAX, UINT16_MAX);
 
-    EXPECT_EQ(bm_l2_init(network_device), BmOK);
+    EXPECT_EQ(bm_l2_init(&network_device), BmOK);
   }
   void TearDown() override { bm_l2_deinit(); }
 };
@@ -55,12 +55,12 @@ TEST_F(L2, init) {
   // Reset init count after deinit
   init_count = 0;
   bm_task_create_fake.return_val = BmENOMEM;
-  EXPECT_NE(bm_l2_init(network_device), BmOK);
+  EXPECT_NE(bm_l2_init(&network_device), BmOK);
   bm_l2_deinit();
   // Reset init count after deinit
   init_count = 0;
   bm_queue_create_fake.return_val = NULL;
-  EXPECT_NE(bm_l2_init(network_device), BmOK);
+  EXPECT_NE(bm_l2_init(&network_device), BmOK);
   bm_l2_deinit();
   // Reset init count after deinit
   init_count = 0;

--- a/test/src/l2_test.cpp
+++ b/test/src/l2_test.cpp
@@ -1,5 +1,5 @@
-#include <helpers.hpp>
 #include <gtest/gtest.h>
+#include <helpers.hpp>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -13,64 +13,26 @@ extern "C" {
 #include "mock_bm_os.h"
 }
 
+FAKE_VALUE_FUNC(BmErr, adin2111_init, Adin2111 *);
+FAKE_VALUE_FUNC(NetworkDevice, create_adin2111_network_device, Adin2111 *);
+
 struct L2Meta {
   BmL2RxCb rx;
-  BmL2DeviceLinkChangeCb link_change;
   void *device_handle;
 };
 
-#define num_devices 3
-#define num_port 6
-#define port_per_device (num_port / num_devices)
+#define port_per_device 2
 #define egress_port_offset 51
-
-#if (num_port % num_devices != 0)
-#error "num_devices must divide evenly into num_port"
-#endif
 
 class L2 : public ::testing::Test {
 public:
   rnd_gen RND;
-  static struct L2Meta META[num_devices];
+  static struct L2Meta META;
   static uint8_t init_count;
-
-  static BmErr init_cb(void *device_handle, BmL2RxCb rx_cb,
-                       BmL2DeviceLinkChangeCb link_change_cb,
-                       uint8_t port_mask) {
-    BmErr err = BmOK;
-    EXPECT_NE(device_handle, nullptr);
-    EXPECT_NE(rx_cb, nullptr);
-    EXPECT_NE(link_change_cb, nullptr);
-    META[init_count].rx = rx_cb;
-    META[init_count].link_change = link_change_cb;
-    META[init_count].device_handle = device_handle;
-    init_count++;
-    return err;
-  }
 
   static BmErr tx_cb(void *device_handle, uint8_t *buf, uint16_t size,
                      uint8_t port_mask, uint8_t port_offset) {
-    BmErr err = BmOK;
-    bool found = false;
-    for (uint8_t i = 0; i < num_devices; i++) {
-      if (device_handle == META[i].device_handle) {
-        found = true;
-      }
-    }
-    EXPECT_EQ(found, true);
-    return err;
-  }
-
-  static BmErr power_cb(const void *device_handle, bool on, uint8_t port_mask) {
-    BmErr err = BmOK;
-    bool found = false;
-    for (uint8_t i = 0; i < num_devices; i++) {
-      if (device_handle == META[i].device_handle) {
-        found = true;
-      }
-    }
-    EXPECT_EQ(found, true);
-    return err;
+    return BmOK;
   }
 
 private:
@@ -78,56 +40,37 @@ protected:
   L2() {}
   ~L2() override {}
 
-  /*!
-    @brief Create a configured number of devices and initialize driver
-  */
+  NetworkDevice network_device;
+
   void SetUp() override {
-    BmNetDevCfg cfg[num_devices];
+    Adin2111 adin;
+    adin2111_init(&adin);
+    network_device = create_adin2111_network_device(&adin);
     init_count = 0;
-
-    for (uint8_t i = 0; i < num_devices; i++) {
-      cfg[i].device_handle = (void *)RND.rnd_int(UINT64_MAX, UINT32_MAX);
-      cfg[i].port_mask = 0b11;
-      cfg[i].num_ports = port_per_device;
-      cfg[i].init_cb = init_cb;
-      cfg[i].power_cb = power_cb;
-      cfg[i].tx_cb = tx_cb;
-    }
-
     bm_queue_create_fake.return_val =
         (void *)RND.rnd_int(UINT32_MAX, UINT16_MAX);
-    EXPECT_EQ(bm_l2_init(NULL, cfg, num_devices), BmOK);
+
+    EXPECT_EQ(bm_l2_init(&network_device), BmOK);
   }
   void TearDown() override { bm_l2_deinit(); }
 };
 
-struct L2Meta L2::META[num_devices] = {};
+struct L2Meta L2::META = {0};
 uint8_t L2::init_count;
 
 TEST_F(L2, init) {
-  BmNetDevCfg cfg[num_devices];
-  for (uint8_t i = 0; i < num_devices; i++) {
-    cfg[i].device_handle = (void *)RND.rnd_int(UINT64_MAX, UINT32_MAX);
-    cfg[i].port_mask = 0b11;
-    cfg[i].num_ports = port_per_device;
-    cfg[i].init_cb = init_cb;
-    cfg[i].power_cb = power_cb;
-    cfg[i].tx_cb = tx_cb;
-  }
-
   // Test failures
   bm_l2_deinit();
   // Reset init count after deinit
   init_count = 0;
-  EXPECT_NE(bm_l2_init(NULL, NULL, num_devices), BmOK);
-  EXPECT_NE(bm_l2_init(NULL, cfg, 0), BmOK);
+  EXPECT_NE(bm_l2_init(NULL), BmOK);
   bm_task_create_fake.return_val = BmENOMEM;
-  EXPECT_NE(bm_l2_init(NULL, cfg, num_devices), BmOK);
+  EXPECT_NE(bm_l2_init(&network_device), BmOK);
   bm_l2_deinit();
   // Reset init count after deinit
   init_count = 0;
   bm_queue_create_fake.return_val = NULL;
-  EXPECT_NE(bm_l2_init(NULL, cfg, num_devices), BmOK);
+  EXPECT_NE(bm_l2_init(&network_device), BmOK);
   bm_l2_deinit();
   // Reset init count after deinit
   init_count = 0;
@@ -171,44 +114,11 @@ TEST_F(L2, link_output) {
 }
 
 /*!
- @brief Get number of ports and devices configured for L2
-*/
-TEST_F(L2, num_devices_ports) {
-  EXPECT_EQ(bm_l2_get_num_ports(), num_port);
-  EXPECT_EQ(bm_l2_get_num_devices(), num_devices);
-}
-
-/*!
- @brief Get the device handle of all devices configured for L2
-*/
-TEST_F(L2, get_device_handle) {
-  void *handle = NULL;
-  uint32_t start_port_idx = 0;
-  for (uint8_t i = 0; i < num_devices; i++) {
-    EXPECT_EQ(bm_l2_get_device_handle(i, &handle, &start_port_idx), true);
-    EXPECT_EQ(handle, META[i].device_handle);
-    EXPECT_EQ(start_port_idx, i * (port_per_device));
-  }
-
-  // Test invalid use cases
-  EXPECT_EQ(bm_l2_get_device_handle(0, NULL, NULL), false);
-  EXPECT_EQ(bm_l2_get_device_handle(0, &handle, NULL), false);
-  EXPECT_EQ(bm_l2_get_device_handle(0, NULL, &start_port_idx), false);
-  EXPECT_EQ(bm_l2_get_device_handle(UINT8_MAX, &handle, &start_port_idx),
-            false);
-}
-
-/*!
   @brief Test setting the power (on/off) of the all devices
 */
 TEST_F(L2, set_power) {
-  for (uint8_t i = 0; i < num_devices; i++) {
-    EXPECT_EQ(bm_l2_netif_set_power(META[i].device_handle, true), BmOK);
-    EXPECT_EQ(bm_l2_netif_set_power(META[i].device_handle, false), BmOK);
-  }
-
-  // Test invalid use cases
-  EXPECT_NE(bm_l2_netif_set_power(NULL, true), BmOK);
+  EXPECT_EQ(bm_l2_netif_set_power(true), BmOK);
+  EXPECT_EQ(bm_l2_netif_set_power(false), BmOK);
 }
 
 /*!
@@ -221,30 +131,23 @@ TEST_F(L2, test_callbacks) {
 
   bm_l2_new_fake.return_val = buf;
   bm_l2_get_payload_fake.return_val = buf;
-  for (uint8_t i = 0; i < num_devices; i++) {
-    ASSERT_EQ(META[i].rx(META[i].device_handle, buf, size,
-                         RND.rnd_int(port_per_device, 1)),
-              BmOK);
-    META[i].link_change(META[i].device_handle, RND.rnd_int(port_per_device, 1),
-                        true);
-    META[i].link_change(META[i].device_handle, RND.rnd_int(port_per_device, 1),
-                        false);
-  }
+  ASSERT_EQ(
+      META.rx(META.device_handle, buf, size, RND.rnd_int(port_per_device, 1)),
+      BmOK);
 
   //Teset invalid use cases
-  ASSERT_NE(META[0].rx(NULL, buf, size, RND.rnd_int(port_per_device, 1)), BmOK);
+  ASSERT_NE(META.rx(NULL, buf, size, RND.rnd_int(port_per_device, 1)), BmOK);
   bm_queue_send_fake.return_val = BmENOMEM;
-  ASSERT_NE(META[0].rx(META[0].device_handle, buf, size,
-                       RND.rnd_int(port_per_device, 1)),
-            BmOK);
+  ASSERT_NE(
+      META.rx(META.device_handle, buf, size, RND.rnd_int(port_per_device, 1)),
+      BmOK);
   bm_l2_new_fake.return_val = NULL;
-  ASSERT_NE(META[0].rx(META[0].device_handle, buf, size,
-                       RND.rnd_int(port_per_device, 1)),
-            BmOK);
-  ASSERT_NE(META[0].rx(META[0].device_handle, NULL, size,
-                       RND.rnd_int(port_per_device, 1)),
-            BmOK);
-  META[0].link_change(NULL, RND.rnd_int(port_per_device, 1), true);
+  ASSERT_NE(
+      META.rx(META.device_handle, buf, size, RND.rnd_int(port_per_device, 1)),
+      BmOK);
+  ASSERT_NE(
+      META.rx(META.device_handle, NULL, size, RND.rnd_int(port_per_device, 1)),
+      BmOK);
 
   bm_free(buf);
 }

--- a/test/src/l2_test.cpp
+++ b/test/src/l2_test.cpp
@@ -42,7 +42,7 @@ protected:
     bm_queue_create_fake.return_val =
         (void *)RND.rnd_int(UINT32_MAX, UINT16_MAX);
 
-    EXPECT_EQ(bm_l2_init(&network_device), BmOK);
+    EXPECT_EQ(bm_l2_init(network_device), BmOK);
   }
   void TearDown() override { bm_l2_deinit(); }
 };
@@ -55,12 +55,12 @@ TEST_F(L2, init) {
   // Reset init count after deinit
   init_count = 0;
   bm_task_create_fake.return_val = BmENOMEM;
-  EXPECT_NE(bm_l2_init(&network_device), BmOK);
+  EXPECT_NE(bm_l2_init(network_device), BmOK);
   bm_l2_deinit();
   // Reset init count after deinit
   init_count = 0;
   bm_queue_create_fake.return_val = NULL;
-  EXPECT_NE(bm_l2_init(&network_device), BmOK);
+  EXPECT_NE(bm_l2_init(network_device), BmOK);
   bm_l2_deinit();
   // Reset init count after deinit
   init_count = 0;

--- a/test/src/l2_test.cpp
+++ b/test/src/l2_test.cpp
@@ -32,7 +32,6 @@ protected:
   L2() {}
   ~L2() override {}
 
-  Adin2111 adin;
   NetworkDevice network_device;
 
   void SetUp() override {

--- a/test/src/topology_test.cpp
+++ b/test/src/topology_test.cpp
@@ -160,7 +160,7 @@ TEST_F(Topology, request_table) {
   memcpy(reply->port_list, replies[0].port_list, size_info);
   data.payload = (uint8_t *)reply;
 
-  EXPECT_EQ(bcmp_topology_init(), BmOK);
+  EXPECT_EQ(bcmp_topology_init(2), BmOK);
 
   bm_timer_start_fake.return_val = BmOK;
   bcmp_tx_fake.return_val = BmOK;
@@ -191,7 +191,7 @@ TEST_F(Topology, request_reply) {
   BcmpProcessData data;
   data.payload = (uint8_t *)&request;
 
-  EXPECT_EQ(bcmp_topology_init(), BmOK);
+  EXPECT_EQ(bcmp_topology_init(2), BmOK);
 
   node_id_fake.return_val = request.target_node_id;
   bcmp_tx_fake.return_val = BmOK;

--- a/test/stubs/bcmp_stub.c
+++ b/test/stubs/bcmp_stub.c
@@ -1,6 +1,6 @@
 #include "mock_bcmp.h"
 
-DEFINE_FAKE_VALUE_FUNC(BmErr, bcmp_init, NetworkDevice *);
+DEFINE_FAKE_VALUE_FUNC(BmErr, bcmp_init, NetworkDevice);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bcmp_tx, const void *, BcmpMessageType, uint8_t *,
                        uint16_t, uint32_t, BcmpReplyCb)
 DEFINE_FAKE_VALUE_FUNC(BmErr, bcmp_ll_forward, BcmpHeader *, void *, uint32_t,

--- a/test/stubs/bcmp_stub.c
+++ b/test/stubs/bcmp_stub.c
@@ -1,6 +1,6 @@
 #include "mock_bcmp.h"
 
-DEFINE_FAKE_VALUE_FUNC(BmErr, bcmp_init);
+DEFINE_FAKE_VALUE_FUNC(BmErr, bcmp_init, NetworkDevice *);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bcmp_tx, const void *, BcmpMessageType, uint8_t *,
                        uint16_t, uint32_t, BcmpReplyCb)
 DEFINE_FAKE_VALUE_FUNC(BmErr, bcmp_ll_forward, BcmpHeader *, void *, uint32_t,

--- a/test/stubs/bm_adin2111_stub.c
+++ b/test/stubs/bm_adin2111_stub.c
@@ -5,8 +5,7 @@ DEFINE_FFF_GLOBALS;
 
 DEFINE_FAKE_VOID_FUNC(network_device_power_cb, bool);
 DEFINE_FAKE_VOID_FUNC(link_changed_on_port, uint8_t, bool);
-DEFINE_FAKE_VALUE_FUNC(size_t, received_data_on_port, uint8_t, uint8_t *,
-                       size_t);
+DEFINE_FAKE_VOID_FUNC(received_data_on_port, uint8_t, uint8_t *, size_t);
 
 DEFINE_FAKE_VALUE_FUNC(BmErr, netdevice_send, void *, uint8_t *, size_t,
                        uint8_t);
@@ -19,8 +18,9 @@ static NetworkDeviceTrait const fake_netdevice_trait = {
     .disable = netdevice_disable};
 
 NetworkDevice create_mock_network_device(void) {
-  static Adin2111 adin = {.device_handle = NULL,
-                          .callbacks = &fake_netdevice_callbacks};
+  static Adin2111 adin = {.device_handle = NULL};
 
-  return (NetworkDevice){.trait = &fake_netdevice_trait, .self = &adin};
+  return (NetworkDevice){.self = &adin,
+                         .trait = &fake_netdevice_trait,
+                         .callbacks = fake_netdevice_callbacks};
 }

--- a/test/stubs/bm_adin2111_stub.c
+++ b/test/stubs/bm_adin2111_stub.c
@@ -17,7 +17,12 @@ static NetworkDeviceTrait const fake_netdevice_trait = {
     .enable = netdevice_enable,
     .disable = netdevice_disable};
 
+static NetworkDeviceCallbacks fake_netdevice_callbacks = {
+    .power = network_device_power_cb,
+    .link_change = link_changed_on_port,
+    .receive = received_data_on_port};
+
 NetworkDevice create_mock_network_device(void) {
   return (NetworkDevice){.trait = &fake_netdevice_trait,
-                         .callbacks = fake_netdevice_callbacks};
+                         .callbacks = &fake_netdevice_callbacks};
 }

--- a/test/stubs/bm_adin2111_stub.c
+++ b/test/stubs/bm_adin2111_stub.c
@@ -9,11 +9,13 @@ DEFINE_FAKE_VALUE_FUNC(BmErr, netdevice_send, void *, uint8_t *, size_t,
                        uint8_t);
 DEFINE_FAKE_VALUE_FUNC(BmErr, netdevice_enable, void *);
 DEFINE_FAKE_VALUE_FUNC(BmErr, netdevice_disable, void *);
+DEFINE_FAKE_VALUE_FUNC(uint8_t, netdevice_num_ports);
 
 static NetworkDeviceTrait const fake_netdevice_trait = {
     .send = netdevice_send,
     .enable = netdevice_enable,
-    .disable = netdevice_disable};
+    .disable = netdevice_disable,
+    .num_ports = netdevice_num_ports};
 
 static NetworkDeviceCallbacks fake_netdevice_callbacks = {
     .power = network_device_power_cb,
@@ -21,6 +23,7 @@ static NetworkDeviceCallbacks fake_netdevice_callbacks = {
     .receive = received_data_on_port};
 
 NetworkDevice create_mock_network_device(void) {
+  netdevice_num_ports_fake.return_val = 2;
   return (NetworkDevice){.trait = &fake_netdevice_trait,
                          .callbacks = &fake_netdevice_callbacks};
 }

--- a/test/stubs/bm_adin2111_stub.c
+++ b/test/stubs/bm_adin2111_stub.c
@@ -1,0 +1,25 @@
+#include "bm_adin2111.h"
+#include "fff.h"
+
+DEFINE_FFF_GLOBALS;
+
+FAKE_VOID_FUNC(network_device_power_cb, bool);
+FAKE_VOID_FUNC(link_changed_on_port, uint8_t, bool);
+FAKE_VALUE_FUNC(size_t, received_data_on_port, uint8_t, uint8_t *, size_t);
+
+static NetworkDeviceCallbacks const callbacks = {
+    .power = network_device_power_cb,
+    .link_change = link_changed_on_port,
+    .receive = received_data_on_port};
+
+NetworkDevice create_fake_network_device(void) {
+  static Adin2111 adin = {.device_handle = NULL, .callbacks = &callbacks};
+
+  // We can only call adin2111_init once per execution (test suite)
+  // because the device memory in the driver is static.
+  if (adin.device_handle == NULL) {
+    adin2111_init(&adin);
+  }
+
+  return create_adin2111_network_device(&adin);
+}

--- a/test/stubs/bm_adin2111_stub.c
+++ b/test/stubs/bm_adin2111_stub.c
@@ -18,9 +18,6 @@ static NetworkDeviceTrait const fake_netdevice_trait = {
     .disable = netdevice_disable};
 
 NetworkDevice create_mock_network_device(void) {
-  static Adin2111 adin = {.device_handle = NULL};
-
-  return (NetworkDevice){.self = &adin,
-                         .trait = &fake_netdevice_trait,
+  return (NetworkDevice){.trait = &fake_netdevice_trait,
                          .callbacks = fake_netdevice_callbacks};
 }

--- a/test/stubs/bm_adin2111_stub.c
+++ b/test/stubs/bm_adin2111_stub.c
@@ -1,8 +1,6 @@
 #include "fff.h"
 #include "mock_bm_adin2111.h"
 
-DEFINE_FFF_GLOBALS;
-
 DEFINE_FAKE_VOID_FUNC(network_device_power_cb, bool);
 DEFINE_FAKE_VOID_FUNC(link_changed_on_port, uint8_t, bool);
 DEFINE_FAKE_VOID_FUNC(received_data_on_port, uint8_t, uint8_t *, size_t);

--- a/test/stubs/l2_stub.c
+++ b/test/stubs/l2_stub.c
@@ -2,6 +2,6 @@
 
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_l2_link_output, void *, uint32_t);
 DEFINE_FAKE_VOID_FUNC(bm_l2_deinit)
-DEFINE_FAKE_VALUE_FUNC(BmErr, bm_l2_init, NetworkDevice);
+DEFINE_FAKE_VALUE_FUNC(BmErr, bm_l2_init, NetworkDevice *);
 DEFINE_FAKE_VALUE_FUNC(bool, bm_l2_get_port_state, uint8_t);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_l2_netif_set_power, bool);

--- a/test/stubs/l2_stub.c
+++ b/test/stubs/l2_stub.c
@@ -2,11 +2,6 @@
 
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_l2_link_output, void *, uint32_t);
 DEFINE_FAKE_VOID_FUNC(bm_l2_deinit)
-DEFINE_FAKE_VALUE_FUNC(BmErr, bm_l2_init, BmL2ModuleLinkChangeCb,
-                       const BmNetDevCfg *, uint8_t);
-DEFINE_FAKE_VALUE_FUNC(bool, bm_l2_get_device_handle, uint8_t, void **,
-                       uint32_t *);
-DEFINE_FAKE_VALUE_FUNC(uint8_t, bm_l2_get_num_ports);
-DEFINE_FAKE_VALUE_FUNC(uint8_t, bm_l2_get_num_devices);
+DEFINE_FAKE_VALUE_FUNC(BmErr, bm_l2_init, NetworkDevice *);
 DEFINE_FAKE_VALUE_FUNC(bool, bm_l2_get_port_state, uint8_t);
-DEFINE_FAKE_VALUE_FUNC(BmErr, bm_l2_netif_set_power, void *, bool);
+DEFINE_FAKE_VALUE_FUNC(BmErr, bm_l2_netif_set_power, bool);

--- a/test/stubs/l2_stub.c
+++ b/test/stubs/l2_stub.c
@@ -2,6 +2,6 @@
 
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_l2_link_output, void *, uint32_t);
 DEFINE_FAKE_VOID_FUNC(bm_l2_deinit)
-DEFINE_FAKE_VALUE_FUNC(BmErr, bm_l2_init, NetworkDevice *);
+DEFINE_FAKE_VALUE_FUNC(BmErr, bm_l2_init, NetworkDevice);
 DEFINE_FAKE_VALUE_FUNC(bool, bm_l2_get_port_state, uint8_t);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_l2_netif_set_power, bool);


### PR DESCRIPTION
Summary of the changes:
- Assume a single static `NetworkDevice` with exactly 2 ports
- Remove the `Adin2111` type, which is no longer needed, though the `NetworkDevice` retains `void *self` for a future when we support multiple devices or in case other future SPE chip drivers require extra data
- The `power`, `link_change`, and `receive` callbacks moved to the `NetworkDevice`, which enables setting them at other layers by passing `NetworkDevice` to various init calls
  - L2 sets the `receive` callback in `bm_l2_init`
  - BCMP sets the `link_change` callback in `bcmp_init`
- Add mock and stub files for `bm_adin2111.c`, used by the BCMP and L2 tests, which required adding include guards to `bm_adin2111.h` and `network_device.h`

Next steps that could go here but I'm leaving for a future PR:
- Do we still need a queue and a thread for TX and RX in L2? I think probably not.
- Let's create a `bristlemouth.h` and `bristlemouth.c` (probably in the middleware folder since it depends on everything else) to tie together all the things! Then the dream will be real! Just call `bristlemouth_init()`!!!