### PR TITLE
Return ENOTINTREC for DFU messages

### DIFF
--- a/bcmp/dfu_core.c
+++ b/bcmp/dfu_core.c
@@ -536,7 +536,7 @@ static void bm_dfu_event_thread(void *parameters) {
 //  \return none
 //*/
 BmErr dfu_copy_and_process_message(BcmpProcessData data) {
-  BmErr err = BmEINVAL;
+  BmErr err = BmENOTINTREC;
   BmDfuFrame *frame = (BmDfuFrame *)data.payload;
   BmDfuEventAddress *evt_addr = (BmDfuEventAddress *)frame->payload;
   if (evt_addr->dst_node_id == node_id()) {


### PR DESCRIPTION
Very minor. Uses the new "not intended recipient" return value for nodes in the middle of a DFU conversation.

In the screenshot the device on the right was updating the one on the left, with the one in the middle passing messages back and forth.
![Screenshot 2024-11-27 at 3 24 39 PM](https://github.com/user-attachments/assets/c5a1417a-3c8d-4f25-a68d-01fa8da02cbc)
