### PR TITLE
Removes Asserts Left Over From FreeRTOS Port

### DIFF
--- a/bcmp/configuration.c
+++ b/bcmp/configuration.c
@@ -1,4 +1,5 @@
 #include "configuration.h"
+#include "bm_config.h"
 #include "bm_configs_generic.h"
 #include "crc.h"
 #include <stdio.h>
@@ -123,12 +124,12 @@ void config_init(void) {
     ConfigPartition *config_partition =
         (ConfigPartition *)CONFIGS[i].ram_buffer;
     if (!load_and_verify_nvm_config(config_partition, (BmConfigPartition)i)) {
-      printf("Unable to load configs from flash.");
+      bm_debug("Unable to load configs from flash.");
       config_partition->header.numKeys = 0;
       config_partition->header.version = CONFIG_VERSION;
       // TODO: Once we have default configs, load these into flash.
     } else {
-      printf("Succesfully loaded configs from flash.");
+      bm_debug("Succesfully loaded configs from flash.");
     }
   }
 }

--- a/bcmp/dfu_client.h
+++ b/bcmp/dfu_client.h
@@ -1,20 +1,20 @@
 #include "dfu.h"
 
-#define bm_dfu_client_chunk_timeout_ms  2000UL
+#define bm_dfu_client_chunk_timeout_ms 2000UL
 
 void bm_dfu_client_process_update_request(void);
 
 /* HFSM functions */
-void s_client_receiving_entry(void);
-void s_client_receiving_run(void);
-void s_client_validating_entry(void);
-void s_client_validating_run(void);
-void s_client_activating_entry(void);
-void s_client_activating_run(void);
-void s_client_reboot_req_entry(void);
-void s_client_reboot_req_run(void);
-void s_client_update_done_entry(void);
-void s_client_update_done_run(void);
+BmErr s_client_receiving_entry(void);
+BmErr s_client_receiving_run(void);
+BmErr s_client_validating_entry(void);
+BmErr s_client_validating_run(void);
+BmErr s_client_activating_entry(void);
+BmErr s_client_activating_run(void);
+BmErr s_client_reboot_req_entry(void);
+BmErr s_client_reboot_req_run(void);
+BmErr s_client_update_done_entry(void);
+BmErr s_client_update_done_run(void);
 
 void bm_dfu_client_init(void);
 bool bm_dfu_client_host_node_valid(uint64_t host_node_id);

--- a/bcmp/dfu_host.c
+++ b/bcmp/dfu_host.c
@@ -31,10 +31,10 @@ static void ack_timer_handler(BmTimer tmr);
 static void heartbeat_timer_handler(BmTimer tmr);
 static void update_timer_handler(BmTimer tmr);
 
-static void bm_dfu_host_req_update();
-static void bm_dfu_host_send_reboot();
-static void bm_dfu_host_transition_to_error(BmDfuErr err);
-static void bm_dfu_host_start_update_timer(uint32_t timeoutMs);
+static void bm_dfu_host_req_update(void);
+static void bm_dfu_host_send_reboot(void);
+static void bm_dfu_host_transition_to_error(BmDfuErr dfu_err);
+static BmErr bm_dfu_host_start_update_timer(uint32_t timeoutMs);
 
 /**
  * @brief ACK Timer Handler function
@@ -49,9 +49,7 @@ static void ack_timer_handler(BmTimer tmr) {
   BmDfuEvent evt = {DfuEventAckTimeout, NULL, 0};
 
   if (bm_queue_send(host_ctx.dfu_event_queue, &evt, 0) != BmOK) {
-    // configASSERT(false);
-    // TODO - handle this better?
-    bm_debug("Failed to send ACK timeout event\n");
+    bm_debug("Failed to queue ACK timeout event...\n");
   }
 }
 
@@ -93,7 +91,7 @@ static void update_timer_handler(BmTimer tmr) {
   BmDfuEvent evt = {DfuEventAbort, NULL, 0};
 
   if (bm_queue_send(host_ctx.dfu_event_queue, &evt, 0) != BmOK) {
-    // configASSERT(false);
+    bm_debug("Failed to queue DFU abort event...\n");
   }
 }
 
@@ -104,7 +102,7 @@ static void update_timer_handler(BmTimer tmr) {
  *
  * @return none
  */
-static void bm_dfu_host_req_update() {
+static void bm_dfu_host_req_update(void) {
   BcmpDfuStart update_start_req_evt;
 
   bm_debug("Sending Update to Client\n");
@@ -133,7 +131,8 @@ static void bm_dfu_host_req_update() {
  *
  * @return none
  */
-static void bm_dfu_host_send_chunk(BmDfuEventChunkRequest *req) {
+static BmErr bm_dfu_host_send_chunk(BmDfuEventChunkRequest *req) {
+  BmErr err = BmENOMEM;
   bm_debug("Processing chunk id %" PRIX32 "\n", req->seq_num);
   uint32_t payload_len =
       (host_ctx.bytes_remaining >= host_ctx.img_info.chunk_size)
@@ -141,43 +140,47 @@ static void bm_dfu_host_send_chunk(BmDfuEventChunkRequest *req) {
           : host_ctx.bytes_remaining;
   uint32_t payload_len_plus_header = sizeof(BcmpDfuPayload) + payload_len;
   uint8_t *buf = (uint8_t *)bm_malloc(payload_len_plus_header);
-  // configASSERT(buf);
-  BcmpDfuPayload *payload_header = (BcmpDfuPayload *)buf;
-  payload_header->header.frame_type = BcmpDFUPayloadMessage;
-  payload_header->chunk.addresses.src_node_id = host_ctx.self_node_id;
-  payload_header->chunk.addresses.dst_node_id = host_ctx.client_node_id;
-  payload_header->chunk.payload_length = payload_len;
 
-  uint32_t flash_offset = DFU_IMG_START_OFFSET_BYTES +
-                          host_ctx.img_info.image_size -
-                          host_ctx.bytes_remaining;
-  do {
-    BmErr err =
-        bm_dfu_host_get_chunk(flash_offset, payload_header->chunk.payload_buf,
-                              payload_len, flash_read_timeout_ms);
-    if (err != BmOK) {
-      bm_debug("Failed to read chunk from flash.\n");
-      bm_dfu_host_transition_to_error(BmDfuErrFlashAccess);
-      break;
-    }
+  if (buf) {
+    BcmpDfuPayload *payload_header = (BcmpDfuPayload *)buf;
+    payload_header->header.frame_type = BcmpDFUPayloadMessage;
+    payload_header->chunk.addresses.src_node_id = host_ctx.self_node_id;
+    payload_header->chunk.addresses.dst_node_id = host_ctx.client_node_id;
+    payload_header->chunk.payload_length = payload_len;
 
-    err = bcmp_tx(&multicast_global_addr,
-                  (BcmpMessageType)(payload_header->header.frame_type), buf,
-                  payload_len_plus_header, 0, NULL);
-    if (err == BmOK) {
-      host_ctx.bytes_remaining -= payload_len;
-      bm_debug("Message %d sent, payload size: %" PRIX32 ", remaining: %" PRIX32
-               "\n",
-               payload_header->header.frame_type, payload_len,
-               host_ctx.bytes_remaining);
-    } else {
-      bm_debug("Failed to send message %d\n",
-               payload_header->header.frame_type);
-      bm_dfu_host_transition_to_error(BmDfuErrImgChunkAccess);
-    }
-  } while (0);
+    uint32_t flash_offset = DFU_IMG_START_OFFSET_BYTES +
+                            host_ctx.img_info.image_size -
+                            host_ctx.bytes_remaining;
+    do {
+      err =
+          bm_dfu_host_get_chunk(flash_offset, payload_header->chunk.payload_buf,
+                                payload_len, flash_read_timeout_ms);
+      if (err != BmOK) {
+        bm_debug("Failed to read chunk from flash.\n");
+        bm_dfu_host_transition_to_error(BmDfuErrFlashAccess);
+        break;
+      }
 
-  bm_free(buf);
+      err = bcmp_tx(&multicast_global_addr,
+                    (BcmpMessageType)(payload_header->header.frame_type), buf,
+                    payload_len_plus_header, 0, NULL);
+      if (err == BmOK) {
+        host_ctx.bytes_remaining -= payload_len;
+        bm_debug("Message %d sent, payload size: %" PRIX32
+                 ", remaining: %" PRIX32 "\n",
+                 payload_header->header.frame_type, payload_len,
+                 host_ctx.bytes_remaining);
+      } else {
+        bm_debug("Failed to send message %d\n",
+                 payload_header->header.frame_type);
+        bm_dfu_host_transition_to_error(BmDfuErrImgChunkAccess);
+      }
+    } while (0);
+
+    bm_free(buf);
+  }
+
+  return err;
 }
 
 /**
@@ -185,7 +188,7 @@ static void bm_dfu_host_send_chunk(BmDfuEventChunkRequest *req) {
  *
  * @return none
  */
-static void bm_dfu_host_send_reboot() {
+static void bm_dfu_host_send_reboot(void) {
   BcmpDfuReboot reboot_msg;
   reboot_msg.addr.src_node_id = host_ctx.self_node_id;
   reboot_msg.addr.dst_node_id = host_ctx.client_node_id;
@@ -207,12 +210,12 @@ static void bm_dfu_host_send_reboot() {
  *
  * @return none
  */
-void s_host_req_update_entry(void) {
+BmErr s_host_req_update_entry(void) {
   BmDfuEvent curr_evt = bm_dfu_get_current_event();
 
   /* Check if we even have a buf to inspect */
   if (!curr_evt.buf) {
-    return;
+    return BmENODATA;
   }
 
   BmDfuFrame *frame = (BmDfuFrame *)(curr_evt.buf);
@@ -229,8 +232,7 @@ void s_host_req_update_entry(void) {
   bm_dfu_host_req_update();
 
   /* Kickoff ACK timeout */
-  // configASSERT(xTimerStart(host_ctx.ack_timer, 10));
-  bm_timer_start(host_ctx.ack_timer, 10);
+  return bm_timer_start(host_ctx.ack_timer, 10);
 }
 
 /**
@@ -240,22 +242,25 @@ void s_host_req_update_entry(void) {
  *
  * @return none
  */
-void s_host_req_update_run(void) {
+BmErr s_host_req_update_run(void) {
+  BmErr err = BmOK;
   BmDfuEvent curr_evt = bm_dfu_get_current_event();
 
   if (curr_evt.type == DfuEventAckReceived) {
     /* Stop ACK Timer */
-    // configASSERT(xTimerStop(host_ctx.ack_timer, 10));
-    bm_timer_stop(host_ctx.ack_timer, 10);
-    // configASSERT(curr_evt.buf);
+    bm_err_check(err, bm_timer_stop(host_ctx.ack_timer, 10));
     BmDfuFrame *frame = (BmDfuFrame *)(curr_evt.buf);
-    BmDfuEventResult *result_evt =
-        (BmDfuEventResult *)(&((uint8_t *)(frame))[1]);
+    if (frame) {
+      BmDfuEventResult *result_evt =
+          (BmDfuEventResult *)(&((uint8_t *)(frame))[1]);
 
-    if (result_evt->success) {
-      bm_dfu_set_pending_state_change(BmDfuStateHostUpdate);
+      if (result_evt->success) {
+        bm_dfu_set_pending_state_change(BmDfuStateHostUpdate);
+      } else {
+        bm_dfu_host_transition_to_error((BmDfuErr)(result_evt->err_code));
+      }
     } else {
-      bm_dfu_host_transition_to_error((BmDfuErr)(result_evt->err_code));
+      err = BmEINVAL;
     }
   } else if (curr_evt.type == DfuEventAckTimeout) {
     host_ctx.ack_retry_num++;
@@ -265,18 +270,19 @@ void s_host_req_update_run(void) {
       bm_dfu_host_transition_to_error(BmDfuErrTimeout);
     } else {
       bm_dfu_host_req_update();
-      // configASSERT(xTimerStart(host_ctx.ack_timer, 10));
-      bm_timer_start(host_ctx.ack_timer, 10);
+      bm_err_check(err, bm_timer_start(host_ctx.ack_timer, 10));
     }
   } else if (curr_evt.type == DfuEventAbort) {
-    BmDfuErr err = BmDfuErrAborted;
+    BmDfuErr dfu_err = BmDfuErrAborted;
     if (curr_evt.buf) {
       BcmpDfuAbort *abort_evt = (BcmpDfuAbort *)(curr_evt.buf);
-      err = (BmDfuErr)(abort_evt->err.err_code);
+      dfu_err = (BmDfuErr)(abort_evt->err.err_code);
     }
     bm_debug("Recieved abort in request.\n");
-    bm_dfu_host_transition_to_error(err);
+    bm_dfu_host_transition_to_error(dfu_err);
   }
+
+  return err;
 }
 
 /**
@@ -286,8 +292,8 @@ void s_host_req_update_run(void) {
  *
  * @return none
  */
-void s_host_update_entry(void) {
-  bm_dfu_host_start_update_timer(host_ctx.host_timeout_ms);
+BmErr s_host_update_entry(void) {
+  return bm_dfu_host_start_update_timer(host_ctx.host_timeout_ms);
 }
 
 /**
@@ -297,7 +303,8 @@ void s_host_update_entry(void) {
  *
  * @return none
  */
-void s_host_update_run(void) {
+BmErr s_host_update_run(void) {
+  BmErr err = BmOK;
   BmDfuFrame *frame = NULL;
   BmDfuEvent curr_evt = bm_dfu_get_current_event();
 
@@ -307,53 +314,60 @@ void s_host_update_run(void) {
   }
 
   if (curr_evt.type == DfuEventChunkRequest) {
-    // configASSERT(frame);
-    BmDfuEventChunkRequest *chunk_req_evt =
-        (BmDfuEventChunkRequest *)(&((uint8_t *)(frame))[1]);
+    if (frame) {
+      BmDfuEventChunkRequest *chunk_req_evt =
+          (BmDfuEventChunkRequest *)(&((uint8_t *)(frame))[1]);
 
-    /* Request Next Chunk */
-    /* Send Heartbeat to Client */
-    // configASSERT(xTimerStart(host_ctx.heartbeat_timer, 10));
-    bm_timer_start(host_ctx.heartbeat_timer, 10);
+      /* Request Next Chunk */
+      /* Send Heartbeat to Client */
+      bm_err_check(err, bm_timer_start(host_ctx.heartbeat_timer, 10));
 
-    /* resend the frame to the client as is */
-    bm_dfu_host_send_chunk(chunk_req_evt);
+      /* resend the frame to the client as is */
+      bm_err_check(err, bm_dfu_host_send_chunk(chunk_req_evt));
 
-    // configASSERT(xTimerStop(host_ctx.heartbeat_timer, 10));
-    bm_timer_stop(host_ctx.heartbeat_timer, 10);
+      bm_err_check(err, bm_timer_stop(host_ctx.heartbeat_timer, 10));
+    } else {
+      err = BmENODATA;
+    }
   } else if (curr_evt.type == DfuEventRebootRequest) {
-    // configASSERT(frame);
     bm_dfu_host_send_reboot();
   } else if (curr_evt.type == DfuEventBootComplete) {
-    // configASSERT(frame);
-    bm_dfu_update_end(host_ctx.client_node_id, true, BmDfuErrNone);
-  } else if (curr_evt.type == DfuEventUpdateEnd) {
-    // configASSERT(xTimerStop(host_ctx.update_timer, 100));
-    bm_timer_stop(host_ctx.update_timer, 100);
-    // configASSERT(frame);
-    BmDfuEventResult *update_end_evt =
-        (BmDfuEventResult *)(&((uint8_t *)(frame))[1]);
-
-    if (update_end_evt->success) {
-      bm_debug("Successfully updated Client\n");
+    if (frame) {
+      bm_dfu_update_end(host_ctx.client_node_id, true, BmDfuErrNone);
     } else {
-      bm_debug("Client Update Failed\n");
+      err = BmENODATA;
     }
-    if (host_ctx.update_complete_callback) {
-      host_ctx.update_complete_callback(update_end_evt->success,
-                                        (BmDfuErr)(update_end_evt->err_code),
-                                        host_ctx.client_node_id);
+  } else if (curr_evt.type == DfuEventUpdateEnd) {
+    bm_err_check(err, bm_timer_stop(host_ctx.update_timer, 100));
+    if (frame) {
+      BmDfuEventResult *update_end_evt =
+          (BmDfuEventResult *)(&((uint8_t *)(frame))[1]);
+
+      if (update_end_evt->success) {
+        bm_debug("Successfully updated Client\n");
+      } else {
+        bm_debug("Client Update Failed\n");
+      }
+      if (host_ctx.update_complete_callback) {
+        host_ctx.update_complete_callback(update_end_evt->success,
+                                          (BmDfuErr)(update_end_evt->err_code),
+                                          host_ctx.client_node_id);
+      }
+      bm_dfu_set_pending_state_change(BmDfuStateIdle);
+    } else {
+      err = BmENODATA;
     }
-    bm_dfu_set_pending_state_change(BmDfuStateIdle);
   } else if (curr_evt.type == DfuEventAbort) {
-    BmDfuErr err = BmDfuErrAborted;
+    BmDfuErr dfu_err = BmDfuErrAborted;
     if (curr_evt.buf) {
       BcmpDfuAbort *abort_evt = (BcmpDfuAbort *)(curr_evt.buf);
-      err = (BmDfuErr)(abort_evt->err.err_code);
+      dfu_err = (BmDfuErr)(abort_evt->err.err_code);
     }
     bm_debug("Recieved abort in run.\n");
-    bm_dfu_host_transition_to_error(err);
+    bm_dfu_host_transition_to_error(dfu_err);
   }
+
+  return err;
 }
 
 void bm_dfu_host_init(void) {
@@ -369,16 +383,22 @@ void bm_dfu_host_init(void) {
   host_ctx.ack_timer = bm_timer_create(
       "DFU Host Ack", bm_ms_to_ticks(bm_dfu_host_ack_timeout_ms), false,
       (void *)&tmr_id, ack_timer_handler);
-  // configASSERT(host_ctx.ack_timer);
+  if (!host_ctx.ack_timer) {
+    bm_debug("Could not create DFU host ACK timer...\n");
+  }
 
   host_ctx.heartbeat_timer = bm_timer_create(
       "DFU Host Heartbeat", bm_ms_to_ticks(bm_dfu_host_heartbeat_timeout_ms),
       true, (void *)&tmr_id, heartbeat_timer_handler);
-  // configASSERT(host_ctx.heartbeat_timer);
+  if (!host_ctx.heartbeat_timer) {
+    bm_debug("Could not create DFU host heartbeat timer...\n");
+  }
   host_ctx.update_timer = bm_timer_create(
       "update timer", bm_ms_to_ticks(bm_dfu_update_default_timeout_ms), false,
       (void *)&tmr_id, update_timer_handler);
-  // configASSERT(host_ctx.update_timer);
+  if (host_ctx.update_timer) {
+    bm_debug("Could not create DFU host update timer...\n");
+  }
 }
 
 void bm_dfu_host_set_params(UpdateFinishCb update_complete_callback,
@@ -387,23 +407,30 @@ void bm_dfu_host_set_params(UpdateFinishCb update_complete_callback,
   host_ctx.host_timeout_ms = host_timeout_ms;
 }
 
-static void bm_dfu_host_start_update_timer(uint32_t timeoutMs) {
-  // configASSERT(xTimerStop(host_ctx.update_timer, 100));
-  // configASSERT(xTimerChangePeriod(host_ctx.update_timer, bm_ms_to_ticks(timeoutMs), 100));
-  // configASSERT(xTimerStart(host_ctx.update_timer, 100));
-  bm_timer_stop(host_ctx.update_timer, 100);
-  bm_timer_change_period(host_ctx.update_timer, bm_ms_to_ticks(timeoutMs), 100);
-  bm_timer_start(host_ctx.update_timer, 100);
+static BmErr bm_dfu_host_start_update_timer(uint32_t timeoutMs) {
+  BmErr err = BmOK;
+
+  bm_err_check(err, bm_timer_stop(host_ctx.update_timer, 100) == BmOK &&
+                            bm_timer_change_period(host_ctx.update_timer,
+                                                   bm_ms_to_ticks(timeoutMs),
+                                                   100) == BmOK &&
+                            bm_timer_start(host_ctx.update_timer, 100) == BmOK
+                        ? BmOK
+                        : BmETIMEDOUT);
+
+  return err;
 }
 
-static void bm_dfu_host_transition_to_error(BmDfuErr err) {
-  // configASSERT(xTimerStop(host_ctx.update_timer, 100));
-  // configASSERT(xTimerStop(host_ctx.heartbeat_timer, 10));
-  // configASSERT(xTimerStop(host_ctx.ack_timer, 10));
-  bm_timer_stop(host_ctx.update_timer, 100);
-  bm_timer_stop(host_ctx.heartbeat_timer, 10);
-  bm_timer_stop(host_ctx.ack_timer, 10);
-  bm_dfu_set_error(err);
+static void bm_dfu_host_transition_to_error(BmDfuErr dfu_err) {
+  BmErr err = BmOK;
+
+  bm_err_check(err,
+               bm_timer_stop(host_ctx.update_timer, 100) &&
+                       bm_timer_stop(host_ctx.heartbeat_timer, 10) == BmOK &&
+                       bm_timer_stop(host_ctx.ack_timer, 10) == BmOK
+                   ? BmOK
+                   : BmETIMEDOUT);
+  bm_dfu_set_error(dfu_err);
   bm_dfu_set_pending_state_change(BmDfuStateError);
 }
 

--- a/bcmp/dfu_host.h
+++ b/bcmp/dfu_host.h
@@ -6,13 +6,13 @@
 #define bm_dfu_host_heartbeat_timeout_ms 1000UL
 #define bm_dfu_update_default_timeout_ms (5 * 60 * 1000)
 
-typedef int (*bm_dfu_chunk_req_cb)(uint16_t chunk_num, uint16_t *chunk_len, uint8_t *buf,
-                                   uint16_t buf_len);
+typedef int (*bm_dfu_chunk_req_cb)(uint16_t chunk_num, uint16_t *chunk_len,
+                                   uint8_t *buf, uint16_t buf_len);
 
-void s_host_req_update_entry(void);
-void s_host_req_update_run(void);
-void s_host_update_entry(void);
-void s_host_update_run(void);
+BmErr s_host_req_update_entry(void);
+BmErr s_host_req_update_run(void);
+BmErr s_host_update_entry(void);
+BmErr s_host_update_run(void);
 
 void bm_dfu_host_init(void);
 void bm_dfu_host_set_params(UpdateFinishCb update_complete_callback,

--- a/bcmp/info.c
+++ b/bcmp/info.c
@@ -1,5 +1,6 @@
 #include "messages/info.h"
 #include "bcmp.h"
+#include "bm_config.h"
 #include "bm_os.h"
 #include "device.h"
 #include "ll.h"

--- a/common/bm_os.h
+++ b/common/bm_os.h
@@ -8,13 +8,6 @@
 extern "C" {
 #endif
 
-// Something like this for the asserts? Although maybe this shouldn't live here
-// #ifdef DEV_MODE
-// #define ASSERT(x) configASSERT(x)
-// #else
-// #define ASSERT(x) ((void)0)
-// #endif
-
 #define BM_MAX_DELAY_UINT64 0xFFFFFFFFFFFFFFFF
 #define BM_MAX_DELAY_UINT32 0xFFFFFFFF
 #define BM_MAX_DELAY_UINT16 0xFFFF

--- a/common/lib_state_machine.c
+++ b/common/lib_state_machine.c
@@ -1,4 +1,5 @@
 #include "lib_state_machine.h"
+#include "bm_config.h"
 
 /*!
   Initialize the state machine
@@ -8,12 +9,17 @@
   \param[in] checkTransitionsForNextState Pointer to the function which will check for state transitions.
   \return N/A
 */
-void lib_sm_init(
-    LibSmContext *ctx, const LibSmState *init_state,
-    CheckTransitionsForNextState check_transitions_for_next_state) {
-  // configASSERT(checkTransitionsForNextState != NULL);
-  ctx->current_state = init_state;
-  ctx->check_transitions_for_next_state = check_transitions_for_next_state;
+BmErr lib_sm_init(LibSmContext *ctx, const LibSmState *init_state,
+                  CheckTransitionsForNextState check_transitions_for_next_state,
+                  const char *name) {
+  BmErr err = BmEINVAL;
+  if (check_transitions_for_next_state && ctx && init_state && name) {
+    ctx->current_state = init_state;
+    ctx->check_transitions_for_next_state = check_transitions_for_next_state;
+    ctx->name = name;
+    err = BmOK;
+  }
+  return err;
 }
 
 /*!
@@ -22,22 +28,35 @@ void lib_sm_init(
   \param[in] ctx Pointer to the state machine context.
   \return N/A
 */
-void lib_sm_run(LibSmContext *ctx) {
-  // configASSERT(ctx.current_state != NULL);
-  // configASSERT(ctx.current_state->run);
-  ctx->current_state->run();
-  const LibSmState *next_state =
-      ctx->check_transitions_for_next_state(ctx->current_state->state_enum);
-  // configASSERT(next_state != NULL);
-  if (ctx->current_state != next_state) {
-    if (ctx->current_state->on_state_exit) {
-      ctx->current_state->on_state_exit();
+BmErr lib_sm_run(LibSmContext *ctx) {
+  BmErr err = BmOK;
+  if (ctx->current_state && ctx->current_state->run) {
+    bm_err_check_print(err, ctx->current_state->run(),
+                       "running current state: %s of %s",
+                       ctx->current_state->state_name, ctx->name);
+    err = BmENODEV;
+    const LibSmState *next_state =
+        ctx->check_transitions_for_next_state(ctx->current_state->state_enum);
+    if (next_state) {
+      err = BmOK;
+      if (ctx->current_state != next_state) {
+        if (ctx->current_state->on_state_exit) {
+          bm_err_check_print(err, ctx->current_state->on_state_exit(),
+                             "exiting current state: %s of %s",
+                             ctx->current_state->state_name, ctx->name);
+        }
+        ctx->current_state = next_state;
+        if (ctx->current_state->on_state_entry) {
+          bm_err_check_print(err, ctx->current_state->on_state_entry(),
+                             "entering current state: %s of %s",
+                             ctx->current_state->state_name, ctx->name);
+        }
+      }
     }
-    ctx->current_state = next_state;
-    if (ctx->current_state->on_state_entry) {
-      ctx->current_state->on_state_entry();
-    }
+  } else {
+    err = BmEINVAL;
   }
+  return err;
 }
 
 /*!
@@ -47,7 +66,6 @@ void lib_sm_run(LibSmContext *ctx) {
   \return The name of the current state.
 */
 const char *lib_sm_get_current_state_name(const LibSmContext *ctx) {
-  // configASSERT(ctx.current_state->stateName != NULL);
   return ctx->current_state->state_name;
 }
 

--- a/common/lib_state_machine.h
+++ b/common/lib_state_machine.h
@@ -1,14 +1,15 @@
 #ifndef __LIB_STATE_MACHINE_H__
 #define __LIB_STATE_MACHINE_H__
 
+#include "util.h"
 #include <stdint.h>
 
 typedef struct {
-  uint8_t state_enum;           // Should match to an ENUM corresponding to state.
-  const char *state_name;       // MUST NOT BE NULL
-  void (*run)(void);            // MUST NOT BE NULL
-  void (*on_state_exit)(void);  // Null or function pointer
-  void (*on_state_entry)(void); // Null or function pointer
+  uint8_t state_enum;     // Should match to an ENUM corresponding to state.
+  const char *state_name; // MUST NOT BE NULL
+  BmErr (*run)(void);     // MUST NOT BE NULL
+  BmErr (*on_state_exit)(void);  // Null or function pointer
+  BmErr (*on_state_entry)(void); // Null or function pointer
 } LibSmState;
 
 typedef const LibSmState *(*CheckTransitionsForNextState)(uint8_t);
@@ -16,11 +17,13 @@ typedef const LibSmState *(*CheckTransitionsForNextState)(uint8_t);
 typedef struct {
   const LibSmState *current_state;
   CheckTransitionsForNextState check_transitions_for_next_state;
+  const char *name;
 } LibSmContext;
 
-void lib_sm_init(LibSmContext *ctx, const LibSmState *init_state,
-               CheckTransitionsForNextState check_transitions_for_next_state);
-void lib_sm_run(LibSmContext *ctx);
+BmErr lib_sm_init(LibSmContext *ctx, const LibSmState *init_state,
+                  CheckTransitionsForNextState check_transitions_for_next_state,
+                  const char *name);
+BmErr lib_sm_run(LibSmContext *ctx);
 const char *lib_sm_get_current_state_name(const LibSmContext *ctx);
 uint8_t get_current_state_enum(const LibSmContext *ctx);
 

--- a/common/util.h
+++ b/common/util.h
@@ -69,14 +69,15 @@ void date_time_from_utc(uint64_t utc_us, UtcDateTime *date_time);
   if (e == BmOK) {                                                             \
     e = f;                                                                     \
     if (e != BmOK) {                                                           \
-      printf("err: %d at %s:%d\n", e, __FILE__, __LINE__);                     \
+      bm_debug("err: %d at %s:%d\n", e, __FILE__, __LINE__);                   \
     }                                                                          \
   }
 #define bm_err_check_print(e, f, format, ...)                                  \
   if (e == BmOK) {                                                             \
     e = f;                                                                     \
     if (e != BmOK) {                                                           \
-      printf("err: %d at %s:%d\n" format, e, __FILE__, __LINE__, __VA_ARGS__); \
+      bm_debug("err: %d at %s:%d " format "\n", e, __FILE__, __LINE__,         \
+               __VA_ARGS__);                                                   \
     }                                                                          \
   }
 

--- a/common/util.h
+++ b/common/util.h
@@ -65,6 +65,17 @@ uint32_t utc_from_date_time(uint16_t year, uint8_t month, uint8_t day,
                             uint8_t hour, uint8_t minute, uint8_t second);
 void date_time_from_utc(uint64_t utc_us, UtcDateTime *date_time);
 
+#define bm_err_report(e, f)                                                    \
+  e = f;                                                                       \
+  if (e != BmOK) {                                                             \
+    bm_debug("err: %d at %s:%d\n", e, __FILE__, __LINE__);                     \
+  }
+#define bm_err_report_print(e, f, format, ...)                                 \
+  e = f;                                                                       \
+  if (e != BmOK) {                                                             \
+    bm_debug("err: %d at %s:%d " format "\n", e, __FILE__, __LINE__,           \
+             __VA_ARGS__);                                                     \
+  }
 #define bm_err_check(e, f)                                                     \
   if (e == BmOK) {                                                             \
     e = f;                                                                     \

--- a/docs/reference/utilities.md
+++ b/docs/reference/utilities.md
@@ -3,6 +3,32 @@
 The following document describes some utility functions/macros that are used throughout Bristlemouth:
 
 ```{eval-rst}
+.. cpp:function:: bm_err_report(err, function)
+
+  Execute a function that returns `BmErr`,
+  if executed function returns an error,
+  then an error message will be printed describing the error found,
+  the line,
+  as well as the file the error occurred in.
+
+  :param err: The error value to be evaluated and assigned in the macro
+  :param function: Function to be ran and assigned to err if err is BmOK
+
+```
+
+```{eval-rst}
+.. cpp:function:: bm_err_check_print(err, function, format, ...)
+
+  This performs the same logic as above
+  but adds the ability to print a formatted string after the original error statement described above
+
+  :param err: The error value to be evaluated and assigned in the macro
+  :param function: Function to be ran and assigned to err if err is BmOK
+  :param format: String with formatting to add to error message
+  :param ...: Arguments for format
+```
+
+```{eval-rst}
 .. cpp:function:: bm_err_check(err, function)
 
   This macro is used to check the error state of a tracked `BmErr` variable

--- a/middleware/bm_service.c
+++ b/middleware/bm_service.c
@@ -94,9 +94,13 @@ bool bm_service_unregister(size_t service_strlen, const char *service) {
  * @brief Initialize the service module.
  * @note Will initialize both the service request and service reply modules.
  */
-void bm_service_init(void) {
-  bm_service_request_init();
+BmErr bm_service_init(void) {
+  BmErr err = BmENOMEM;
   BM_SERVICE_CONTEXT.lock = bm_semaphore_create();
+  if (BM_SERVICE_CONTEXT.lock) {
+    err = bm_service_request_init();
+  }
+  return err;
 }
 
 static void _service_list_add_service(BmServiceListElem *list_elem) {

--- a/middleware/bm_service.h
+++ b/middleware/bm_service.h
@@ -5,6 +5,7 @@ extern "C" {
 #endif
 
 #include "pubsub.h"
+#include "util.h"
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -26,7 +27,7 @@ typedef bool (*BmServiceHandler)(size_t service_strlen, const char *service,
                                  size_t req_data_len, uint8_t *req_data,
                                  size_t *buffer_len, uint8_t *reply_data);
 
-void bm_service_init(void);
+BmErr bm_service_init(void);
 bool bm_service_register(size_t service_strlen, const char *service,
                          BmServiceHandler service_handler);
 bool bm_service_unregister(size_t service_strlen, const char *service);

--- a/middleware/bm_service_request.h
+++ b/middleware/bm_service_request.h
@@ -4,6 +4,7 @@
 extern "C" {
 #endif
 
+#include "util.h"
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -23,7 +24,7 @@ typedef bool (*BmServiceReplyCb)(bool ack, uint32_t msg_id,
                                  size_t service_strlen, const char *service,
                                  size_t reply_len, uint8_t *reply_data);
 
-void bm_service_request_init(void);
+BmErr bm_service_request_init(void);
 bool bm_service_request(size_t service_strlen, const char *service,
                         size_t data_len, const uint8_t *data,
                         BmServiceReplyCb reply_cb, uint32_t timeout_s);

--- a/middleware/bristlemouth.c
+++ b/middleware/bristlemouth.c
@@ -1,6 +1,7 @@
 #include "bristlemouth.h"
 #include "bcmp.h"
 #include "bm_adin2111.h"
+#include "bm_config.h"
 #include "bm_ip.h"
 #include "bm_service.h"
 #include "l2.h"
@@ -19,11 +20,7 @@ BmErr bristlemouth_init(NetworkDevicePowerCallback net_power_cb) {
   bm_err_check(err, bm_ip_init());
   bm_err_check(err, bcmp_init(network_device));
   bm_err_check(err, topology_init(network_device.trait->num_ports()));
-
-  if (err == BmOK) {
-    bm_service_init();
-  }
-
+  bm_err_check(err, bm_service_init());
   bm_err_check(err, bm_middleware_init(BM_MIDDLEWARE_PORT));
   return err;
 }

--- a/test/mocks/mock_bm_service.h
+++ b/test/mocks/mock_bm_service.h
@@ -1,7 +1,7 @@
 #include "bm_service.h"
 #include "fff.h"
 
-DECLARE_FAKE_VOID_FUNC(bm_service_init);
+DECLARE_FAKE_VALUE_FUNC(BmErr, bm_service_init);
 DECLARE_FAKE_VALUE_FUNC(bool, bm_service_register, size_t, const char *,
                         BmServiceHandler);
 DECLARE_FAKE_VALUE_FUNC(bool, bm_service_unregister, size_t, const char *);

--- a/test/mocks/mock_bm_service_request.h
+++ b/test/mocks/mock_bm_service_request.h
@@ -1,6 +1,6 @@
 #include "bm_service_request.h"
 #include "fff.h"
 
-DECLARE_FAKE_VOID_FUNC(bm_service_request_init);
+DECLARE_FAKE_VALUE_FUNC(BmErr, bm_service_request_init);
 DECLARE_FAKE_VALUE_FUNC(bool, bm_service_request, size_t, const char *, size_t,
                         const uint8_t *, BmServiceReplyCb, uint32_t);

--- a/test/src/bm_service_request_test.cpp
+++ b/test/src/bm_service_request_test.cpp
@@ -38,7 +38,20 @@ protected:
   }
 };
 
-TEST_F(BmServiceRequest, init) { bm_service_request_init(); }
+TEST_F(BmServiceRequest, init) {
+  bm_semaphore_create_fake.return_val =
+      (void *)RND.rnd_int(UINT64_MAX, UINT32_MAX);
+  bm_timer_create_fake.return_val = (void *)RND.rnd_int(UINT64_MAX, UINT32_MAX);
+  ASSERT_EQ(bm_service_request_init(), BmOK);
+
+  bm_semaphore_create_fake.return_val = 0;
+  ASSERT_NE(bm_service_request_init(), BmOK);
+  bm_semaphore_create_fake.return_val =
+      (void *)RND.rnd_int(UINT64_MAX, UINT32_MAX);
+
+  bm_timer_create_fake.return_val = 0;
+  ASSERT_NE(bm_service_request_init(), BmOK);
+}
 
 TEST_F(BmServiceRequest, request) {
   size_t size = RND.rnd_int(UINT8_MAX, UINT8_MAX / 2);

--- a/test/src/dfu_test.cpp
+++ b/test/src/dfu_test.cpp
@@ -48,6 +48,7 @@ class BcmpDfu : public ::testing::Test {
         RESET_FAKE(bm_dfu_client_flash_area_erase);
         RESET_FAKE(bm_dfu_client_flash_area_get_size);
         RESET_FAKE(bm_dfu_client_confirm_is_enabled);
+        RESET_FAKE(bm_dfu_client_set_confirmed);
         RESET_FAKE(bm_dfu_client_confirm_enable);
         RESET_FAKE(bm_dfu_host_get_chunk);
         RESET_FAKE(bm_dfu_core_lpm_peripheral_active);

--- a/test/src/lib_state_machine_test.cpp
+++ b/test/src/lib_state_machine_test.cpp
@@ -32,35 +32,35 @@ extern "C" {
 
 // ENUM describing the position of each state in the states array.
 typedef enum {
-STAGE_1,
-STAGE_2,
-STAGE_3,
-STAGE_4,
-NUM_STAGES,
+  STAGE_1,
+  STAGE_2,
+  STAGE_3,
+  STAGE_4,
+  NUM_STAGES,
 } stageEnum_t;
 
 // State machine state functions forward declarations.
-static void stage1Run();
-static void stage2Run();
-static void stage2Exit();
-static void stage3Run();
-static void stage3Entry();
-static void stage4Run();
+static BmErr stage1Run();
+static BmErr stage2Run();
+static BmErr stage2Exit();
+static BmErr stage3Run();
+static BmErr stage3Entry();
+static BmErr stage4Run();
 
 // Global context structure for the file.
 // It's generally useful to encapsulate the state machine context so you can pair
 // it with other variables, but not strictly necessary.
 typedef struct {
- // State machine context
- LibSmContext sm_ctx;
- // Stage 1 vars
+  // State machine context
+  LibSmContext sm_ctx;
+  // Stage 1 vars
   uint8_t count_s1;
- // Stage 2 vars
+  // Stage 2 vars
   bool flag_s2;
- // Stage 3 vars
+  // Stage 3 vars
   bool flag_s3;
- // Stage N vars
- // ...
+  // Stage N vars
+  // ...
 } GlobalContext;
 
 static GlobalContext GLOBAL_CTX;
@@ -68,8 +68,8 @@ static const LibSmState states[NUM_STAGES] = {
     {
         .state_enum = STAGE_1,
         .state_name = "Stage1", // The name MUST NOT BE NULL
-        .run = stage1Run, // This function MUST NOT BE NULL
-        .on_state_exit = NULL, // This function can be NULL
+        .run = stage1Run,       // This function MUST NOT BE NULL
+        .on_state_exit = NULL,  // This function can be NULL
         .on_state_entry = NULL, // This function can be NULL
     },
     {
@@ -96,66 +96,75 @@ static const LibSmState states[NUM_STAGES] = {
 };
 
 // Transitions function
-const LibSmState* checkTransitions(uint8_t current_state){
-    switch ((stageEnum_t)current_state){
-        case STAGE_1: {
-            if(GLOBAL_CTX.count_s1 == 2) {
-                return &states[STAGE_2];
-            }
-            return &states[STAGE_1];
-        }
-        case STAGE_2: {
-            return &states[STAGE_3];
-        }
-        case STAGE_3: {
-            return &states[STAGE_4];
-        }
-        case STAGE_4: {
-            return &states[STAGE_1];
-        }
-        default:
-            return NULL; // Bad if we get here - This will generate an ASSERT in lib_sm_run.
+const LibSmState *checkTransitions(uint8_t current_state) {
+  switch ((stageEnum_t)current_state) {
+  case STAGE_1: {
+    if (GLOBAL_CTX.count_s1 == 2) {
+      return &states[STAGE_2];
     }
+    return &states[STAGE_1];
+  }
+  case STAGE_2: {
+    return &states[STAGE_3];
+  }
+  case STAGE_3: {
+    return &states[STAGE_4];
+  }
+  case STAGE_4: {
+    return &states[STAGE_1];
+  }
+  default:
+    return NULL; // Bad if we get here - This will generate an ASSERT in lib_sm_run.
+  }
 }
 
 // State function definitions.
-static void stage1Run() {GLOBAL_CTX.count_s1++;}
-static void stage2Run() {}
-static void stage2Exit() {GLOBAL_CTX.flag_s2 = true;}
+static BmErr stage1Run() {
+  GLOBAL_CTX.count_s1++;
+  return BmOK;
+}
+static BmErr stage2Run() { return BmOK; }
+static BmErr stage2Exit() {
+  GLOBAL_CTX.flag_s2 = true;
+  return BmOK;
+}
 
-static void stage3Run(){}
-static void stage3Entry(){GLOBAL_CTX.flag_s3 = true;}
+static BmErr stage3Run() { return BmOK; }
+static BmErr stage3Entry() {
+  GLOBAL_CTX.flag_s3 = true;
+  return BmOK;
+}
 
-static void stage4Run() {}
+static BmErr stage4Run() { return BmOK; }
 
 // The fixture for testing class Foo.
 class LibStateMachineTest : public ::testing::Test {
- protected:
+protected:
   // You can remove any or all of the following functions if its body
   // is empty.
 
   LibStateMachineTest() {
-     // You can do set-up work for each test here.
+    // You can do set-up work for each test here.
   }
 
   ~LibStateMachineTest() override {
-     // You can do clean-up work that doesn't throw exceptions here.
+    // You can do clean-up work that doesn't throw exceptions here.
   }
 
   // If the constructor and destructor are not enough for setting up
   // and cleaning up each test, you can define the following methods:
 
   void SetUp() override {
-     // Code here will be called immediately after the constructor (right
-     // before each test).
-     GLOBAL_CTX.count_s1 = 0;
-     GLOBAL_CTX.flag_s2 = false;
-     GLOBAL_CTX.flag_s3 = false;
+    // Code here will be called immediately after the constructor (right
+    // before each test).
+    GLOBAL_CTX.count_s1 = 0;
+    GLOBAL_CTX.flag_s2 = false;
+    GLOBAL_CTX.flag_s3 = false;
   }
 
   void TearDown() override {
-     // Code here will be called immediately after each test (right
-     // before the destructor).
+    // Code here will be called immediately after each test (right
+    // before the destructor).
   }
 
   // Objects declared here can be used by all tests in the test suite for Foo.
@@ -163,77 +172,81 @@ class LibStateMachineTest : public ::testing::Test {
 
 // Although lib_sm_run should be run in a for(;;) loop, while writing unit tests for our state machines
 // We should seperate out each call to run() to more granularly test what's going on.
-TEST_F(LibStateMachineTest, basic_pump)
-{
+TEST_F(LibStateMachineTest, basic_pump) {
   // Check Initialization.
-  lib_sm_init(&GLOBAL_CTX.sm_ctx, &states[STAGE_1], checkTransitions);
+  lib_sm_init(&GLOBAL_CTX.sm_ctx, &states[STAGE_1], checkTransitions, "basic");
   EXPECT_TRUE(GLOBAL_CTX.sm_ctx.current_state == &states[STAGE_1]);
-  EXPECT_TRUE((strcmp(lib_sm_get_current_state_name(&GLOBAL_CTX.sm_ctx), "Stage1") == 0));
+  EXPECT_TRUE((strcmp(lib_sm_get_current_state_name(&GLOBAL_CTX.sm_ctx),
+                      "Stage1") == 0));
 
   // Run 1 count_s1 == 1
   lib_sm_run(&GLOBAL_CTX.sm_ctx);
   EXPECT_TRUE(GLOBAL_CTX.sm_ctx.current_state == &states[STAGE_1]);
-  EXPECT_TRUE((strcmp(lib_sm_get_current_state_name(&GLOBAL_CTX.sm_ctx), "Stage1") == 0));
+  EXPECT_TRUE((strcmp(lib_sm_get_current_state_name(&GLOBAL_CTX.sm_ctx),
+                      "Stage1") == 0));
 
   // Run 2 count_s1 == 2
   lib_sm_run(&GLOBAL_CTX.sm_ctx);
   EXPECT_TRUE(GLOBAL_CTX.sm_ctx.current_state == &states[STAGE_2]);
-  EXPECT_TRUE((strcmp(lib_sm_get_current_state_name(&GLOBAL_CTX.sm_ctx), "Stage2") == 0));
+  EXPECT_TRUE((strcmp(lib_sm_get_current_state_name(&GLOBAL_CTX.sm_ctx),
+                      "Stage2") == 0));
 
   // Run 3
   lib_sm_run(&GLOBAL_CTX.sm_ctx);
   EXPECT_TRUE(GLOBAL_CTX.flag_s2 == true);
   EXPECT_TRUE(GLOBAL_CTX.flag_s3 == true);
   EXPECT_TRUE(GLOBAL_CTX.sm_ctx.current_state == &states[STAGE_3]);
-  EXPECT_TRUE((strcmp(lib_sm_get_current_state_name(&GLOBAL_CTX.sm_ctx), "Stage3") == 0));
+  EXPECT_TRUE((strcmp(lib_sm_get_current_state_name(&GLOBAL_CTX.sm_ctx),
+                      "Stage3") == 0));
 
   // Run 4
   lib_sm_run(&GLOBAL_CTX.sm_ctx);
   EXPECT_TRUE(GLOBAL_CTX.sm_ctx.current_state == &states[STAGE_4]);
-  EXPECT_TRUE((strcmp(lib_sm_get_current_state_name(&GLOBAL_CTX.sm_ctx), "Stage4") == 0));
+  EXPECT_TRUE((strcmp(lib_sm_get_current_state_name(&GLOBAL_CTX.sm_ctx),
+                      "Stage4") == 0));
 
   // Run 5
   lib_sm_run(&GLOBAL_CTX.sm_ctx);
   EXPECT_TRUE(GLOBAL_CTX.sm_ctx.current_state == &states[STAGE_1]);
-  EXPECT_TRUE((strcmp(lib_sm_get_current_state_name(&GLOBAL_CTX.sm_ctx), "Stage1") == 0));
+  EXPECT_TRUE((strcmp(lib_sm_get_current_state_name(&GLOBAL_CTX.sm_ctx),
+                      "Stage1") == 0));
 }
 
-// TODO - re-enable these tests once we have re-enabled ASSERTs. This test expects to crash,
-// but we have the ASSERTs commented out.
-// TEST_F(LibStateMachineTest, BadInit)
-// {
-//   EXPECT_DEATH(lib_sm_init(&GLOBAL_CTX.sm_ctx, &states[STAGE_1], NULL),"");
-// }
+TEST_F(LibStateMachineTest, BadInit) {
+  ASSERT_NE(lib_sm_init(&GLOBAL_CTX.sm_ctx, &states[STAGE_1], NULL, "bad_init"),
+            BmOK);
+}
 
-// TEST_F(LibStateMachineTest, BadContext)
-// {
-//   LibSmContext ctx;
-//   EXPECT_DEATH(lib_sm_run(&ctx), ""); // No init
-// }
+TEST_F(LibStateMachineTest, BadContext) {
+  LibSmContext ctx = {0};
+  ASSERT_NE(lib_sm_run(&ctx), BmOK); // No init
+}
 
-// // An invalid transition (Used for BadContext test)
-// const LibSmState* badTransition(uint8_t current_state) {
-//     (void)(current_state);
-//     return NULL;
-// }
+// An invalid transition (Used for BadContext test)
+const LibSmState *badTransition(uint8_t current_state) {
+  (void)(current_state);
+  return NULL;
+}
 
-// TEST_F(LibStateMachineTest, BadTransition)
-// {
-//   LibSmContext ctx;
-//   lib_sm_init(&ctx, &states[STAGE_1], badTransition);
-//   EXPECT_DEATH(lib_sm_run(&ctx), ""); // badTransition returns NULL
-// }
+TEST_F(LibStateMachineTest, BadTransition) {
+  LibSmContext ctx = {0};
+  ASSERT_EQ(
+      lib_sm_init(&ctx, &states[STAGE_1], badTransition, "bad_transition"),
+      BmOK);
+  ASSERT_NE(lib_sm_run(&ctx), BmOK); // badTransition returns NULL
+}
 
-// TEST_F(LibStateMachineTest, BadStateName)
-// {
-//   LibSmContext ctx;
-//   LibSmState badNameState = {
-//     .state_enum = 0,
-//     .state_name = NULL,
-//     .run = stage1Run,
-//     .on_state_exit = NULL,
-//     .on_state_entry = NULL,
-//   };
-//   lib_sm_init(&ctx, &badNameState, checkTransitions);
-//   EXPECT_DEATH(strcmp(lib_sm_get_current_state_name(&ctx), "I have no name :("), "");
-// }
+TEST_F(LibStateMachineTest, BadStateName) {
+  LibSmContext ctx;
+  LibSmState badNameState = {
+      .state_enum = 0,
+      .state_name = NULL,
+      .run = stage1Run,
+      .on_state_exit = NULL,
+      .on_state_entry = NULL,
+  };
+  ASSERT_EQ(lib_sm_init(&ctx, &badNameState, checkTransitions, "bad_name"),
+            BmOK);
+  EXPECT_DEATH(strcmp(lib_sm_get_current_state_name(&ctx), "I have no name :("),
+               "");
+}

--- a/test/src/lib_state_machine_test.cpp
+++ b/test/src/lib_state_machine_test.cpp
@@ -247,6 +247,5 @@ TEST_F(LibStateMachineTest, BadStateName) {
   };
   ASSERT_EQ(lib_sm_init(&ctx, &badNameState, checkTransitions, "bad_name"),
             BmOK);
-  EXPECT_DEATH(strcmp(lib_sm_get_current_state_name(&ctx), "I have no name :("),
-               "");
+  EXPECT_EQ(lib_sm_get_current_state_name(&ctx), nullptr);
 }

--- a/test/stubs/bm_service_request_stub.c
+++ b/test/stubs/bm_service_request_stub.c
@@ -1,5 +1,5 @@
 #include "mock_bm_service_request.h"
 
-DEFINE_FAKE_VOID_FUNC(bm_service_request_init);
+DEFINE_FAKE_VALUE_FUNC(BmErr, bm_service_request_init);
 DEFINE_FAKE_VALUE_FUNC(bool, bm_service_request, size_t, const char *, size_t,
                        const uint8_t *, BmServiceReplyCb, uint32_t);

--- a/test/stubs/bm_service_stub.c
+++ b/test/stubs/bm_service_stub.c
@@ -1,6 +1,6 @@
 #include "mock_bm_service.h"
 
-DEFINE_FAKE_VOID_FUNC(bm_service_init);
+DEFINE_FAKE_VALUE_FUNC(BmErr, bm_service_init);
 DEFINE_FAKE_VALUE_FUNC(bool, bm_service_register, size_t, const char *,
                        BmServiceHandler);
 DEFINE_FAKE_VALUE_FUNC(bool, bm_service_unregister, size_t, const char *);


### PR DESCRIPTION
Returns BmErr values in API that previously returned nothing
Handles instances where asserts were previously located with bm_err_check API

Most of this code touched DFU.
Tested with the `python tools/scripts/dfu/bm_load_img_to_flash.py` script and the CLI command `dfu start <node_id> <magic_key> <timeout>` and was able to see a proper DFU occur.
