### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,10 +10,6 @@
 
 
 
-## Links
-
-
-
 ## Checklist
 
 - [ ] Add or update unit tests for changed code

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## What changed?
+
+
+
+## How does it make Bristlemouth better?
+
+
+
+## Where should reviewers focus?
+
+
+
+## Links
+
+
+
+## Checklist
+
+- [ ] Add or update unit tests for changed code
+- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
+- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.


### PR DESCRIPTION
## What changed?

This PR adds a pull request template. I've used the template here manually. Once the PR is merged to main, it will become the template for new PRs.

## How does it make Bristlemouth better?

It helps ensure that we remember some tricky process details that are easy to skip over.

## Where should reviewers focus?

Do you like the wording of the headings? Should we even keep the headings? In our meeting yesterday we only discussed the checklist.

## Links

None. Normally I would delete the section, but I'm showing it for demo purposes.

## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.