### PR TITLE
Add debug packet dump callback to network device

### DIFF
--- a/drivers/adin2111/bm_adin2111.c
+++ b/drivers/adin2111/bm_adin2111.c
@@ -200,6 +200,11 @@ static BmErr adin2111_netdevice_send(uint8_t *data, size_t length,
   if (adin2111_SubmitTxBuffer(&DEVICE_STRUCT, port, buffer_description) !=
       ADI_ETH_SUCCESS) {
     free_tx_buffer(buffer_description);
+    goto end;
+  }
+
+  if (NETWORK_DEVICE.callbacks->debug_packet_dump) {
+    NETWORK_DEVICE.callbacks->debug_packet_dump(data, length);
   }
 
 end:

--- a/network/network_device.h
+++ b/network/network_device.h
@@ -7,6 +7,7 @@ typedef struct {
   void (*power)(bool on);
   void (*link_change)(uint8_t port_index, bool is_up);
   void (*receive)(uint8_t port_mask, uint8_t *data, size_t length);
+  void (*debug_packet_dump)(const uint8_t *data, size_t length);
 } NetworkDeviceCallbacks;
 
 typedef struct {

--- a/test/src/bm_adin2111_test.cpp
+++ b/test/src/bm_adin2111_test.cpp
@@ -10,6 +10,7 @@ void bm_free(void *p) { free(p); }
 }
 
 FAKE_VOID_FUNC(network_device_power_cb, bool);
+FAKE_VOID_FUNC(debug_packet_dump_cb, const uint8_t *, size_t);
 
 FAKE_VALUE_FUNC(uint32_t, HAL_EnterCriticalSection);
 FAKE_VALUE_FUNC(uint32_t, HAL_ExitCriticalSection);
@@ -69,4 +70,15 @@ TEST(Adin2111, port_stats) {
     // SEGFAULT because PHY is NULL, because no real SPI transactions
     EXPECT_DEATH(device.trait->port_stats(device.self, port, &stats), "");
   }
+}
+
+TEST(Adin2111, debug_packet_dump) {
+  NetworkDevice device = setup();
+  device.callbacks->debug_packet_dump = debug_packet_dump_cb;
+  device.trait->send(device.self, (uint8_t *)"foo", 3, ADIN2111_PORT_MASK);
+  EXPECT_EQ(debug_packet_dump_cb_fake.call_count, 1);
+  device.trait->send(device.self, (uint8_t *)"bar", 3, ADIN2111_PORT_MASK);
+  EXPECT_EQ(debug_packet_dump_cb_fake.call_count, 2);
+  device.trait->send(device.self, (uint8_t *)"baz", 3, ADIN2111_PORT_MASK);
+  EXPECT_EQ(debug_packet_dump_cb_fake.call_count, 3);
 }

--- a/test/src/bm_adin2111_test.cpp
+++ b/test/src/bm_adin2111_test.cpp
@@ -81,4 +81,6 @@ TEST(Adin2111, debug_packet_dump) {
   EXPECT_EQ(debug_packet_dump_cb_fake.call_count, 2);
   device.trait->send(device.self, (uint8_t *)"baz", 3, ADIN2111_PORT_MASK);
   EXPECT_EQ(debug_packet_dump_cb_fake.call_count, 3);
+  // We also expect packet dump on receive.
+  // There's no way to fake that in a test.
 }


### PR DESCRIPTION
Adds a new `debug_packet_dump` callback to the network device that an implementing application can optionally define. All TX and RX packets get sent to that callback if it exists.