### PR TITLE
Fix/bcmp forward checksum

### DIFF
--- a/bcmp/bcmp.c
+++ b/bcmp/bcmp.c
@@ -202,12 +202,14 @@ BmErr bcmp_ll_forward(BcmpHeader *header, void *payload, uint32_t size,
     // so calculate the checksum on the link-local multicast address.
     forward = bm_ip_tx_new(&multicast_ll_addr, size + sizeof(BcmpHeader));
     if (forward) {
-      header->checksum = 0;
-      header->checksum = packet_checksum(forward, size + sizeof(BcmpHeader));
 
       // Copy data to be forwarded
+      header->checksum = 0;
       bm_ip_tx_copy(forward, header, sizeof(BcmpHeader), 0);
       bm_ip_tx_copy(forward, payload, size, sizeof(BcmpHeader));
+
+      header->checksum = packet_checksum(forward, size + sizeof(BcmpHeader));
+      bm_ip_tx_copy(forward, header, sizeof(BcmpHeader), 0);
 
       err = bm_ip_tx_perform(forward, &port_specific_dst);
       if (err != BmOK) {

--- a/bcmp/packet.c
+++ b/bcmp/packet.c
@@ -446,7 +446,7 @@ BmErr process_received_message(void *payload, uint32_t size) {
     checksum_read = data.header->checksum;
     data.header->checksum = 0;
     checksum_calc = PACKET.cb.checksum(payload, size + sizeof(BcmpHeader));
-    if (checksum_calc - checksum_read != 0) {
+    if (checksum_calc != checksum_read) {
       bm_debug("Packet checksum mismatch!\n");
       err = BmEBADMSG;
       return err;

--- a/bcmp/packet.c
+++ b/bcmp/packet.c
@@ -9,6 +9,9 @@
 
 #define default_message_timeout_ms 24
 #define message_timer_expiry_period_ms 12
+/* Ingress and Egress ports are mapped to the 5th and 6th byte of the IPv6 src address as per
+    the bristlemouth protocol spec */
+#define clear_ports(x) (x[1] &= (~(0xFFFFU)))
 
 typedef struct BcmpRequestElement {
   uint16_t type;
@@ -421,6 +424,8 @@ BmErr process_received_message(void *payload, uint32_t size) {
   BcmpRequestElement *request_message = NULL;
   BcmpPacketCfg *cfg = NULL;
   void *buf = NULL;
+  uint16_t checksum_read = 0;
+  uint16_t checksum_calc = 0;
 
   if (payload && PACKET.initialized) {
     buf = PACKET.cb.data(payload);
@@ -428,6 +433,7 @@ BmErr process_received_message(void *payload, uint32_t size) {
       bm_debug("Recieved BCMP message with no contents!\n");
       return err;
     }
+
     data.header = (BcmpHeader *)buf;
     data.payload = (uint8_t *)(buf + sizeof(BcmpHeader));
     data.src = PACKET.cb.src_ip(payload);
@@ -435,6 +441,18 @@ BmErr process_received_message(void *payload, uint32_t size) {
     data.size = size;
     // TODO: make me endian agnostic look up the spec
     data.ingress_port = (((uint32_t *)(data.src))[1] >> 8) & 0xFF;
+    clear_ports(((uint32_t *)data.src));
+
+    checksum_read = data.header->checksum;
+    data.header->checksum = 0;
+    checksum_calc = PACKET.cb.checksum(payload, size + sizeof(BcmpHeader));
+    if (checksum_calc - checksum_read != 0) {
+      bm_debug("Packet checksum mismatch!\n");
+      err = BmEBADMSG;
+      return err;
+    }
+    data.header->checksum = checksum_read;
+
     check_endianness(data.header, BcmpHeaderMessage);
 
     // Process parsed message type

--- a/network/bm_lwip.c
+++ b/network/bm_lwip.c
@@ -125,27 +125,26 @@ static uint8_t ip_recv(void *arg, struct raw_pcb *pcb, struct pbuf *pbuf,
     if (pbuf_remove_header(pbuf, PBUF_IP_HLEN) != 0) {
       //  Restore original packet
       pbuf_add_header(pbuf, PBUF_IP_HLEN);
-    } else {
-
-      // Make a copy of the IP address since we'll be modifying it later when we
-      // remove the src/dest ports (and since it might not be in the pbuf so someone
-      // else is managing that memory)
-      ip_addr_t *src_ref = (ip_addr_t *)bm_malloc(sizeof(ip_addr_t));
-      ip_addr_t *dst_ref = (ip_addr_t *)bm_malloc(sizeof(ip_addr_t));
-      LwipLayout *layout = (LwipLayout *)bm_malloc(sizeof(LwipLayout));
-      memcpy(dst_ref, ip6_hdr->dest.addr, sizeof(ip_addr_t));
-      memcpy(src_ref, src, sizeof(ip_addr_t));
-      *layout = (LwipLayout){pbuf, src_ref, dst_ref};
-
-      BcmpQueueItem item = {BcmpEventRx, (void *)layout, layout->pbuf->len};
-      if (bm_queue_send(queue, &item, 0) != BmOK) {
-        bm_debug("Error sending to Queue\n");
-        pbuf_free(pbuf);
-      }
-
-      // Eat the packet
-      rval = 1;
     }
+
+    // Make a copy of the IP address since we'll be modifying it later when we
+    // remove the src/dest ports (and since it might not be in the pbuf so someone
+    // else is managing that memory)
+    ip_addr_t *src_ref = (ip_addr_t *)bm_malloc(sizeof(ip_addr_t));
+    ip_addr_t *dst_ref = (ip_addr_t *)bm_malloc(sizeof(ip_addr_t));
+    LwipLayout *layout = (LwipLayout *)bm_malloc(sizeof(LwipLayout));
+    memcpy(dst_ref, ip6_hdr->dest.addr, sizeof(ip_addr_t));
+    memcpy(src_ref, src, sizeof(ip_addr_t));
+    *layout = (LwipLayout){pbuf, src_ref, dst_ref};
+
+    BcmpQueueItem item = {BcmpEventRx, (void *)layout, layout->pbuf->len};
+    if (bm_queue_send(queue, &item, 0) != BmOK) {
+      bm_debug("Error sending to Queue\n");
+      pbuf_free(pbuf);
+    }
+
+    // Eat the packet
+    rval = 1;
   }
 
   return rval;


### PR DESCRIPTION
## What changed?
Fixes BCMP forwarding checksum calculation.
Adds checksum validation for BCMP messages.
Add unit test to make sure checksum failure registers properly.

## How does it make Bristlemouth better?
Fixes a bug and adds in a checksum validation functionality that did not exist before (in `bm_core`)


## Where should reviewers focus?
The logic in `bcmp.c` and the checksum validation in `packet.c`.


## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
