### PR TITLE
Robustify HIL Tests

### DIFF
--- a/test/scripts/conftest.py
+++ b/test/scripts/conftest.py
@@ -63,7 +63,7 @@ def pytest_generate_tests(metafunc):
         # as it runs for every test being ran, we only want to create
         # SER one time
         if SER is None:
-            SER = SerialHelper(port, baud, 0.5)
+            SER = SerialHelper(port, baud, 5.0)
         metafunc.parametrize("ser", [SER])
     if "file" in metafunc.fixturenames:
         metafunc.parametrize("file", [file])

--- a/test/scripts/test_config.py
+++ b/test/scripts/test_config.py
@@ -3,7 +3,7 @@ from serial_helper import SerialHelper
 from topology_helper import Topology
 from typing import Callable, Any
 from time import sleep
-from util import format_node_id_to_hex_str
+from util import format_node_id_to_hex_str, retry_test
 
 
 class TestConfig:
@@ -182,6 +182,7 @@ class TestConfig:
                     ser.close()
                     ser.open(ser.port, ser.baud, ser.timeout_s)
 
+    @retry_test(max_attempts=3, wait_s=2)
     def test_config_set(self, ser: SerialHelper):
         """Send set command from node
 
@@ -204,6 +205,7 @@ class TestConfig:
             ser, message, wait_msg, pattern, True, self.__process_value_message_handler
         )
 
+    @retry_test(max_attempts=3, wait_s=2)
     def test_config_get(self, ser: SerialHelper):
         """Send get command from node
 
@@ -226,6 +228,7 @@ class TestConfig:
             ser, message, wait_msg, pattern, True, self.__process_value_message_handler
         )
 
+    @retry_test(max_attempts=3, wait_s=2)
     def test_config_commit(self, ser: SerialHelper):
         """Send commit message to all nodes
 
@@ -258,6 +261,7 @@ class TestConfig:
 
         self.test_config_get(ser)
 
+    @retry_test(max_attempts=3, wait_s=2)
     def test_config_status(self, ser: SerialHelper, delete: bool = False):
         """Send status message to all nodes
 
@@ -308,6 +312,7 @@ class TestConfig:
             self.test_config_set(ser)
         self.__send_config_message(ser, message, wait_msg, pattern, False, compare)
 
+    @retry_test(max_attempts=3, wait_s=2)
     def test_config_delete(self, ser: SerialHelper):
         """Send delete message to all nodes
 

--- a/test/scripts/test_info.py
+++ b/test/scripts/test_info.py
@@ -1,11 +1,12 @@
 from topology_helper import Topology
 from serial_helper import SerialHelper
-from util import format_node_id_to_hex_str
+from util import format_node_id_to_hex_str, retry_test
 
 
 class TestInfo:
     """Info test class"""
 
+    @retry_test(max_attempts=3, wait_s=2)
     def test_info(self, ser: SerialHelper):
         """Test the BCMP info message
 

--- a/test/scripts/test_neighbors.py
+++ b/test/scripts/test_neighbors.py
@@ -1,13 +1,14 @@
 import pytest
 from serial_helper import SerialHelper
 from neighbors_helper import Neighbors
-from util import RunOrder
+from util import RunOrder, retry_test
 
 
 class TestNeighbors:
     """Neighbors HIL test class"""
 
     @pytest.mark.order(RunOrder.NEIGHBORS_TEST_RUN_ORDER.value)
+    @retry_test(max_attempts=5, wait_s=2)
     def test_neighbors_get(self, ser: SerialHelper):
         """Test to see if neighbors exist
 
@@ -19,7 +20,6 @@ class TestNeighbors:
             ser (SerialHelper): Serial helper instance passed in from
                                 starting the pytests (see: conftest.py).
         """
-        port = 0
         neighbors = Neighbors(ser)
         neighbors_info = list()
         neighbors_info = neighbors.get()
@@ -27,9 +27,7 @@ class TestNeighbors:
         # Ensure that there are actual neighbors
         assert len(neighbors_info) > 0
         for neighbor_info in neighbors_info:
-            port += 1
 
-            # Ensure that a neighbor node ID exists and the port found
-            # matches the port expected number
-            if not isinstance(neighbor_info[0], int) or neighbor_info[1] != port:
-                pytest.fail("Failed neighbor test and cannot move on")
+            # Ensure that a neighbor node ID and the port found exists
+            assert isinstance(neighbor_info[0], int)
+            assert isinstance(neighbor_info[1], int)

--- a/test/scripts/test_ping.py
+++ b/test/scripts/test_ping.py
@@ -1,6 +1,6 @@
 from topology_helper import Topology
 from serial_helper import SerialHelper
-from util import format_node_id_to_hex_str
+from util import format_node_id_to_hex_str, retry_test
 
 
 class TestPing:
@@ -8,6 +8,17 @@ class TestPing:
 
     TEST_STRING = "test_string"
 
+    def __compare_data(self, ser: SerialHelper):
+        pattern = r"\d+ bytes from [0-9a-fA-F]{16} bcmp_seq=\d+ time=\d+ ms payload="
+        ser.read_until_regex(pattern)
+        read = ser.read_line()
+        vals = read.split()
+        for i in range(len(vals)):
+            vals[i] = int(vals[i], 16)
+        vals = bytes(vals).decode("utf-8")
+        assert self.TEST_STRING == vals
+
+    @retry_test(max_attempts=3, wait_s=2)
     def test_ping(self, ser: SerialHelper):
         """Test to see if ping command works as expected
 
@@ -18,7 +29,6 @@ class TestPing:
             ser (SerialHelper): Serial helper instance passed in from
                                 starting the pytests (see: conftest.py).
         """
-        pattern = r"\d+ bytes from [0-9a-fA-F]{16} bcmp_seq=\d+ time=\d+ ms payload="
         topology = Topology(ser)
         nodes = topology.get()
         for node in nodes:
@@ -27,19 +37,14 @@ class TestPing:
                 ser.transmit_str(
                     "bm ping " + formatted_node + " " + self.TEST_STRING + "\n"
                 )
-                ser.read_until_regex(pattern)
-                read = ser.read_line()
-                vals = read.split()
-                for i in range(len(vals)):
-                    vals[i] = int(vals[i], 16)
-                vals = bytes(vals).decode("utf-8")
-                assert self.TEST_STRING == vals
+                self.__compare_data(ser)
 
         # Send ping request to all nodes and ensure that all respond
         # this would be the ping request with 0 as the node ID
         count = 0
         ser.transmit_str("bm ping 0 " + self.TEST_STRING + "\n")
         for node in nodes:
-            ser.read_until_regex(pattern)
-            count += 1
-        assert count == len(nodes)
+            if node != topology.root():
+                self.__compare_data(ser)
+                count += 1
+        assert count == len(nodes) - 1

--- a/test/scripts/test_ping.py
+++ b/test/scripts/test_ping.py
@@ -8,7 +8,7 @@ class TestPing:
 
     TEST_STRING = "test_string"
 
-    def __compare_data(self, ser: SerialHelper):
+    def _compare_data(self, ser: SerialHelper):
         pattern = r"\d+ bytes from [0-9a-fA-F]{16} bcmp_seq=\d+ time=\d+ ms payload="
         ser.read_until_regex(pattern)
         read = ser.read_line()
@@ -37,7 +37,7 @@ class TestPing:
                 ser.transmit_str(
                     "bm ping " + formatted_node + " " + self.TEST_STRING + "\n"
                 )
-                self.__compare_data(ser)
+                self._compare_data(ser)
 
         # Send ping request to all nodes and ensure that all respond
         # this would be the ping request with 0 as the node ID
@@ -45,6 +45,6 @@ class TestPing:
         ser.transmit_str("bm ping 0 " + self.TEST_STRING + "\n")
         for node in nodes:
             if node != topology.root():
-                self.__compare_data(ser)
+                self._compare_data(ser)
                 count += 1
         assert count == len(nodes) - 1

--- a/test/scripts/test_time.py
+++ b/test/scripts/test_time.py
@@ -3,7 +3,7 @@ import re
 from serial_helper import SerialHelper
 from topology_helper import Topology
 from datetime import datetime, timezone
-from util import format_node_id_to_hex_str
+from util import format_node_id_to_hex_str, retry_test
 
 
 class TestTime:
@@ -47,6 +47,7 @@ class TestTime:
         else:
             assert 0
 
+    @retry_test(max_attempts=3, wait_s=2)
     def test_time_set(self, ser: SerialHelper):
         """Time set test
 
@@ -72,6 +73,7 @@ class TestTime:
                 )
                 self.__time_process(ser, node, now)
 
+    @retry_test(max_attempts=3, wait_s=2)
     def test_time_get(self, ser: SerialHelper):
         """Time set test
 

--- a/test/scripts/test_topology.py
+++ b/test/scripts/test_topology.py
@@ -2,13 +2,14 @@ import pytest
 from serial_helper import SerialHelper
 from topology_helper import Topology
 from neighbors_helper import Neighbors
-from util import RunOrder
+from util import RunOrder, retry_test
 
 
 class TestTopology:
     """Topology HIL test class"""
 
     @pytest.mark.order(RunOrder.TOPOLOGY_TEST_RUN_ORDER.value)
+    @retry_test(max_attempts=5, wait_s=2)
     def test_topology_get(self, ser: SerialHelper):
         """Test to see if the topology report is correct
 

--- a/test/scripts/topology_helper.py
+++ b/test/scripts/topology_helper.py
@@ -1,6 +1,7 @@
 from serial_helper import SerialHelper
 import re
 import sys
+import argparse
 
 
 class Topology:
@@ -70,50 +71,26 @@ if __name__ == "__main__":
     CLI Options that will print topology information if this script
     is invoked directly
     """
-    help = False
-    root = False
-    port = None
-    port_arg = False
-    baud = None
-    baud_arg = False
-
-    for arg in sys.argv:
-        if arg == "--help" or arg == "-h":
-            help = True
-            break
-        elif arg == "--root" or arg == "-r":
-            root = True
-        elif arg == "--port" or arg == "-p":
-            port_arg = True
-        elif port_arg is True:
-            port = arg
-            port_arg = False
-        elif arg == "--baud" or arg == "-b":
-            baud_arg = True
-        elif baud_arg is True:
-            baud = int(arg)
-            baud_arg = False
-
-    if help is True:
-        print(
-            "usage: topology_helper.py [-h] [-r] -p {port}\n\n"
-            "prints a list of the topology or "
-            "root node to the console\n\n"
-            "required arguments:\n"
-            "-p, --port {port} serial port to access node\n"
-            "-b, --baud {baud} baud rate of serial connection\n"
-            "\n"
-            "optional arguments:\n"
-            "-h, --help show this help message and exit\n"
-            "-r, --root print the root to the console"
-        )
+    parser = argparse.ArgumentParser(
+        description="Prints a list of the Bristlemouth topology or root"
+        "node to the console",
+    )
+    parser.add_argument(
+        "-r", "--root", action="store_true", help="print the root to the console"
+    )
+    parser.add_argument(
+        "-p", "--port", help="serial port to access node", required=True
+    )
+    parser.add_argument(
+        "-b", "--baud", help="baud rate of serial connection", required=True
+    )
+    args = parser.parse_args()
+    ser = SerialHelper(args.port, args.baud)
+    topology = Topology(ser)
+    if args.root is True:
+        print(hex(topology.root()))
     else:
-        ser = SerialHelper(port, baud)
-        topology = Topology(ser)
-        if root is True:
-            print(hex(topology.root()))
-        else:
-            values = topology.get()
-            for i in range(len(values)):
-                values[i] = hex(values[i])
-            print(values)
+        values = topology.get()
+        for i in range(len(values)):
+            values[i] = hex(values[i])
+        print(values)

--- a/test/scripts/topology_helper.py
+++ b/test/scripts/topology_helper.py
@@ -1,5 +1,6 @@
 from serial_helper import SerialHelper
 import re
+import sys
 
 
 class Topology:
@@ -61,3 +62,58 @@ class Topology:
         if self.__root is None:
             self.get()
         return self.__root
+
+
+if __name__ == "__main__":
+    """Command line option is this script is invoked directly
+
+    CLI Options that will print topology information is this script
+    is invoked directly
+    """
+    help = False
+    root = False
+    port = None
+    port_arg = False
+    baud = None
+    baud_arg = False
+
+    for arg in sys.argv:
+        if arg == "--help" or arg == "-h":
+            help = True
+            break
+        elif arg == "--root" or arg == "-r":
+            root = True
+        elif arg == "--port" or arg == "-p":
+            port_arg = True
+        elif port_arg is True:
+            port = arg
+            port_arg = False
+        elif arg == "--baud" or arg == "-b":
+            baud_arg = True
+        elif baud_arg is True:
+            baud = int(arg)
+            baud_arg = False
+
+    if help is True:
+        print(
+            "usage: topology_helper.py [-h] [-r] -p {port}\n\n"
+            "prints a list of the topology or "
+            "root node to the console\n\n"
+            "required arguments:\n"
+            "-p, --port {port} serial port to access node\n"
+            "-b, --baud {baud} baud rate of serial connection\n"
+            "\n"
+            "optional arguments:\n"
+            "-h, --help show this help message and exit\n"
+            "-r, --root print the root to the console"
+        )
+    else:
+        ser = SerialHelper(port, baud)
+        topology = Topology(ser)
+        if root is True:
+            print(hex(topology.root()))
+        else:
+            values = topology.get()
+            for i in range(len(values)):
+                values[i] = hex(values[i])
+            print(values)

--- a/test/scripts/topology_helper.py
+++ b/test/scripts/topology_helper.py
@@ -65,9 +65,9 @@ class Topology:
 
 
 if __name__ == "__main__":
-    """Command line option is this script is invoked directly
+    """Command line option if this script is invoked directly
 
-    CLI Options that will print topology information is this script
+    CLI Options that will print topology information if this script
     is invoked directly
     """
     help = False

--- a/test/scripts/util.py
+++ b/test/scripts/util.py
@@ -67,23 +67,13 @@ def retry_test(max_attempts: int = 5, wait_s: float = 5.0):
                 try:
                     return test_fun(*args, **kwargs)
 
-                except AssertionError as assert_error:
-                    assert_message = assert_error.__str__().split("\n")[0]
+                except (AssertionError, serial.SerialException) as err:
+                    assert_message = err.__str__().split("\n")[0]
                     print(
                         f'Retry error: "{test_fun.__name__}" '
                         f"--> {assert_message}."
                         f"[{retry_count}/{max_attempts - 1}]"
                         f"Retrying new execution in {wait_s} second(s)"
-                    )
-                    time.sleep(wait_s)
-                    retry_count += 1
-                except serial.SerialException as serial_error:
-                    serial_message = serial_error.__str__().split("\n")[0]
-                    print(
-                        f'Retry error: "{test_fun.__name__}" '
-                        f"--> {serial_message}."
-                        f"[{retry_count}/{max_attempts - 1}]"
-                        f" Retrying new execition in {wait_s} second(s)"
                     )
                     time.sleep(wait_s)
                     retry_count += 1

--- a/test/scripts/util.py
+++ b/test/scripts/util.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import sys
 from typing import Union
+import serial
+import time
+from functools import wraps
 
 
 class RunOrder(Enum):
@@ -38,3 +41,56 @@ def print_progress_bar(s: str, current: Union[int, float], total: Union[int, flo
         f"\r{s}: [{'#' * progress}{' ' * (100 - progress)}]" f"{progress}%"
     )
     sys.stdout.flush()
+
+
+def retry_test(max_attempts: int = 5, wait_s: float = 5.0):
+    """Retry pytest for specified number of attempts
+
+    Decorator to retry pytest tests for specific number of attempts.
+    If a test fails, it will retry the the test after waiting
+    a specified number of seconds. If the test fails after retried
+    number of attempts, then it will be reported accordingly.
+
+    Args:
+        max_attempts (int): Number of maximum attempts the test can
+                            be ran.
+        wait_s (int): Time in seconds to wait in between test runs
+                      if a test is to fail.
+    """
+
+    def decorator(test_fun):
+        @wraps(test_fun)
+        def wrapper(*args, **kwargs):
+            retry_count = 1
+
+            while retry_count < max_attempts:
+                try:
+                    return test_fun(*args, **kwargs)
+
+                except AssertionError as assert_error:
+                    assert_message = assert_error.__str__().split("\n")[0]
+                    print(
+                        f'Retry error: "{test_fun.__name__}" '
+                        f"--> {assert_message}."
+                        f"[{retry_count}/{max_attempts - 1}]"
+                        f"Retrying new execution in {wait_s} second(s)"
+                    )
+                    time.sleep(wait_s)
+                    retry_count += 1
+                except serial.SerialException as serial_error:
+                    serial_message = serial_error.__str__().split("\n")[0]
+                    print(
+                        f'Retry error: "{test_fun.__name__}" '
+                        f"--> {serial_message}."
+                        f"[{retry_count}/{max_attempts - 1}]"
+                        f" Retrying new execition in {wait_s} second(s)"
+                    )
+                    time.sleep(wait_s)
+                    retry_count += 1
+
+            # Preserve original traceback in case assertion Failed
+            return test_fun(*args, **kwargs)
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
## What changed?
Adds retry logic to HIL tests
Adds topology helper script CLI option if script invoked directly
Fixes neighbors test (previously would check each port and verify that a neighbor is associated with each port even if there were not two neighbors or a single neighbor was on the opposite port)

## How does it make Bristlemouth better?
Adds the ability to retry tests just in case a serial message was missed,
can invoke topology script directly to obtain a systems topology (useful for bm_protocol's HIL implementation run on a local runner)


## Where should reviewers focus?
Mainly the retry logic, ensure it looks adequate for the tests.


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
