### PR TITLE
fix: ensure dfu messages for other nodes are forwarded

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,6 +9,7 @@
         {
             "name": "unit-tests",
             "generator": "Unix Makefiles",
+            "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {
                 "ENABLE_TESTING": "1"
             }

--- a/bcmp/dfu_client.c
+++ b/bcmp/dfu_client.c
@@ -62,7 +62,7 @@ static void bm_dfu_client_abort(BmDfuErr err_code) {
   abort_msg.err.err_code = err_code;
   abort_msg.err.success = 0;
   abort_msg.header.frame_type = BcmpDFUAbortMessage;
-  BmErr err = bcmp_tx(&multicast_ll_addr,
+  BmErr err = bcmp_tx(&multicast_global_addr,
                       (BcmpMessageType)(abort_msg.header.frame_type),
                       (uint8_t *)(&abort_msg), sizeof(abort_msg), 0, NULL);
   if (err == BmOK) {
@@ -79,7 +79,7 @@ static void bm_dfu_client_send_reboot_request() {
   reboot_req.addr.dst_node_id = CLIENT_CTX.host_node_id;
   reboot_req.header.frame_type = BcmpDFURebootReqMessage;
   BmErr err = bcmp_tx(
-      &multicast_ll_addr, (BcmpMessageType)(reboot_req.header.frame_type),
+      &multicast_global_addr, (BcmpMessageType)(reboot_req.header.frame_type),
       (uint8_t *)(&reboot_req), sizeof(BcmpDfuRebootReq), 0, NULL);
   if (err == BmOK) {
     bm_debug("Message %d sent \n", reboot_req.header.frame_type);
@@ -95,7 +95,7 @@ static void bm_dfu_client_send_boot_complete(uint64_t host_node_id) {
   boot_compl.addr.dst_node_id = host_node_id;
   boot_compl.header.frame_type = BcmpDFUBootCompleteMessage;
   BmErr err = bcmp_tx(
-      &multicast_ll_addr, (BcmpMessageType)(boot_compl.header.frame_type),
+      &multicast_global_addr, (BcmpMessageType)(boot_compl.header.frame_type),
       (uint8_t *)(&boot_compl), sizeof(BcmpDfuBootComplete), 0, NULL);
   if (err == BmOK) {
     bm_debug("Message %d sent \n", boot_compl.header.frame_type);

--- a/bcmp/dfu_core.c
+++ b/bcmp/dfu_core.c
@@ -530,11 +530,14 @@ static void bm_dfu_event_thread(void *parameters) {
   }
 }
 
-static bool is_link_local_multicast(void *dst_ip) {
+static bool is_link_local_multicast(uint8_t *dst_ip) {
   bool is_ll_multi = false;
   if (dst_ip != NULL) {
-    uint8_t *bytes = (uint8_t *)dst_ip;
-    is_ll_multi = bytes[0] == 0xFF && bytes[1] == 0x02 && bytes[15] == 0x01;
+    // Link-local multicast address is FF02::1
+    uint8_t *ll_multi_bytes = (uint8_t *)&multicast_ll_addr;
+    is_ll_multi = dst_ip[0] == ll_multi_bytes[0] && // FF
+                  dst_ip[1] == ll_multi_bytes[1] && // 02
+                  dst_ip[15] == ll_multi_bytes[15]; // 01
   }
   return is_ll_multi;
 }

--- a/bcmp/dfu_core.c
+++ b/bcmp/dfu_core.c
@@ -530,18 +530,6 @@ static void bm_dfu_event_thread(void *parameters) {
   }
 }
 
-static bool is_link_local_multicast(uint8_t *dst_ip) {
-  bool is_ll_multi = false;
-  if (dst_ip != NULL) {
-    // Link-local multicast address is FF02::1
-    uint8_t *ll_multi_bytes = (uint8_t *)&multicast_ll_addr;
-    is_ll_multi = dst_ip[0] == ll_multi_bytes[0] && // FF
-                  dst_ip[1] == ll_multi_bytes[1] && // 02
-                  dst_ip[15] == ll_multi_bytes[15]; // 01
-  }
-  return is_ll_multi;
-}
-
 ///*!
 //  Process a DFU message. Allocates memory that the consumer is in charge of freeing.
 //  \param pbuf[in] pbuf buffer

--- a/bcmp/dfu_host.c
+++ b/bcmp/dfu_host.c
@@ -114,7 +114,7 @@ static void bm_dfu_host_req_update() {
   update_start_req_evt.info.addresses.src_node_id = host_ctx.self_node_id;
   update_start_req_evt.info.addresses.dst_node_id = host_ctx.client_node_id;
   update_start_req_evt.header.frame_type = BcmpDFUStartMessage;
-  BmErr err = bcmp_tx(&multicast_ll_addr,
+  BmErr err = bcmp_tx(&multicast_global_addr,
                       (BcmpMessageType)(update_start_req_evt.header.frame_type),
                       (uint8_t *)(&update_start_req_evt),
                       sizeof(update_start_req_evt), 0, NULL);
@@ -161,7 +161,7 @@ static void bm_dfu_host_send_chunk(BmDfuEventChunkRequest *req) {
       break;
     }
 
-    err = bcmp_tx(&multicast_ll_addr,
+    err = bcmp_tx(&multicast_global_addr,
                   (BcmpMessageType)(payload_header->header.frame_type), buf,
                   payload_len_plus_header, 0, NULL);
     if (err == BmOK) {
@@ -190,7 +190,7 @@ static void bm_dfu_host_send_reboot() {
   reboot_msg.addr.src_node_id = host_ctx.self_node_id;
   reboot_msg.addr.dst_node_id = host_ctx.client_node_id;
   reboot_msg.header.frame_type = BcmpDFURebootMessage;
-  BmErr err = bcmp_tx(&multicast_ll_addr,
+  BmErr err = bcmp_tx(&multicast_global_addr,
                       (BcmpMessageType)(reboot_msg.header.frame_type),
                       (uint8_t *)(&reboot_msg), sizeof(BcmpDfuReboot), 0, NULL);
   if (err == BmOK) {

--- a/common/util.c
+++ b/common/util.c
@@ -14,6 +14,32 @@ uint32_t time_remaining(uint32_t start, uint32_t current, uint32_t timeout) {
   return remaining;
 }
 
+bool is_global_multicast(void *dst_ip) {
+  bool is_global_multi = false;
+  if (dst_ip != NULL) {
+    // Global multicast address is FF03::1
+    uint8_t *dst_bytes = (uint8_t *)dst_ip;
+    uint8_t *global_multi_bytes = (uint8_t *)&multicast_global_addr;
+    is_global_multi = dst_bytes[0] == global_multi_bytes[0] && // FF
+                      dst_bytes[1] == global_multi_bytes[1] && // 03
+                      dst_bytes[15] == global_multi_bytes[15]; // 01
+  }
+  return is_global_multi;
+}
+
+bool is_link_local_multicast(void *dst_ip) {
+  bool is_ll_multi = false;
+  if (dst_ip != NULL) {
+    // Link-local multicast address is FF02::1
+    uint8_t *dst_bytes = (uint8_t *)dst_ip;
+    uint8_t *ll_multi_bytes = (uint8_t *)&multicast_ll_addr;
+    is_ll_multi = dst_bytes[0] == ll_multi_bytes[0] && // FF
+                  dst_bytes[1] == ll_multi_bytes[1] && // 02
+                  dst_bytes[15] == ll_multi_bytes[15]; // 01
+  }
+  return is_ll_multi;
+}
+
 bool is_little_endian(void) {
   static const uint32_t endianness = 1;
   return (*(uint8_t *)&endianness);

--- a/common/util.h
+++ b/common/util.h
@@ -89,6 +89,8 @@ typedef struct {
 extern const bm_ip_addr multicast_global_addr;
 extern const bm_ip_addr multicast_ll_addr;
 
+bool is_global_multicast(void *dst_ip);
+bool is_link_local_multicast(void *dst_ip);
 bool is_little_endian(void);
 void swap_16bit(void *x);
 void swap_32bit(void *x);

--- a/network/l2.c
+++ b/network/l2.c
@@ -72,9 +72,6 @@
   (addr[ipv6_source_address_offset + egress_port_idx] = port)
 #define add_ingress_port(addr, port)                                           \
   (addr[ipv6_source_address_offset + ingress_port_idx] = port)
-#define is_global_multicast(addr)                                              \
-  (((uint8_t *)(addr))[ipv6_destination_address_offset] == 0xFFU &&            \
-   ((uint8_t *)(addr))[ipv6_destination_address_offset + 1] == 0x03U)
 
 #define evt_queue_len (32)
 
@@ -233,7 +230,7 @@ static void bm_l2_process_rx_evt(L2QueueElement *rx_evt) {
     // We need to code the RX Port into the IPV6 address passed up the stack
     add_ingress_port(payload, rx_evt->port_mask);
 
-    if (is_global_multicast(payload)) {
+    if (is_global_multicast(&payload[ipv6_destination_address_offset])) {
       uint8_t new_port_mask = CTX.all_ports_mask & ~(rx_evt->port_mask);
       bm_l2_tx(rx_evt->buf, rx_evt->length, new_port_mask);
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -267,6 +267,9 @@ set (L2_SRCS
     # File we're testing
     ${NETWORK_DIR}/l2.c
 
+    # Support files
+    ${COMMON_DIR}/util.c
+
     # Stubs
     ${STUB_DIR}/bm_os_stub.c
     ${STUB_DIR}/bm_ip_stub.c

--- a/test/src/dfu_test.cpp
+++ b/test/src/dfu_test.cpp
@@ -1156,24 +1156,36 @@ TEST_F(BcmpDfu, client_confirm_skip)
 // Testing private function, not in header but not marked static
 extern "C" BmErr dfu_copy_and_process_message(BcmpProcessData data);
 
-TEST_F(BcmpDfu, forward_msg_for_other) {
-  // Forward message not intended for this node
+TEST_F(BcmpDfu, forward_ll_msg_for_other) {
+  const uint64_t me = 0xdeadbeefbeeffeed;
+  const uint64_t other = 0x7777beeffeed2222;
+
+  // Forward link-local message not intended for this node
   BcmpDfuStart *fwd_start_msg = (BcmpDfuStart *)malloc(sizeof(BcmpDfuStart));
   fwd_start_msg->header.frame_type = BcmpDFUStartMessage;
-  fwd_start_msg->info.addresses.dst_node_id = 0x7777beeffeed2222;
+  fwd_start_msg->info.addresses.dst_node_id = other;
   fwd_start_msg->info.addresses.src_node_id = 0xdeaddeaddeaddead;
   BcmpProcessData data = {
       .header = (BcmpHeader *)fwd_start_msg,
       .payload = (uint8_t *)fwd_start_msg,
       .size = sizeof(BcmpDfuStart),
+      .dst = (void *)&multicast_ll_addr,
   };
   dfu_copy_and_process_message(data);
   EXPECT_EQ(bcmp_ll_forward_fake.call_count, 1);
   RESET_FAKE(bcmp_ll_forward);
 
-  // Do not forward message intended for this node
-  fwd_start_msg->info.addresses.dst_node_id = 0xdeadbeefbeeffeed;
+  // Do not forward link-local message intended for this node
+  fwd_start_msg->info.addresses.dst_node_id = me;
   dfu_copy_and_process_message(data);
   EXPECT_EQ(bcmp_ll_forward_fake.call_count, 0);
+
+  // Do not forward global multicast message not intended for this node
+  // Already forwarded in L2 before being passed to BCMP
+  data.dst = (void *)&multicast_global_addr;
+  fwd_start_msg->info.addresses.dst_node_id = other;
+  dfu_copy_and_process_message(data);
+  EXPECT_EQ(bcmp_ll_forward_fake.call_count, 0);
+
   free(fwd_start_msg);
 }


### PR DESCRIPTION
In testing today I discovered that dfu worked to a neighbor but not farther away in the network. This was because messages like dfu start were not being forwarded by the first neighbor. They were simply being dropped.

On the bm_protocol develop branch, dfu works targeting a client node farther down the chain.

I confirmed that this fixes the issue with bm_core, though I did not find how/why it works on the develop branch, since there is no call to `bcmp_ll_forward` in the dfu code there.