### PR TITLE
Align ingress and egress ports to spec

### DIFF
--- a/bcmp/packet.c
+++ b/bcmp/packet.c
@@ -440,7 +440,7 @@ BmErr process_received_message(void *payload, uint32_t size) {
     data.dst = PACKET.cb.dst_ip(payload);
     data.size = size;
     // TODO: make me endian agnostic look up the spec
-    data.ingress_port = (((uint32_t *)(data.src))[1] >> 8) & 0xFF;
+    data.ingress_port = (((uint8_t *)data.src)[2] >> 4) & 0xF;
     clear_ports(((uint32_t *)data.src));
 
     checksum_read = data.header->checksum;

--- a/bcmp/packet.c
+++ b/bcmp/packet.c
@@ -439,7 +439,6 @@ BmErr process_received_message(void *payload, uint32_t size) {
     data.src = PACKET.cb.src_ip(payload);
     data.dst = PACKET.cb.dst_ip(payload);
     data.size = size;
-    // TODO: make me endian agnostic look up the spec
     data.ingress_port = (((uint8_t *)data.src)[2] >> 4) & 0xF;
     clear_ports(((uint32_t *)data.src));
 

--- a/common/util.c
+++ b/common/util.c
@@ -14,28 +14,26 @@ uint32_t time_remaining(uint32_t start, uint32_t current, uint32_t timeout) {
   return remaining;
 }
 
-bool is_global_multicast(void *dst_ip) {
+bool is_global_multicast(const uint8_t *dst_ip) {
   bool is_global_multi = false;
   if (dst_ip != NULL) {
     // Global multicast address is FF03::1
-    uint8_t *dst_bytes = (uint8_t *)dst_ip;
     uint8_t *global_multi_bytes = (uint8_t *)&multicast_global_addr;
-    is_global_multi = dst_bytes[0] == global_multi_bytes[0] && // FF
-                      dst_bytes[1] == global_multi_bytes[1] && // 03
-                      dst_bytes[15] == global_multi_bytes[15]; // 01
+    is_global_multi = dst_ip[0] == global_multi_bytes[0] && // FF
+                      dst_ip[1] == global_multi_bytes[1] && // 03
+                      dst_ip[15] == global_multi_bytes[15]; // 01
   }
   return is_global_multi;
 }
 
-bool is_link_local_multicast(void *dst_ip) {
+bool is_link_local_multicast(const uint8_t *dst_ip) {
   bool is_ll_multi = false;
   if (dst_ip != NULL) {
     // Link-local multicast address is FF02::1
-    uint8_t *dst_bytes = (uint8_t *)dst_ip;
     uint8_t *ll_multi_bytes = (uint8_t *)&multicast_ll_addr;
-    is_ll_multi = dst_bytes[0] == ll_multi_bytes[0] && // FF
-                  dst_bytes[1] == ll_multi_bytes[1] && // 02
-                  dst_bytes[15] == ll_multi_bytes[15]; // 01
+    is_ll_multi = dst_ip[0] == ll_multi_bytes[0] && // FF
+                  dst_ip[1] == ll_multi_bytes[1] && // 02
+                  dst_ip[15] == ll_multi_bytes[15]; // 01
   }
   return is_ll_multi;
 }

--- a/common/util.h
+++ b/common/util.h
@@ -101,8 +101,8 @@ typedef struct {
 extern const bm_ip_addr multicast_global_addr;
 extern const bm_ip_addr multicast_ll_addr;
 
-bool is_global_multicast(void *dst_ip);
-bool is_link_local_multicast(void *dst_ip);
+bool is_global_multicast(const uint8_t *dst_ip);
+bool is_link_local_multicast(const uint8_t *dst_ip);
 bool is_little_endian(void);
 void swap_16bit(void *x);
 void swap_32bit(void *x);

--- a/drivers/adin2111/bm_adin2111.c
+++ b/drivers/adin2111/bm_adin2111.c
@@ -177,6 +177,17 @@ static void tx_complete(void *device_param, uint32_t event,
   free_tx_buffer(buffer_description);
 }
 
+static inline adin2111_TxPort_e driver_tx_port(uint8_t port) {
+  switch (port) {
+  case 1:
+    return ADIN2111_TX_PORT_1;
+  case 2:
+    return ADIN2111_TX_PORT_2;
+  default:
+    return ADIN2111_TX_PORT_FLOOD;
+  }
+}
+
 // Allocate buffers for sending, copy the given data, and submit to the driver
 static BmErr adin2111_netdevice_send(uint8_t *data, size_t length,
                                      uint8_t port) {
@@ -197,8 +208,10 @@ static BmErr adin2111_netdevice_send(uint8_t *data, size_t length,
   memcpy(buffer_description->pBuf, data, length);
   buffer_description->trxSize = length;
   buffer_description->cbFunc = tx_complete;
-  if (adin2111_SubmitTxBuffer(&DEVICE_STRUCT, port, buffer_description) !=
-      ADI_ETH_SUCCESS) {
+  adin2111_TxPort_e tx_port = driver_tx_port(port);
+  adi_eth_Result_e result =
+      adin2111_SubmitTxBuffer(&DEVICE_STRUCT, tx_port, buffer_description);
+  if (result != ADI_ETH_SUCCESS) {
     free_tx_buffer(buffer_description);
     goto end;
   }

--- a/drivers/adin2111/bm_adin2111.c
+++ b/drivers/adin2111/bm_adin2111.c
@@ -241,8 +241,9 @@ static void receive_callback(void *device, uint32_t event,
       (adi_eth_BufDesc_t *)buffer_description_param;
 
   if (NETWORK_DEVICE.callbacks->receive) {
-    uint8_t port_mask = 1 << buffer_description->port;
-    NETWORK_DEVICE.callbacks->receive(port_mask, buffer_description->pBuf,
+    // Driver gives us zero or one. Bristlemouth spec ingress port is 1-15.
+    uint8_t port_num = buffer_description->port + 1;
+    NETWORK_DEVICE.callbacks->receive(port_num, buffer_description->pBuf,
                                       buffer_description->trxSize);
   }
 

--- a/network/bm_lwip.c
+++ b/network/bm_lwip.c
@@ -322,10 +322,9 @@ void *bm_l2_get_payload(void *buf) {
 }
 
 /*!
-  @brief Prepare For A Transmite
+  @brief Prepare to Transmit
 
-  @details This allows for some logic to occur before preparing for a
-           transmission
+  @details This allows for some logic to occur before a transmission
 
   @param buf buffer created with bm_l2_new
   @param size size of buffer to transmit up the stack in bytes

--- a/network/l2.c
+++ b/network/l2.c
@@ -230,7 +230,7 @@ static void bm_l2_process_tx_evt(L2QueueElement *tx_evt) {
 
   @details Receive message from L2 queue and:
              1. re-transmit over other ports if the message is global multicast
-             2. send up to lwip for processing via net_if->input()
+             2. submit up to IP stack for processing via bm_l2_submit
 
   @param *rx_evt - rx event with buffer, port, and other information
 */
@@ -261,7 +261,7 @@ static void bm_l2_process_rx_evt(L2QueueElement *rx_evt) {
   // TODO: When we implement Resource-Based Routing (RBR)
   // described in section 5.4.4.3 of the Bristlemouth specification
   // this is where routing and filtering functions would happen
-  // to prevent passing the packet to net_if->input() if unnecessary,
+  // to prevent submitting the packet to upper layers if unnecessary,
   // as well as forwarding routed multicast data to interested neighbors.
 
   // Submit packet to IP stack.

--- a/network/network_device.h
+++ b/network/network_device.h
@@ -6,11 +6,14 @@
 typedef struct {
   void (*power)(bool on);
   void (*link_change)(uint8_t port_index, bool is_up);
-  void (*receive)(uint8_t port_mask, uint8_t *data, size_t length);
+
+  // Bristlemouth spec ingress port_num is an integer 1-15
+  void (*receive)(uint8_t port_num, uint8_t *data, size_t length);
   void (*debug_packet_dump)(const uint8_t *data, size_t length);
 } NetworkDeviceCallbacks;
 
 typedef struct {
+  // If port=0, send on all ports. Otherwise select a single egress port 1-15.
   BmErr (*const send)(void *self, uint8_t *data, size_t length, uint8_t port);
   BmErr (*const enable)(void *self);
   BmErr (*const disable)(void *self);


### PR DESCRIPTION
## What changed?

The primary change here is moving the ingress and egress ports to the location within the source address that is actually in the Bristlemouth specification. Up to this moment they have been encoded in the wrong location.

I also clarified and corrected several places where port index (zero-based), port number (one-based), and port mask were confused.

On TX, the L2 API allows sending to a port mask. Under the hood that is converted either to a driver-specific all-ports call or else many calls to send to each individual port set in the mask.

On RX, we deal primarily with a single ingress port number, since the idea of having received a packet on multiple ports is nonsensical.

Ingress and egress ports in the Bristlemouth spec are encoded in 4 bits, numbers 1-15. Thus, for a mask of such ports, we need a `uint16_t`. Previously the mask was a `uint8_t`, which works fine for the 2-port ADIN2111, but this was a convenient time to make sure we support future devices in line with the spec.

Functions that ask whether a packet is to the link-local or global addresses should allow const pointers since they don't modify data.

When shifting bits to create or compare to a mask, use unsigned numbers to avoid arithmetic shifting surprises like negative numbers left-filling with 1s on right shift. In particular I changed literal 1 to 1U in some places. 

## How does it make Bristlemouth better?

This PR finally aligns the code to the specification with regard to the encoding of ingress and egress ports in the source IP address. This was required before we could consider implementing resource-based routing, described in section 5.4.4.3 of the spec, since the old locations overlapped the resource options field.

## Compatibility considerations

Egress ports (a sending node notifying receivers which port it sent a message on) has never been used, and it continues not to be used. This can be modified with no ill effects.

Ingress ports are crucial to how we build the topology. Luckily though, they are entirely set and used within one node. Since the ingress port does not actually travel on the wire between a sender and receiver that might be on different versions of Bristlemouth firmware, there is no incompatibility to manage.

## Where should reviewers focus?

Focus on l2.c, especially `bm_l2_process_tx_evt` and `bm_l2_process_rx_evt`. I'm happy to talk through the changes in a meeting side-by-side with the relevant sections of the Bristlemouth specification.

## Checklist

- [ ] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
