### PR TITLE
Fix/adjust packet failure prints

### DIFF
--- a/bcmp/neighbors.c
+++ b/bcmp/neighbors.c
@@ -84,12 +84,13 @@ static BmErr bcmp_send_neighbor_table(void *addr) {
   @return BmErr if failed
 */
 static BmErr bcmp_process_neighbor_table_request(BcmpProcessData data) {
-  BmErr err = BmEINVAL;
+  BmErr err = BmENOTINTREC;
   BcmpNeighborTableRequest *request = (BcmpNeighborTableRequest *)data.payload;
-  if (request && ((request->target_node_id == 0) ||
-                  node_id() == request->target_node_id)) {
+
+  if (request->target_node_id == 0 || node_id() == request->target_node_id) {
     err = bcmp_send_neighbor_table(data.dst);
   }
+
   return err;
 }
 
@@ -99,7 +100,7 @@ static BmErr bcmp_process_neighbor_table_request(BcmpProcessData data) {
   @param *neighbor_table_reply - reply message to process
 */
 static BmErr bcmp_process_neighbor_table_reply(BcmpProcessData data) {
-  BmErr err = BmEINVAL;
+  BmErr err = BmENOTINTREC;
   BcmpNeighborTableReply *reply = (BcmpNeighborTableReply *)data.payload;
 
   if (TARGET_NODE_ID == reply->node_id) {

--- a/bcmp/packet.c
+++ b/bcmp/packet.c
@@ -425,7 +425,7 @@ BmErr process_received_message(void *payload, uint32_t size) {
   if (payload && PACKET.initialized) {
     buf = PACKET.cb.data(payload);
     if (buf == NULL) {
-      bm_debug("Recieved BCMP message with NULL header!\n");
+      bm_debug("Recieved BCMP message with no contents!\n");
       return err;
     }
     data.header = (BcmpHeader *)buf;

--- a/bcmp/packet.c
+++ b/bcmp/packet.c
@@ -462,7 +462,7 @@ BmErr process_received_message(void *payload, uint32_t size) {
         // Utilize parsing callback
         if (cfg->process && (err = cfg->process(data)) != BmOK) {
           if (err == BmENOTINTREC) {
-            bm_debug("Received a %d message that is not intended for us\n", data.header->type);
+            bm_debug("Received a message of type: %d that is not intended for us\n", data.header->type);
           } else {
             bm_debug("Error processing parsed cb: %d of message %d\n", err,
                    data.header->type);

--- a/bcmp/packet.c
+++ b/bcmp/packet.c
@@ -426,6 +426,9 @@ BmErr process_received_message(void *payload, uint32_t size) {
     buf = PACKET.cb.data(payload);
     data.header = (BcmpHeader *)buf;
     data.payload = (uint8_t *)(buf + sizeof(BcmpHeader));
+    if (data.payload == NULL) {
+      return err;
+    }
     data.src = PACKET.cb.src_ip(payload);
     data.dst = PACKET.cb.dst_ip(payload);
     data.size = size;

--- a/bcmp/packet.c
+++ b/bcmp/packet.c
@@ -416,7 +416,7 @@ BmErr packet_remove(BcmpMessageType type) {
  */
 BmErr process_received_message(void *payload, uint32_t size) {
   BmErr err = BmEINVAL;
-  BcmpProcessData data;
+  BcmpProcessData data = {0};
   BcmpSequencedRequestCb cb = NULL;
   BcmpRequestElement *request_message = NULL;
   BcmpPacketCfg *cfg = NULL;
@@ -424,11 +424,12 @@ BmErr process_received_message(void *payload, uint32_t size) {
 
   if (payload && PACKET.initialized) {
     buf = PACKET.cb.data(payload);
-    data.header = (BcmpHeader *)buf;
-    data.payload = (uint8_t *)(buf + sizeof(BcmpHeader));
-    if (data.payload == NULL) {
+    if (buf == NULL) {
+      bm_debug("Recieved BCMP message with NULL header!\n");
       return err;
     }
+    data.header = (BcmpHeader *)buf;
+    data.payload = (uint8_t *)(buf + sizeof(BcmpHeader));
     data.src = PACKET.cb.src_ip(payload);
     data.dst = PACKET.cb.dst_ip(payload);
     data.size = size;
@@ -476,7 +477,6 @@ BmErr process_received_message(void *payload, uint32_t size) {
       }
     }
   }
-
   return err;
 }
 

--- a/bcmp/packet.c
+++ b/bcmp/packet.c
@@ -462,10 +462,12 @@ BmErr process_received_message(void *payload, uint32_t size) {
         // Utilize parsing callback
         if (cfg->process && (err = cfg->process(data)) != BmOK) {
           if (err == BmENOTINTREC) {
-            bm_debug("Received a message of type: %d that is not intended for us\n", data.header->type);
+            bm_debug("Ignored a message of type: %d since it was not intended "
+                     "for us!\n",
+                     data.header->type);
           } else {
             bm_debug("Error processing parsed cb: %d of message %d\n", err,
-                   data.header->type);
+                     data.header->type);
           }
         }
       }

--- a/bcmp/packet.c
+++ b/bcmp/packet.c
@@ -461,8 +461,12 @@ BmErr process_received_message(void *payload, uint32_t size) {
       } else {
         // Utilize parsing callback
         if (cfg->process && (err = cfg->process(data)) != BmOK) {
-          bm_debug("Error processing parsed cb: %d of message %d\n", err,
+          if (err == BmENOTINTREC) {
+            bm_debug("Received a %d message that is not intended for us\n", data.header->type);
+          } else {
+            bm_debug("Error processing parsed cb: %d of message %d\n", err,
                    data.header->type);
+          }
         }
       }
     }

--- a/bcmp/ping.c
+++ b/bcmp/ping.c
@@ -100,7 +100,7 @@ static BmErr bcmp_send_ping_reply(BcmpEchoReply *echo_reply, void *addr,
 */
 static BmErr bcmp_process_ping_request(BcmpProcessData data) {
   BcmpEchoRequest *echo_req = (BcmpEchoRequest *)data.payload;
-  BmErr err = BmOK;
+  BmErr err = BmENOTINTREC;
   if ((echo_req->target_node_id == 0) ||
       (node_id() == echo_req->target_node_id)) {
     echo_req->target_node_id = node_id();
@@ -123,7 +123,7 @@ static BmErr bcmp_process_ping_request(BcmpProcessData data) {
   @return BmErr if failed
 */
 static BmErr bcmp_process_ping_reply(BcmpProcessData data) {
-  BmErr err = BmEINVAL;
+  BmErr err = BmENOTINTREC;
   BcmpEchoReply *echo_reply = (BcmpEchoReply *)data.payload;
 
   // TODO - once we have random numbers working we can then use a static number to check

--- a/common/util.h
+++ b/common/util.h
@@ -30,6 +30,7 @@ typedef enum {
   BmEALREADY = 114,
   BmEINPROGRESS = 115,
   BmECANCELED = 125,
+  BmENOTINTREC = 140,
 } BmErr;
 
 // Task Priorities

--- a/test/src/packet_test.cpp
+++ b/test/src/packet_test.cpp
@@ -319,3 +319,11 @@ TEST_F(Packet, sequence_reply) {
             0);
   ASSERT_EQ(((BcmpHeader *)data.payload)->seq_num, 0);
 }
+
+TEST_F(Packet, null_payload) {
+  PacketTestData data = {};
+  RND.rnd_array((uint8_t *)data.src_addr, sizeof(data.src_addr));
+  RND.rnd_array((uint8_t *)data.dst_addr, sizeof(data.dst_addr));
+  // Test a completely null payload
+  ASSERT_EQ(process_received_message((void *)&data, sizeof(BcmpHeartbeat)), BmEINVAL);
+  }

--- a/test/src/ping_test.cpp
+++ b/test/src/ping_test.cpp
@@ -53,7 +53,7 @@ TEST_F(Ping, request_ping) {
 
   // Test request process with wrong node id
   node_id_fake.return_val = 0;
-  ASSERT_EQ(packet_process_invoke(BcmpEchoRequestMessage, data), BmOK);
+  ASSERT_EQ(packet_process_invoke(BcmpEchoRequestMessage, data), BmENOTINTREC);
   ASSERT_EQ(bcmp_tx_fake.call_count, 0);
   RESET_FAKE(node_id);
 


### PR DESCRIPTION
Adds a new error: `BmENOTINTREC` - "Bm Error Not Intended Recipient"

This error is then used by the packet processor so that we can more clearly print when we actually failed to process a message, or if it was just not intended for us.

Ex:
<img width="980" alt="Screenshot 2024-11-22 at 4 00 38 PM" src="https://github.com/user-attachments/assets/80d657be-a880-4170-8e4d-74c06617ea50">
