### PR TITLE
DFU HIL Testing

### DIFF
--- a/bcmp/dfu.h
+++ b/bcmp/dfu.h
@@ -116,7 +116,8 @@ BmErr bm_dfu_init(void);
 void bm_dfu_process_message(uint8_t *buf, size_t len);
 bool bm_dfu_initiate_update(BmDfuImgInfo info, uint64_t dest_node_id,
                             UpdateFinishCb update_finish_callback,
-                            uint32_t timeoutMs);
+                            uint32_t timeoutMs, bool internal);
+bool bm_dfu_internal(void);
 
 /*!
  * UNIT TEST FUNCTIONS BELOW HERE

--- a/bcmp/dfu_core.c
+++ b/bcmp/dfu_core.c
@@ -20,6 +20,7 @@ typedef struct dfu_core_ctx_t {
   uint64_t self_node_id;
   uint64_t client_node_id;
   UpdateFinishCb update_finish_callback;
+  bool internal;
 } dfu_core_ctx_t;
 
 #ifndef ENABLE_TESTING
@@ -111,7 +112,7 @@ static const LibSmState dfu_states[BmNumDfuStates] = {
         .state_enum = BmDfuStateHostUpdate,
         .state_name = "Host Update",
         .run = s_host_update_run,
-        .on_state_exit = NULL,
+        .on_state_exit = s_host_update_exit,
         .on_state_entry = s_host_update_entry,
     },
 };
@@ -629,7 +630,7 @@ BmErr bm_dfu_init(void) {
 
 bool bm_dfu_initiate_update(BmDfuImgInfo info, uint64_t dest_node_id,
                             UpdateFinishCb update_finish_callback,
-                            uint32_t timeoutMs) {
+                            uint32_t timeoutMs, bool internal) {
   bool ret = false;
   do {
     if (info.chunk_size > bm_dfu_max_chunk_size) {
@@ -669,10 +670,13 @@ bool bm_dfu_initiate_update(BmDfuImgInfo info, uint64_t dest_node_id,
       bm_debug("Message could not be added to Queue\n");
       break;
     }
+    dfu_ctx.internal = internal;
     ret = true;
   } while (0);
   return ret;
 }
+
+bool bm_dfu_internal(void) { return dfu_ctx.internal; }
 
 BmDfuErr bm_dfu_get_error(void) { return dfu_ctx.error; }
 

--- a/bcmp/dfu_host.c
+++ b/bcmp/dfu_host.c
@@ -252,7 +252,6 @@ BmErr s_host_req_update_entry(void) {
   /* Request Client Firmware Update */
   bm_dfu_host_req_update();
 
-  //TODO: place restrictions on how big the chunksize can be here?
   if (!bm_dfu_internal()) {
     host_ctx.data_queue =
         bm_queue_create(data_queue_size, img_info_evt->img_info.chunk_size);

--- a/bcmp/dfu_host.c
+++ b/bcmp/dfu_host.c
@@ -166,12 +166,15 @@ static BmErr bm_dfu_host_send_chunk(BmDfuEventChunkRequest *req) {
                                     payload_header->chunk.payload_buf,
                                     payload_len, flash_read_timeout_ms);
       } else if (host_ctx.data_queue) {
-        //TODO: handle gracefully if cannot malloc
         uint8_t *data_buf = (uint8_t *)bm_malloc(host_ctx.img_info.chunk_size);
-        err = bm_queue_receive(host_ctx.data_queue, data_buf,
-                               host_ctx.host_timeout_ms);
-        memcpy(payload_header->chunk.payload_buf, data_buf, payload_len);
-        bm_free(data_buf);
+        if (data_buf) {
+          err = bm_queue_receive(host_ctx.data_queue, data_buf,
+                                 host_ctx.host_timeout_ms);
+          memcpy(payload_header->chunk.payload_buf, data_buf, payload_len);
+          bm_free(data_buf);
+        } else {
+          err = BmENOMEM;
+        }
       }
       if (err != BmOK) {
         bm_debug("Failed to read chunk from flash.\n");

--- a/bcmp/dfu_host.h
+++ b/bcmp/dfu_host.h
@@ -13,8 +13,10 @@ BmErr s_host_req_update_entry(void);
 BmErr s_host_req_update_run(void);
 BmErr s_host_update_entry(void);
 BmErr s_host_update_run(void);
+BmErr s_host_update_exit(void);
 
 void bm_dfu_host_init(void);
 void bm_dfu_host_set_params(UpdateFinishCb update_complete_callback,
                             uint32_t host_timeout_ms);
 bool bm_dfu_host_client_node_valid(uint64_t client_node_id);
+BmErr bm_dfu_host_queue_data(uint8_t *data, uint32_t size);

--- a/common/bm_os.h
+++ b/common/bm_os.h
@@ -17,6 +17,7 @@ typedef void *BmQueue;
 typedef void *BmSemaphore;
 typedef void *BmTimer;
 typedef void *BmTaskHandle;
+typedef void *BmBuffer;
 
 typedef void (*BmTimerCallback)(BmTimer timer);
 typedef void (*BmTask)(void *arg);
@@ -31,6 +32,14 @@ void bm_queue_delete(BmQueue queue);
 BmErr bm_queue_receive(BmQueue queue, void *item, uint32_t timeout_ms);
 BmErr bm_queue_send(BmQueue queue, const void *item, uint32_t timeout_ms);
 BmErr bm_queue_send_to_front_from_isr(BmQueue queue, const void *item);
+
+// Stream buffer functions
+BmBuffer bm_stream_buffer_create(uint32_t max_size);
+void bm_stream_buffer_delete(BmBuffer buf);
+BmErr bm_stream_buffer_send(BmBuffer buf, uint8_t *data, uint32_t size,
+                            uint32_t timeout_ms);
+BmErr bm_stream_buffer_receive(BmBuffer buf, uint8_t *data, uint32_t *size,
+                               uint32_t timeout_ms);
 
 // Semaphore functions
 BmSemaphore bm_semaphore_create(void);

--- a/test/mocks/mock_bm_os.h
+++ b/test/mocks/mock_bm_os.h
@@ -7,6 +7,7 @@ typedef void *BmQueue;
 typedef void *BmSemaphore;
 typedef void *BmTimer;
 typedef void *BmTaskHandle;
+typedef void *BmBuffer;
 typedef void (*BmTimerCb)(void *);
 typedef void (*BmTaskCb)(void *);
 
@@ -33,6 +34,12 @@ DECLARE_FAKE_VALUE_FUNC(BmErr, bm_queue_receive, BmQueue, void *, uint32_t);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_queue_send, BmQueue, const void *, uint32_t);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_queue_send_to_front_from_isr, BmQueue,
                         const void *);
+DECLARE_FAKE_VALUE_FUNC(BmBuffer, bm_stream_buffer_create, uint32_t);
+DECLARE_FAKE_VOID_FUNC(bm_stream_buffer_delete, BmBuffer);
+DECLARE_FAKE_VALUE_FUNC(BmErr, bm_stream_buffer_send, BmBuffer, uint8_t *,
+                        uint32_t, uint32_t);
+DECLARE_FAKE_VALUE_FUNC(BmErr, bm_stream_buffer_receive, BmBuffer, uint8_t *,
+                        uint32_t *, uint32_t);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_task_create, BmTaskCb, const char *, uint32_t,
                         void *, uint32_t, BmTaskHandle);
 DECLARE_FAKE_VOID_FUNC(bm_task_delete, BmTaskHandle);

--- a/test/scripts/README.md
+++ b/test/scripts/README.md
@@ -30,6 +30,9 @@ $ conda activate bm_hil
 
 ## Running HIL Tests
 
+It is recommended to run the HIL tests with 3 or more nodes on a network.
+This will ensure proper functionality across multiple nodes.
+
 HIL tests require a serial communication to the device being tested.
 The requirements for this serial interface are as so:
 
@@ -40,12 +43,26 @@ The requirements for this serial interface are as so:
 
 A specified baud rate is not a requirement.
 
-In order to run the tests the following command must be invoked:
+In order to run the base tests the following command must be invoked:
 
 `pytest -s @tests_to_run.txt --port '{port}' --baud {baud}`
 
 Where port is the serial port you are attempting to talk to the Bristlemouth node on,
 and baud is the desired baud rate.
+
+If you want to include testing the DFU functionality (this is skipped by default in the above command),
+the following command can be run:
+
+`pytest -s @tests_to_run.txt --port '{port}' --baud {baud} --file {relative/path/to/file} --node_id {node_id}`
+
+Two additionally added arguments are provided to the previous command:
+
+- file, which is the relative path to the binary file to be loaded
+- node_id, which is the node ID of the node to be updated,
+this cannot be the node ID of the node this is being tested on,
+if the node is to be passed in as a hex value,
+it must be prepended with `0x`,
+as an example - `0xdeadbeef12345678`
 
 ## Contributing
 

--- a/test/scripts/conftest.py
+++ b/test/scripts/conftest.py
@@ -18,6 +18,12 @@ def pytest_addoption(parser):
         default=115200,
         help="Serial port baud rate for HIL test",
     )
+    parser.addoption(
+        "--file",
+        action="store",
+        default=None,
+        help="DFU binary application file for loading over bristlemouth",
+    )
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -44,6 +50,7 @@ def pytest_generate_tests(metafunc):
     global SER
     port = metafunc.config.option.port
     baud = metafunc.config.option.baud
+    file = metafunc.config.option.file
     if "ser" in metafunc.fixturenames and port is not None:
         # This function should always pass only one instance of SER
         # as it runs for every test being ran, we only want to create
@@ -51,6 +58,8 @@ def pytest_generate_tests(metafunc):
         if SER is None:
             SER = SerialHelper(port, baud, 0.5)
         metafunc.parametrize("ser", [SER])
+    if "file" in metafunc.fixturenames:
+        metafunc.parametrize("file", [file])
 
 
 def pytest_sessionfinish(session, exitstatus):
@@ -61,4 +70,5 @@ def pytest_sessionfinish(session, exitstatus):
     serial port opened.
     """
     global SER
-    SER.close()
+    if SER is not None:
+        SER.close()

--- a/test/scripts/conftest.py
+++ b/test/scripts/conftest.py
@@ -24,6 +24,12 @@ def pytest_addoption(parser):
         default=None,
         help="DFU binary application file for loading over bristlemouth",
     )
+    parser.addoption(
+        "--node_id",
+        action="store",
+        default=None,
+        help="Node ID of device to receive DFU, if passed in hex, prefix with 0x",
+    )
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -51,6 +57,7 @@ def pytest_generate_tests(metafunc):
     port = metafunc.config.option.port
     baud = metafunc.config.option.baud
     file = metafunc.config.option.file
+    node_id = metafunc.config.option.node_id
     if "ser" in metafunc.fixturenames and port is not None:
         # This function should always pass only one instance of SER
         # as it runs for every test being ran, we only want to create
@@ -60,6 +67,8 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("ser", [SER])
     if "file" in metafunc.fixturenames:
         metafunc.parametrize("file", [file])
+    if "node_id" in metafunc.fixturenames:
+        metafunc.parametrize("node_id", [node_id])
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/test/scripts/environment.yml
+++ b/test/scripts/environment.yml
@@ -12,3 +12,4 @@ dependencies:
       - regex
       - func_timeout
       - pytest-order
+      - crcmod

--- a/test/scripts/serial_helper.py
+++ b/test/scripts/serial_helper.py
@@ -78,7 +78,6 @@ class SerialHelper:
         """Transmit data
 
         Transmits data to open serial port in bytearray.
-
         Args:
             data (bytearray): data to transmit to opened port.
         """

--- a/test/scripts/test_config.py
+++ b/test/scripts/test_config.py
@@ -195,7 +195,7 @@ class TestConfig:
                                 starting the pytests (see: conftest.py).
         """
         pattern = r"Node Id: [0-9a-fA-F]{16} Value:"
-        wait_msg = "Succesfully sent config set msg\n"
+        wait_msg = "Successfully sent config set msg\n"
 
         def message(x, y, z, a):
             return "bm cfg set " + x + " s " + y + " " + a + " " + str(z) + "\n"
@@ -217,7 +217,7 @@ class TestConfig:
                                 starting the pytests (see: conftest.py).
         """
         pattern = r"Node Id: [0-9a-fA-F]{16} Value:"
-        wait_msg = "Succesfully sent config get msg\n"
+        wait_msg = "Successfully sent config get msg\n"
 
         def message(x, y, z, a):
             return "bm cfg get " + x + " s " + a + "\n"
@@ -245,7 +245,7 @@ class TestConfig:
                                 starting the pytests (see: conftest.py).
         """
         pattern = None
-        wait_msg = "Succesfully config commit send\n"
+        wait_msg = "Successfully sent config commit msg\n"
 
         def message(x, y, z, a):
             return "bm cfg commit " + x + " s\n"
@@ -280,7 +280,7 @@ class TestConfig:
                                 starting the pytests (see: conftest.py).
         """
         pattern = r"Response msg -- Node Id: [0-9a-fA-F]{16}, Partition: \d+, Commit Status: \d+\nNum Keys: (\d+)\n"
-        wait_msg = "Successful status request send\n"
+        wait_msg = "Successfully sent status request msg\n"
 
         def message(x, y, z, a):
             return "bm cfg status " + x + " s\n"
@@ -319,7 +319,7 @@ class TestConfig:
                                 starting the pytests (see: conftest.py).
         """
         pattern = None
-        wait_msg = "Successfully sent del key request\n"
+        wait_msg = "Successfully sent del key request msg\n"
 
         def message(x, y, z, a):
             return "bm cfg del " + x + " s " + a + "\n"

--- a/test/scripts/test_dfu.py
+++ b/test/scripts/test_dfu.py
@@ -6,14 +6,29 @@ from typing import Dict, Any
 import crcmod
 from pathlib import Path
 from func_timeout import func_timeout, FunctionTimedOut
-import sys
+from util import print_progress_bar
 
 
 class TestDFU:
 
     SUCCESSFUL_TIMEOUT_S = 60
+    BYTES_TO_SEND = 16
 
     def __get_version_from_bin(self, file: str, offset: int = 0) -> Dict[str, Any]:
+        """Get versioning information from file
+
+        Obtains the versioning information from the binary application,
+        this includes the sha and version. This reads in file byte by
+        byte attempts to find the header from when the binary was
+        generated.
+
+        Args:
+            file (str): Binary application file to search in.
+            offset (int): Offset to begin searching file in.
+
+        Returns:
+            Dict[str, Any]: SHA and version number found in header.
+        """
         VersionHeader = namedtuple("VersionHeader", "magic gitSHA maj min")
         magic = 0xDF7F9AFDEC06627C
         header_format = "QIBB"
@@ -36,6 +51,17 @@ class TestDFU:
         return version
 
     def __wait_until_update_success(self, ser: SerialHelper) -> bool:
+        """After the DFU wait until it succeeds or fails
+
+        This is to be ran after DFU update to see if the DFU succeeds
+        or fails
+
+        Args:
+            ser (SerialHelper): Serial helper instance.
+
+        Returns:
+            bool: True if successful, False if unsuccessful
+        """
         ret = False
         while True:
             read = ser.read_line()
@@ -46,9 +72,23 @@ class TestDFU:
                 break
         return ret
 
-    def test_dfu_perform(self, ser: SerialHelper, file: str):
-        if file is not None:
-            # try:
+    def test_dfu_perform(self, ser: SerialHelper, file: str, node_id: str):
+        """Test DFU functionality
+
+        Runs through a DFU update over the serial console. Will send
+        bytes to the device in the order of BYTES_TO_SEND. A Node ID
+        and a proper DFU binary file path must be passed into the
+        command line.
+
+        Args:
+            ser (SerialHelper): Serial helper instance passed in from
+                                starting the pytests (see: conftest.py).
+            file (str): File name passed in from starting the pytests
+                        (see: conftest.py).
+            node_id (str): Node ID passed in from starting the pytests
+                           (see: conftest.py).
+        """
+        if file is not None and node_id is not None:
             file = os.path.abspath(file)
             size = os.path.getsize(file)
             data = Path(file).read_bytes()
@@ -56,11 +96,16 @@ class TestDFU:
             kermit = crcmod.predefined.mkCrcFun("kermit")
             crc = kermit(data)
             fw_ver = self.__get_version_from_bin(file)
+            assert fw_ver is not None
             major = int(fw_ver["version"].split(".")[0])
             minor = int(fw_ver["version"].split(".")[1])
             sha = int(fw_ver["sha"], 16)
+
+            # Start dfu update
             tx = (
-                "bm dfu start 0x8b718c26aea126dc "
+                "bm dfu start "
+                + str(node_id)
+                + " "
                 + str(size)
                 + " "
                 + str(crc)
@@ -76,23 +121,43 @@ class TestDFU:
             assert "Received ACK\n" in ser.read_until("Received ACK\n")
             count = 0
             print("\n")
-            for byte in data:
+
+            # Obtain the number of times a message must be sent
+            _range = len(data) / self.BYTES_TO_SEND
+            # iF there is a bit extra data, round up
+            if not _range.is_integer():
+                _range += 1
+            _range = int(_range)
+
+            for i in range(_range):
+                # Build the transmit message
+                tx = "bm dfu byte"
+                offset = i * self.BYTES_TO_SEND
+                max_bytes = (
+                    self.BYTES_TO_SEND
+                    if size - offset > self.BYTES_TO_SEND
+                    else size - offset
+                )
+                for j in range(max_bytes):
+                    tx += " " + str(data[offset + j])
+                tx += "\n"
+
+                # Send the built message
                 ser.flush()
-                ser.transmit_str("bm dfu byte " + str(byte) + "\n")
+                ser.transmit_str(tx)
                 read = ser.read_until("DFU Byte Added\n")
                 if "Update failed" in read:
                     break
 
                 # Add a pretty progress bar
-                count += 1
-                progress = int((count / size) * 100.0)
-                sys.stdout.write(
-                    f"\rDFU Update Progress: [{'#' * progress}{' ' * (100 - progress)}]"
-                    f"{progress}%"
-                )
-                sys.stdout.flush()
+                count += self.BYTES_TO_SEND
+                print_progress_bar("DFU Update Progress", count, size)
+
+            # Finish the transmission with any leftover data in buffer
             ser.transmit_str("bm dfu finish\n")
             read = ser.read_until("DFU Finish\n")
+
+            # Determine if DFU passed
             try:
                 assert (
                     func_timeout(

--- a/test/scripts/test_dfu.py
+++ b/test/scripts/test_dfu.py
@@ -174,7 +174,6 @@ class TestDFU:
 
         else:
             pytest.skip(
-                "\nSkipping DFU test as file and node ID was not passed"
-                "in to command line..."
+                "\nSkipping DFU test as file and node ID were not passed"
+                " in to command line..."
             )
-        pass

--- a/test/scripts/test_dfu.py
+++ b/test/scripts/test_dfu.py
@@ -7,6 +7,7 @@ import crcmod
 from pathlib import Path
 from func_timeout import func_timeout, FunctionTimedOut
 from util import print_progress_bar
+import pytest
 
 
 class TestDFU:
@@ -72,7 +73,7 @@ class TestDFU:
                 break
         return ret
 
-    def test_dfu_perform(self, ser: SerialHelper, file: str, node_id: str):
+    def test_dfu(self, ser: SerialHelper, file: str, node_id: str):
         """Test DFU functionality
 
         Runs through a DFU update over the serial console. Will send
@@ -172,5 +173,8 @@ class TestDFU:
                 assert 0
 
         else:
-            print("\nSkipping DFU test as file was not passed in...")
+            pytest.skip(
+                "\nSkipping DFU test as file and node ID was not passed"
+                "in to command line..."
+            )
         pass

--- a/test/scripts/test_dfu.py
+++ b/test/scripts/test_dfu.py
@@ -1,0 +1,105 @@
+from serial_helper import SerialHelper
+import os
+import struct
+from collections import namedtuple
+from typing import Dict, Any
+import crcmod
+from pathlib import Path
+from func_timeout import func_timeout, FunctionTimedOut
+
+
+class TestDFU:
+
+    SUCCESSFUL_TIMEOUT_S = 60
+
+    def __get_version_from_bin(self, file: str, offset: int = 0) -> Dict[str, Any]:
+        VersionHeader = namedtuple("VersionHeader", "magic gitSHA maj min")
+        magic = 0xDF7F9AFDEC06627C
+        header_format = "QIBB"
+        header_len = struct.calcsize(header_format)
+        version = None
+        with open(file, "rb") as f:
+            data = f.read()
+
+            for offset in range(offset, len(data) - header_len):
+                header = VersionHeader._make(
+                    struct.unpack_from(header_format, data, offset=offset)
+                )
+
+                if magic == header.magic:
+                    version = {
+                        "sha": f"{header.gitSHA:08X}",
+                        "version": f"{header.maj}.{header.min}",
+                    }
+                    break
+        return version
+
+    def __wait_until_update_success(self, ser: SerialHelper) -> bool:
+        ret = False
+        while True:
+            read = ser.read_line()
+            if "Update successful" in read:
+                ret = True
+                break
+            if "Update failed" in read:
+                break
+        return ret
+
+    def test_dfu_perform(self, ser: SerialHelper, file: str):
+        if file is not None:
+            # try:
+            file = os.path.abspath(file)
+            size = os.path.getsize(file)
+            data = Path(file).read_bytes()
+
+            kermit = crcmod.predefined.mkCrcFun("kermit")
+            crc = kermit(data)
+            fw_ver = self.__get_version_from_bin(file)
+            major = int(fw_ver["version"].split(".")[0])
+            minor = int(fw_ver["version"].split(".")[1])
+            sha = int(fw_ver["sha"], 16)
+            tx = (
+                "bm dfu start 0x8b718c26aea126dc "
+                + str(size)
+                + " "
+                + str(crc)
+                + " "
+                + str(major)
+                + " "
+                + str(minor)
+                + " "
+                + str(sha)
+                + "\n"
+            )
+            ser.transmit_str(tx)
+            assert "Received ACK\n" in ser.read_until("Received ACK\n")
+            count = 0
+            print(size)
+            print(len(data))
+            print(crc)
+            for byte in data:
+                ser.flush()
+                ser.transmit_str("bm dfu byte " + str(byte) + "\n")
+                read = ser.read_until("DFU Byte Added\n")
+                if "update failed" in read:
+                    break
+                count += 1
+                print("\r" + str((count / size) * 100) + "%", "")
+            ser.transmit_str("bm dfu finish\n")
+            read = ser.read_until("DFU Finish\n")
+            try:
+                assert (
+                    func_timeout(
+                        self.SUCCESSFUL_TIMEOUT_S,
+                        self.__wait_until_update_success,
+                        args=(ser,),
+                    )
+                    is True
+                )
+            except FunctionTimedOut:
+                print("Update was not successful...")
+                assert 0
+
+        else:
+            print("\nSkipping DFU test as file was not passed in...")
+        pass

--- a/test/scripts/tests_to_run.txt
+++ b/test/scripts/tests_to_run.txt
@@ -9,3 +9,4 @@ test_time.py::TestTime::test_time_set
 test_time.py::TestTime::test_time_get
 test_ping.py::TestPing::test_ping
 test_info.py::TestInfo::test_info
+test_dfu.py::TestDFU::test_dfu

--- a/test/scripts/util.py
+++ b/test/scripts/util.py
@@ -1,4 +1,6 @@
 from enum import Enum
+import sys
+from typing import Union
 
 
 class RunOrder(Enum):
@@ -17,3 +19,22 @@ def format_node_id_to_hex_str(node: int) -> str:
                     or another node found elsewhere (ex. neighbor).
     """
     return hex(node)[2:]
+
+
+def print_progress_bar(s: str, current: Union[int, float], total: Union[int, float]):
+    """Print a progress bar to the console
+
+    Prints a pretty progress bar to the console formmatted as so:
+
+        String To Print Here [##                     ]10%
+
+    Args:
+        s (str): String to print befor the progress bar.
+        current (Union[int, float]): Current value.
+        total (Union[int, float]): Total value.
+    """
+    progress = int((current / total) * 100.0)
+    sys.stdout.write(
+        f"\r{s}: [{'#' * progress}{' ' * (100 - progress)}]" f"{progress}%"
+    )
+    sys.stdout.flush()

--- a/test/src/dfu_test.cpp
+++ b/test/src/dfu_test.cpp
@@ -213,7 +213,7 @@ TEST_F(BcmpDfu, dfu_api_test) {
   info.major_ver = 0;
   info.minor_ver = 1;
   info.gitSHA = 0xd00dd00d;
-  EXPECT_EQ(bm_dfu_initiate_update(info, 0xdeadbeefbeeffeed, NULL, 1000),
+  EXPECT_EQ(bm_dfu_initiate_update(info, 0xdeadbeefbeeffeed, NULL, 1000, true),
             false);
 }
 

--- a/test/src/dfu_test.cpp
+++ b/test/src/dfu_test.cpp
@@ -189,6 +189,14 @@ TEST_F(BcmpDfu, dfu_api_test) {
   EXPECT_EQ(bm_queue_create_fake.call_count, 1);
   EXPECT_EQ(bm_timer_create_fake.call_count, 4);
   EXPECT_EQ(node_id_fake.call_count, 3);
+  LibSmContext *ctx = bm_dfu_test_get_sm_ctx();
+  BmDfuEvent evt = {
+      .type = DfuEventInitSuccess,
+      .buf = NULL,
+      .len = 0,
+  };
+  bm_dfu_test_set_dfu_event_and_run_sm(evt);
+  EXPECT_EQ(get_current_state_enum(ctx), BmDfuStateIdle);
 
   bm_dfu_send_ack(0xdeadbeefbeeffeed, 1, BmDfuErrNone);
   EXPECT_EQ(bcmp_tx_fake.call_count, 1);
@@ -214,7 +222,7 @@ TEST_F(BcmpDfu, dfu_api_test) {
   info.minor_ver = 1;
   info.gitSHA = 0xd00dd00d;
   EXPECT_EQ(bm_dfu_initiate_update(info, 0xdeadbeefbeeffeed, NULL, 1000, true),
-            false);
+            true);
 }
 
 TEST_F(BcmpDfu, client_golden) {
@@ -460,6 +468,16 @@ TEST_F(BcmpDfu, host_golden) {
   };
   bm_dfu_test_set_dfu_event_and_run_sm(evt);
   EXPECT_EQ(get_current_state_enum(ctx), BmDfuStateIdle);
+
+  BmDfuImgInfo info;
+  info.chunk_size = bm_dfu_max_chunk_size;
+  info.crc16 = 0xbaad;
+  info.image_size = 2 * 1000 * 1024;
+  info.major_ver = 0;
+  info.minor_ver = 1;
+  info.gitSHA = 0xd00dd00d;
+  EXPECT_EQ(bm_dfu_initiate_update(info, 0xdeadbeefbeeffeed, NULL, 1000, true),
+            true);
 
   // HOST REQUEST
   evt.type = DfuEventBeginHost;

--- a/test/stubs/bm_os_stub.c
+++ b/test/stubs/bm_os_stub.c
@@ -44,6 +44,12 @@ DEFINE_FAKE_VALUE_FUNC(BmErr, bm_queue_receive, BmQueue, void *, uint32_t);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_queue_send, BmQueue, const void *, uint32_t);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_queue_send_to_front_from_isr, BmQueue,
                        const void *);
+DEFINE_FAKE_VALUE_FUNC(BmBuffer, bm_stream_buffer_create, uint32_t);
+DEFINE_FAKE_VOID_FUNC(bm_stream_buffer_delete, BmBuffer);
+DEFINE_FAKE_VALUE_FUNC(BmErr, bm_stream_buffer_send, BmBuffer, uint8_t *,
+                       uint32_t, uint32_t);
+DEFINE_FAKE_VALUE_FUNC(BmErr, bm_stream_buffer_receive, BmBuffer, uint8_t *,
+                       uint32_t *, uint32_t);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_task_create, BmTaskCb, const char *, uint32_t,
                        void *, uint32_t, BmTaskHandle);
 DEFINE_FAKE_VOID_FUNC(bm_task_delete, BmTaskHandle);


### PR DESCRIPTION
## What changed?
Added "external" way of DFU'ing a node over the network by means of a queue.
The API `bm_dfu_host_queue_data` is used to queue data by means of whatever method an integrator may choose.
Added HIL test for DFU

## How does it make Bristlemouth better?
This adds the ability for integrators to trigger a DFU from another location other than the wrapper function `bm_dfu_host_queue_data` (which is used to read data from flash in our implementation).
Adds a robust HIL test for DFU updates.


## Where should reviewers focus?
The HIL test specifically as well as the changes in `dfu_host.c`


## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
