### PR TITLE
Add send to front of queue from isr wrapper

### DIFF
--- a/common/bm_freertos.c
+++ b/common/bm_freertos.c
@@ -35,6 +35,11 @@ BmErr bm_queue_send(BmQueue queue, const void *item, uint32_t timeout_ms) {
 BmErr bm_queue_send_to_front_from_isr(BmQueue queue, const void *item) {
   BaseType_t higher_priority_task_woken = pdFALSE;
   if (xQueueSendToFrontFromISR(queue, item, &higher_priority_task_woken) == pdPASS) {
+    // The portYIELD_FROM_ISR() is safe to do on ARM Cortex-M architectures because
+    // it sets a pending switch bit in the NVIC such that once all interrupts are complete
+    // it knows to tell the scheduler to do a context switch. On some other architectures,
+    // the yield may immediately call the scheduler to perform the context switch so this
+    // function should be the last thing called from the ISR if possible.
     portYIELD_FROM_ISR(higher_priority_task_woken);
     return BmOK;
   } else {

--- a/common/bm_freertos.c
+++ b/common/bm_freertos.c
@@ -32,9 +32,10 @@ BmErr bm_queue_send(BmQueue queue, const void *item, uint32_t timeout_ms) {
   }
 }
 
-BmErr bm_queue_send_to_front_from_isr(BmQueue queue, const void *item, uint32_t *higher_priority_task_woken) {
-  // BaseType_t higher_priority_task_woken = pdFALSE;
-  if (xQueueSendToFrontFromISR(queue, item, higher_priority_task_woken) == pdPASS) {
+BmErr bm_queue_send_to_front_from_isr(BmQueue queue, const void *item) {
+  BaseType_t higher_priority_task_woken = pdFALSE;
+  if (xQueueSendToFrontFromISR(queue, item, &higher_priority_task_woken) == pdPASS) {
+    portYIELD_FROM_ISR(higher_priority_task_woken);
     return BmOK;
   } else {
     return BmENOMEM;

--- a/common/bm_freertos.c
+++ b/common/bm_freertos.c
@@ -32,10 +32,9 @@ BmErr bm_queue_send(BmQueue queue, const void *item, uint32_t timeout_ms) {
   }
 }
 
-BmErr bm_queue_send_to_front_from_isr(BmQueue queue, const void *item, uint32_t *task_woken) {
-  BaseType_t higher_priority_task_woken = pdFALSE;
-  if (xQueueSendToFrontFromISR(queue, item, &higher_priority_task_woken) == pdPASS) {
-    *task_woken = higher_priority_task_woken;
+BmErr bm_queue_send_to_front_from_isr(BmQueue queue, const void *item, uint32_t *higher_priority_task_woken) {
+  // BaseType_t higher_priority_task_woken = pdFALSE;
+  if (xQueueSendToFrontFromISR(queue, item, higher_priority_task_woken) == pdPASS) {
     return BmOK;
   } else {
     return BmENOMEM;

--- a/common/bm_freertos.c
+++ b/common/bm_freertos.c
@@ -32,6 +32,16 @@ BmErr bm_queue_send(BmQueue queue, const void *item, uint32_t timeout_ms) {
   }
 }
 
+BmErr bm_queue_send_to_front_from_isr(BmQueue queue, const void *item, uint32_t *task_woken) {
+  BaseType_t higher_priority_task_woken = pdFALSE;
+  if (xQueueSendToFrontFromISR(queue, item, &higher_priority_task_woken) == pdPASS) {
+    *task_woken = higher_priority_task_woken;
+    return BmOK;
+  } else {
+    return BmENOMEM;
+  }
+}
+
 BmSemaphore bm_semaphore_create(void) { return xSemaphoreCreateMutex(); }
 
 void bm_semaphore_delete(BmSemaphore semaphore) { vSemaphoreDelete((SemaphoreHandle_t)semaphore); }

--- a/common/bm_os.h
+++ b/common/bm_os.h
@@ -37,7 +37,7 @@ BmQueue bm_queue_create(uint32_t queue_length, uint32_t item_size);
 void bm_queue_delete(BmQueue queue);
 BmErr bm_queue_receive(BmQueue queue, void *item, uint32_t timeout_ms);
 BmErr bm_queue_send(BmQueue queue, const void *item, uint32_t timeout_ms);
-BmErr bm_queue_send_to_front_from_isr(BmQueue queue, const void *item, uint32_t *task_woken);
+BmErr bm_queue_send_to_front_from_isr(BmQueue queue, const void *item, uint32_t *higher_priority_task_woken);
 
 // Semaphore functions
 BmSemaphore bm_semaphore_create(void);

--- a/common/bm_os.h
+++ b/common/bm_os.h
@@ -37,6 +37,7 @@ BmQueue bm_queue_create(uint32_t queue_length, uint32_t item_size);
 void bm_queue_delete(BmQueue queue);
 BmErr bm_queue_receive(BmQueue queue, void *item, uint32_t timeout_ms);
 BmErr bm_queue_send(BmQueue queue, const void *item, uint32_t timeout_ms);
+BmErr bm_queue_send_to_front_from_isr(BmQueue queue, const void *item, uint32_t *task_woken);
 
 // Semaphore functions
 BmSemaphore bm_semaphore_create(void);

--- a/common/bm_os.h
+++ b/common/bm_os.h
@@ -37,7 +37,7 @@ BmQueue bm_queue_create(uint32_t queue_length, uint32_t item_size);
 void bm_queue_delete(BmQueue queue);
 BmErr bm_queue_receive(BmQueue queue, void *item, uint32_t timeout_ms);
 BmErr bm_queue_send(BmQueue queue, const void *item, uint32_t timeout_ms);
-BmErr bm_queue_send_to_front_from_isr(BmQueue queue, const void *item, uint32_t *higher_priority_task_woken);
+BmErr bm_queue_send_to_front_from_isr(BmQueue queue, const void *item);
 
 // Semaphore functions
 BmSemaphore bm_semaphore_create(void);

--- a/network/l2.c
+++ b/network/l2.c
@@ -210,14 +210,11 @@ static BmErr bm_l2_handle_device_interrupt(void) {
 
   L2QueueElement int_evt = {0, NULL, L2Irq, 0};
 
-  uint32_t xHigherPriorityTaskWoken = 0;
-
   if (CTX.evt_queue) {
-    bm_queue_send_to_front_from_isr(CTX.evt_queue, &int_evt,
-                                    &xHigherPriorityTaskWoken);
+    return bm_queue_send_to_front_from_isr(CTX.evt_queue, &int_evt);
   }
 
-  return xHigherPriorityTaskWoken ? BmOK : BmENOMEM;
+  return BmENOMEM;
 }
 
 /*!

--- a/network/l2.c
+++ b/network/l2.c
@@ -5,11 +5,6 @@
 #include "bm_os.h"
 #include "util.h"
 
-//TODO tie this into CTX variable and make callback associated with network device
-// this would be bm_l2_register_interrupt_callback as a trait in the network device
-#include "FreeRTOS.h"
-#include "queue.h"
-
 #define ethernet_packet_size_byte 14
 #define ipv6_version_traffic_class_flow_label_size_bytes 4
 #define ipv6_payload_length_size_bytes 2
@@ -215,14 +210,14 @@ static BmErr bm_l2_handle_device_interrupt(void) {
 
   L2QueueElement int_evt = {0, NULL, L2Irq, 0};
 
-  BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+  uint32_t xHigherPriorityTaskWoken = 0;
 
   if (CTX.evt_queue) {
-    xQueueSendToFrontFromISR(CTX.evt_queue, &int_evt,
-                             &xHigherPriorityTaskWoken);
+    bm_queue_send_to_front_from_isr(CTX.evt_queue, &int_evt,
+                                    &xHigherPriorityTaskWoken);
   }
 
-  return xHigherPriorityTaskWoken == pdTRUE ? BmOK : BmEPERM;
+  return xHigherPriorityTaskWoken ? BmOK : BmENOMEM;
 }
 
 /*!

--- a/test/mocks/mock_bm_os.h
+++ b/test/mocks/mock_bm_os.h
@@ -32,7 +32,7 @@ DECLARE_FAKE_VOID_FUNC(bm_queue_delete, BmQueue);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_queue_receive, BmQueue, void *, uint32_t);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_queue_send, BmQueue, const void *, uint32_t);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_queue_send_to_front_from_isr, BmQueue,
-                        const void *, uint32_t *);
+                        const void *);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_task_create, BmTaskCb, const char *, uint32_t,
                         void *, uint32_t, BmTaskHandle);
 DECLARE_FAKE_VOID_FUNC(bm_task_delete, BmTaskHandle);

--- a/test/mocks/mock_bm_os.h
+++ b/test/mocks/mock_bm_os.h
@@ -31,6 +31,8 @@ DECLARE_FAKE_VALUE_FUNC(BmQueue, bm_queue_create, uint32_t, uint32_t);
 DECLARE_FAKE_VOID_FUNC(bm_queue_delete, BmQueue);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_queue_receive, BmQueue, void *, uint32_t);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_queue_send, BmQueue, const void *, uint32_t);
+DECLARE_FAKE_VALUE_FUNC(BmErr, bm_queue_send_to_front_from_isr, BmQueue,
+                        const void *, uint32_t *);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_task_create, BmTaskCb, const char *, uint32_t,
                         void *, uint32_t, BmTaskHandle);
 DECLARE_FAKE_VOID_FUNC(bm_task_delete, BmTaskHandle);

--- a/test/stubs/bm_os_stub.c
+++ b/test/stubs/bm_os_stub.c
@@ -43,7 +43,7 @@ DEFINE_FAKE_VOID_FUNC(bm_queue_delete, BmQueue);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_queue_receive, BmQueue, void *, uint32_t);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_queue_send, BmQueue, const void *, uint32_t);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_queue_send_to_front_from_isr, BmQueue,
-                       const void *, uint32_t *);
+                       const void *);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_task_create, BmTaskCb, const char *, uint32_t,
                        void *, uint32_t, BmTaskHandle);
 DEFINE_FAKE_VOID_FUNC(bm_task_delete, BmTaskHandle);

--- a/test/stubs/bm_os_stub.c
+++ b/test/stubs/bm_os_stub.c
@@ -42,6 +42,8 @@ DEFINE_FAKE_VALUE_FUNC(BmQueue, bm_queue_create, uint32_t, uint32_t);
 DEFINE_FAKE_VOID_FUNC(bm_queue_delete, BmQueue);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_queue_receive, BmQueue, void *, uint32_t);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_queue_send, BmQueue, const void *, uint32_t);
+DEFINE_FAKE_VALUE_FUNC(BmErr, bm_queue_send_to_front_from_isr, BmQueue,
+                       const void *, uint32_t *);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_task_create, BmTaskCb, const char *, uint32_t,
                        void *, uint32_t, BmTaskHandle);
 DEFINE_FAKE_VOID_FUNC(bm_task_delete, BmTaskHandle);


### PR DESCRIPTION
Adding a `bm_queue_send_to_front_from_isr` function for the IO interrupt to be able to use an L2 provided function for queueing up an event. This is a merge into the `feat/l2-uses-new-adin-driver` branch. There are still some tests that need to be updated w.r.g. to the link change/egress port work that is being done still.

I have tested the bm_protocol - `feat/new-adin-driver` branch with these changes BM comms are working between a bridge and a hello-world app!

Note: 
The `portYIELD_FROM_ISR()` is safe to do on ARM Cortex-M architectures because it sets a pending switch bit in the NVIC such that once all interrupts are complete it knows to tell the scheduler to do a context switch. On some other architectures, the yield may immediately call the scheduler to perform the context switch so this function should be the last thing called from the ISR if possible.