### PR TITLE
fix: callers of bcmp_tx bool inversion

### DIFF
--- a/bcmp/config.c
+++ b/bcmp/config.c
@@ -198,10 +198,9 @@ bool bcmp_config_del_key(uint64_t target_node_id, BmConfigPartition partition,
       del_msg->partition = partition;
       del_msg->key_length = key_len;
       memcpy(del_msg->key, key, key_len);
-      if (bcmp_tx(&multicast_ll_addr, BcmpConfigDeleteRequestMessage,
-                  (uint8_t *)(del_msg), msg_size, 0, reply_cb) == BmOK) {
-        rval = true;
-      }
+      BmErr err = bcmp_tx(&multicast_ll_addr, BcmpConfigDeleteRequestMessage,
+                          (uint8_t *)(del_msg), msg_size, 0, reply_cb);
+      rval = (err == BmOK);
       bm_free(del_msg);
     }
   }

--- a/bcmp/dfu_client.c
+++ b/bcmp/dfu_client.c
@@ -53,21 +53,23 @@ static void bm_dfu_client_fail_update_and_reboot(void);
  *
  * @return none
  */
-static void bm_dfu_client_abort(BmDfuErr err) {
+static void bm_dfu_client_abort(BmDfuErr err_code) {
   BcmpDfuAbort abort_msg;
 
   /* Populate the appropriate event */
   abort_msg.err.addresses.dst_node_id = CLIENT_CTX.host_node_id;
   abort_msg.err.addresses.src_node_id = CLIENT_CTX.self_node_id;
-  abort_msg.err.err_code = err;
+  abort_msg.err.err_code = err_code;
   abort_msg.err.success = 0;
   abort_msg.header.frame_type = BcmpDFUAbortMessage;
-  if (bcmp_tx(&multicast_ll_addr,
-              (BcmpMessageType)(abort_msg.header.frame_type),
-              (uint8_t *)(&abort_msg), sizeof(abort_msg), 0, NULL)) {
+  BmErr err = bcmp_tx(&multicast_ll_addr,
+                      (BcmpMessageType)(abort_msg.header.frame_type),
+                      (uint8_t *)(&abort_msg), sizeof(abort_msg), 0, NULL);
+  if (err == BmOK) {
     bm_debug("Message %d sent \n", abort_msg.header.frame_type);
   } else {
-    bm_debug("Failed to send message %d\n", abort_msg.header.frame_type);
+    bm_debug("Failed to send message %d, error %d\n",
+             abort_msg.header.frame_type, err);
   }
 }
 
@@ -76,12 +78,14 @@ static void bm_dfu_client_send_reboot_request() {
   reboot_req.addr.src_node_id = CLIENT_CTX.self_node_id;
   reboot_req.addr.dst_node_id = CLIENT_CTX.host_node_id;
   reboot_req.header.frame_type = BcmpDFURebootReqMessage;
-  if (bcmp_tx(&multicast_ll_addr,
-              (BcmpMessageType)(reboot_req.header.frame_type),
-              (uint8_t *)(&reboot_req), sizeof(BcmpDfuRebootReq), 0, NULL)) {
+  BmErr err = bcmp_tx(
+      &multicast_ll_addr, (BcmpMessageType)(reboot_req.header.frame_type),
+      (uint8_t *)(&reboot_req), sizeof(BcmpDfuRebootReq), 0, NULL);
+  if (err == BmOK) {
     bm_debug("Message %d sent \n", reboot_req.header.frame_type);
   } else {
-    bm_debug("Failed to send message %d\n", reboot_req.header.frame_type);
+    bm_debug("Failed to send message %d, error %d\n",
+             reboot_req.header.frame_type, err);
   }
 }
 
@@ -90,12 +94,14 @@ static void bm_dfu_client_send_boot_complete(uint64_t host_node_id) {
   boot_compl.addr.src_node_id = CLIENT_CTX.self_node_id;
   boot_compl.addr.dst_node_id = host_node_id;
   boot_compl.header.frame_type = BcmpDFUBootCompleteMessage;
-  if (bcmp_tx(&multicast_ll_addr,
-              (BcmpMessageType)(boot_compl.header.frame_type),
-              (uint8_t *)(&boot_compl), sizeof(BcmpDfuBootComplete), 0, NULL)) {
+  BmErr err = bcmp_tx(
+      &multicast_ll_addr, (BcmpMessageType)(boot_compl.header.frame_type),
+      (uint8_t *)(&boot_compl), sizeof(BcmpDfuBootComplete), 0, NULL);
+  if (err == BmOK) {
     bm_debug("Message %d sent \n", boot_compl.header.frame_type);
   } else {
-    bm_debug("Failed to send message %d\n", boot_compl.header.frame_type);
+    bm_debug("Failed to send message %d, error %d\n",
+             boot_compl.header.frame_type, err);
   }
 }
 

--- a/bcmp/dfu_core.c
+++ b/bcmp/dfu_core.c
@@ -420,8 +420,10 @@ void bm_dfu_send_ack(uint64_t dst_node_id, uint8_t success, BmDfuErr err_code) {
   ack_msg.ack.addresses.src_node_id = dfu_ctx.self_node_id;
   ack_msg.header.frame_type = BcmpDFUAckMessage;
 
-  if (bcmp_tx(&multicast_ll_addr, (BcmpMessageType)(ack_msg.header.frame_type),
-              (uint8_t *)(&ack_msg), sizeof(ack_msg), 0, NULL)) {
+  BmErr err =
+      bcmp_tx(&multicast_ll_addr, (BcmpMessageType)(ack_msg.header.frame_type),
+              (uint8_t *)(&ack_msg), sizeof(ack_msg), 0, NULL);
+  if (err == BmOK) {
     bm_debug("Message %d sent \n", ack_msg.header.frame_type);
   } else {
     bm_debug("Failed to send message %d\n", ack_msg.header.frame_type);
@@ -445,9 +447,10 @@ void bm_dfu_req_next_chunk(uint64_t dst_node_id, uint16_t chunk_num) {
   chunk_req_msg.chunk_req.addresses.dst_node_id = dst_node_id;
   chunk_req_msg.header.frame_type = BcmpDFUPayloadReqMessage;
 
-  if (bcmp_tx(&multicast_ll_addr,
-              (BcmpMessageType)(chunk_req_msg.header.frame_type),
-              (uint8_t *)(&chunk_req_msg), sizeof(chunk_req_msg), 0, NULL)) {
+  BmErr err = bcmp_tx(
+      &multicast_ll_addr, (BcmpMessageType)(chunk_req_msg.header.frame_type),
+      (uint8_t *)(&chunk_req_msg), sizeof(chunk_req_msg), 0, NULL);
+  if (err == BmOK) {
     bm_debug("Message %d sent \n", chunk_req_msg.header.frame_type);
   } else {
     bm_debug("Failed to send message %d\n", chunk_req_msg.header.frame_type);
@@ -474,9 +477,10 @@ void bm_dfu_update_end(uint64_t dst_node_id, uint8_t success,
   update_end_msg.result.addresses.src_node_id = dfu_ctx.self_node_id;
   update_end_msg.header.frame_type = BcmpDFUEndMessage;
 
-  if (bcmp_tx(&multicast_ll_addr,
-              (BcmpMessageType)(update_end_msg.header.frame_type),
-              (uint8_t *)(&update_end_msg), sizeof(update_end_msg), 0, NULL)) {
+  BmErr err = bcmp_tx(
+      &multicast_ll_addr, (BcmpMessageType)(update_end_msg.header.frame_type),
+      (uint8_t *)(&update_end_msg), sizeof(update_end_msg), 0, NULL);
+  if (err == BmOK) {
     bm_debug("Message %d sent \n", update_end_msg.header.frame_type);
   } else {
     bm_debug("Failed to send message %d\n", update_end_msg.header.frame_type);
@@ -496,9 +500,10 @@ void bm_dfu_send_heartbeat(uint64_t dst_node_id) {
   heartbeat_msg.addr.src_node_id = dfu_ctx.self_node_id;
   heartbeat_msg.header.frame_type = BcmpDFUHeartbeatMessage;
 
-  if (bcmp_tx(&multicast_ll_addr,
-              (BcmpMessageType)(heartbeat_msg.header.frame_type),
-              (uint8_t *)(&heartbeat_msg), sizeof(heartbeat_msg), 0, NULL)) {
+  BmErr err = bcmp_tx(
+      &multicast_ll_addr, (BcmpMessageType)(heartbeat_msg.header.frame_type),
+      (uint8_t *)(&heartbeat_msg), sizeof(heartbeat_msg), 0, NULL);
+  if (err == BmOK) {
     bm_debug("Message %d sent \n", heartbeat_msg.header.frame_type);
   } else {
     bm_debug("Failed to send message %d\n", heartbeat_msg.header.frame_type);

--- a/bcmp/dfu_host.c
+++ b/bcmp/dfu_host.c
@@ -114,10 +114,11 @@ static void bm_dfu_host_req_update() {
   update_start_req_evt.info.addresses.src_node_id = host_ctx.self_node_id;
   update_start_req_evt.info.addresses.dst_node_id = host_ctx.client_node_id;
   update_start_req_evt.header.frame_type = BcmpDFUStartMessage;
-  if (bcmp_tx(&multicast_ll_addr,
-              (BcmpMessageType)(update_start_req_evt.header.frame_type),
-              (uint8_t *)(&update_start_req_evt), sizeof(update_start_req_evt),
-              0, NULL)) {
+  BmErr err = bcmp_tx(&multicast_ll_addr,
+                      (BcmpMessageType)(update_start_req_evt.header.frame_type),
+                      (uint8_t *)(&update_start_req_evt),
+                      sizeof(update_start_req_evt), 0, NULL);
+  if (err == BmOK) {
     bm_debug("Message %d sent \n", update_start_req_evt.header.frame_type);
   } else {
     bm_debug("Failed to send message %d\n",
@@ -151,15 +152,19 @@ static void bm_dfu_host_send_chunk(BmDfuEventChunkRequest *req) {
                           host_ctx.img_info.image_size -
                           host_ctx.bytes_remaining;
   do {
-    if (bm_dfu_host_get_chunk(flash_offset, payload_header->chunk.payload_buf,
-                              payload_len, flash_read_timeout_ms) != BmOK) {
+    BmErr err =
+        bm_dfu_host_get_chunk(flash_offset, payload_header->chunk.payload_buf,
+                              payload_len, flash_read_timeout_ms);
+    if (err != BmOK) {
       bm_debug("Failed to read chunk from flash.\n");
       bm_dfu_host_transition_to_error(BmDfuErrFlashAccess);
       break;
     }
-    if (bcmp_tx(&multicast_ll_addr,
-                (BcmpMessageType)(payload_header->header.frame_type), buf,
-                payload_len_plus_header, 0, NULL) == BmOK) {
+
+    err = bcmp_tx(&multicast_ll_addr,
+                  (BcmpMessageType)(payload_header->header.frame_type), buf,
+                  payload_len_plus_header, 0, NULL);
+    if (err == BmOK) {
       host_ctx.bytes_remaining -= payload_len;
       bm_debug("Message %d sent, payload size: %" PRIX32 ", remaining: %" PRIX32
                "\n",
@@ -185,9 +190,10 @@ static void bm_dfu_host_send_reboot() {
   reboot_msg.addr.src_node_id = host_ctx.self_node_id;
   reboot_msg.addr.dst_node_id = host_ctx.client_node_id;
   reboot_msg.header.frame_type = BcmpDFURebootMessage;
-  if (bcmp_tx(&multicast_ll_addr,
-              (BcmpMessageType)(reboot_msg.header.frame_type),
-              (uint8_t *)(&reboot_msg), sizeof(BcmpDfuReboot), 0, NULL)) {
+  BmErr err = bcmp_tx(&multicast_ll_addr,
+                      (BcmpMessageType)(reboot_msg.header.frame_type),
+                      (uint8_t *)(&reboot_msg), sizeof(BcmpDfuReboot), 0, NULL);
+  if (err == BmOK) {
     bm_debug("Message %d sent \n", reboot_msg.header.frame_type);
   } else {
     bm_debug("Failed to send message %d\n", reboot_msg.header.frame_type);


### PR DESCRIPTION
Return values from bcmp_tx used to have zero meaning failure whereas now as BmErr, zero means success.