### PR TITLE
Reduce App Cmake and Docs Update

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -49,6 +49,9 @@ set(BM_CORE_FREERTOS_INCLUDES
     path/to/includes/here
 )
 
+# Add directory path to bm_config.h here
+include_directories(/path/to/config/directory)
+
 # Include bm_core.cmake to add functions necessary to choose platform items
 include(path/to/bm_core/cmake/bm_core.cmake)
 setup_bm_ip_stack(LWIP "${BM_CORE_LWIP_INCLUDES}")
@@ -56,9 +59,6 @@ setup_bm_os(FREERTOS "${BM_CORE_FREERTOS_INCLUDES}")
 
 # Add bm_core to the build
 add_subdirectory(path/to/bm_core bmcore)
-
-# Add directory path to bm_config.h here
-target_include_directories(bmcore PRIVATE /path/to/config/directory)
 
 # Link bm_core to the executable
 target_link_libraries(${EXECUTABLE_NAME} bmcore)

--- a/drivers/adin2111/CMakeLists.txt
+++ b/drivers/adin2111/CMakeLists.txt
@@ -15,6 +15,8 @@ set(SOURCES
 
 add_library(bmadin2111 ${SOURCES})
 
+target_link_libraries(bmadin2111 bmcommon)
+
 if(ENABLE_TESTING)
     add_compile_definitions(ENABLE_TESTING)
 endif()


### PR DESCRIPTION
## What changed?
bmadin2111 library has a dependency on bmcommon that needed to be addressed
Doc updates for how to include bm_config.h into project


## How does it make Bristlemouth better?
Better documentation and builds that actually compile without external intervention (bmadin2111 dependency was worked around in the bm_protocol repo)


## Where should reviewers focus?
All changes, quite minimal!


## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
