### PR TITLE
Fixes WDT tripping if the bus is down during a topology event that times out

### DIFF
--- a/bcmp/neighbors.c
+++ b/bcmp/neighbors.c
@@ -425,7 +425,7 @@ BmErr bcmp_request_neighbor_table(uint64_t target_node_id, const void *addr,
     bm_timer_delete(NEIGHBOR_TIMER, 10);
   }
   NEIGHBOR_TIMER = bm_timer_create("neighbor_request_timer",
-                                   bcmp_neighbor_timer_timeout_s * 1000, true,
+                                   bcmp_neighbor_timer_timeout_s * 1000, false,
                                    NULL, timeout);
 
   if (NEIGHBOR_TIMER) {


### PR DESCRIPTION
There was a watchdog event occurring on the bridge if there was no RTC set during a topology event.
The timer for  the neighbors message would continuously be called and the timeout event would occur indefinitely (due to it being a reloaded timer and not a one shot timer), this would block all other tasks and trip the watchdog.