### PR TITLE
Fix L2 Global Multicast Free-ing Race Condition

### DIFF
--- a/network/bm_lwip.c
+++ b/network/bm_lwip.c
@@ -141,6 +141,9 @@ static uint8_t ip_recv(void *arg, struct raw_pcb *pcb, struct pbuf *pbuf,
     if (bm_queue_send(queue, &item, 0) != BmOK) {
       bm_debug("Error sending to Queue\n");
       pbuf_free(pbuf);
+      bm_free(src_ref);
+      bm_free(dst_ref);
+      bm_free(layout);
     }
 
     // Eat the packet

--- a/network/l2.c
+++ b/network/l2.c
@@ -120,7 +120,6 @@ static BmErr bm_l2_tx(void *buf, uint32_t length, uint8_t port_mask) {
   L2QueueElement tx_evt = {port_mask & CTX.enabled_ports_mask, buf, L2Tx,
                            length};
 
-  bm_l2_tx_prep(buf, length);
   if (bm_queue_send(CTX.evt_queue, &tx_evt, 10) != BmOK) {
     bm_l2_free(buf);
     err = BmENOMEM;
@@ -244,7 +243,9 @@ static void bm_l2_process_rx_evt(L2QueueElement *rx_evt) {
 
     // Submit packet to ip stack.
     // Upper level RX Callback is responsible for freeing the packet
-    bm_l2_submit(rx_evt->buf, rx_evt->length);
+    if (bm_l2_submit(rx_evt->buf, rx_evt->length) != BmOK) {
+      bm_l2_free(rx_evt->buf);
+    }
   }
 }
 
@@ -413,6 +414,8 @@ BmErr bm_l2_link_output(void *buf, uint32_t length) {
 
   // clear the egress port set by the application
   eth_frame[egress_idx] = 0;
+
+  bm_l2_tx_prep(buf, length);
 
   return bm_l2_tx(buf, length, port_mask);
 }

--- a/network/l2.c
+++ b/network/l2.c
@@ -232,7 +232,10 @@ static void bm_l2_process_rx_evt(L2QueueElement *rx_evt) {
 
     if (is_global_multicast(&payload[ipv6_destination_address_offset])) {
       uint8_t new_port_mask = CTX.all_ports_mask & ~(rx_evt->port_mask);
-      bm_l2_tx(rx_evt->buf, rx_evt->length, new_port_mask);
+      void *buf = bm_l2_new(rx_evt->length);
+      memcpy(bm_l2_get_payload(buf), bm_l2_get_payload(rx_evt->buf),
+             rx_evt->length);
+      bm_l2_tx(buf, rx_evt->length, new_port_mask);
     }
 
     /* TODO: This is the place where routing and filtering functions would happen, to prevent passing the


### PR DESCRIPTION
## What changed?
Create a new buffer for global multi-cast messages that need to be forwarded on L2.


## How does it make Bristlemouth better?
Prevents potential free-ing race condition between bcmp thread and l2 thread that causes device to crash.


## Where should reviewers focus?
Testing, ensure that there are no memory leaks (last push has addressed this), and the logic looks sound.


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
