### PR TITLE
Adds bcmp_config_decode_value API

### DIFF
--- a/bcmp/config.c
+++ b/bcmp/config.c
@@ -27,7 +27,7 @@
  */
 BmErr bcmp_config_decode_value(ConfigDataTypes type, uint8_t *data,
                                uint32_t data_length, void *buf,
-                               uint32_t *buf_length) {
+                               size_t *buf_length) {
   BmErr err = BmEINVAL;
   CborValue it;
   CborParser parser;
@@ -75,7 +75,7 @@ BmErr bcmp_config_decode_value(ConfigDataTypes type, uint8_t *data,
       case STR: {
         char *p = (char *)buf;
         uint32_t init_length = *buf_length;
-        if (cbor_value_copy_text_string(&it, p, (size_t *)buf_length, NULL) ==
+        if (cbor_value_copy_text_string(&it, p, buf_length, NULL) ==
             CborNoError) {
           if (*buf_length > init_length) {
             break;
@@ -85,8 +85,9 @@ BmErr bcmp_config_decode_value(ConfigDataTypes type, uint8_t *data,
         }
       } break;
       case BYTES: {
-        if (cbor_value_copy_byte_string(&it, buf, (size_t *)buf_length, NULL) ==
-            CborNoError) {
+        if (cbor_value_copy_byte_string(&it, (uint8_t *)buf,
+                                        (size_t *)buf_length,
+                                        NULL) == CborNoError) {
           err = BmOK;
         }
       } break;

--- a/bcmp/messages/config.h
+++ b/bcmp/messages/config.h
@@ -9,6 +9,9 @@ extern "C" {
 #endif
 
 BmErr bcmp_config_init(void);
+BmErr bcmp_config_decode_value(ConfigDataTypes type, uint8_t *data,
+                               uint32_t data_length, void *buf,
+                               uint32_t *buf_length);
 bool bcmp_config_get(uint64_t target_node_id, BmConfigPartition partition,
                      size_t key_len, const char *key, BmErr *err,
                      BmErr (*reply_cb)(uint8_t *));

--- a/bcmp/messages/config.h
+++ b/bcmp/messages/config.h
@@ -11,7 +11,7 @@ extern "C" {
 BmErr bcmp_config_init(void);
 BmErr bcmp_config_decode_value(ConfigDataTypes type, uint8_t *data,
                                uint32_t data_length, void *buf,
-                               uint32_t *buf_length);
+                               size_t *buf_length);
 bool bcmp_config_get(uint64_t target_node_id, BmConfigPartition partition,
                      size_t key_len, const char *key, BmErr *err,
                      BmErr (*reply_cb)(uint8_t *));

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -262,6 +262,30 @@ set (DFU_SRCS
 )
 create_gtest("dfu" "${DFU_SRCS}")
 
+# BCMP CONFIG TESTS
+set (BCMP_CONFIG_SRCS
+    # Files we're testing
+    ${BCMP_DIR}/config.c
+
+    # Support files
+    ${BCMP_DIR}/configuration.c
+    ${COMMON_DIR}/util.c
+    ${COMMON_DIR}/ll.c
+    ${THIRD_PARTY_DIR}/tinycbor/src/cborparser.c
+    ${THIRD_PARTY_DIR}/tinycbor/src/cborencoder_float.c
+    ${THIRD_PARTY_DIR}/tinycbor/src/cborencoder.c
+    ${THIRD_PARTY_DIR}/tinycbor/src/cborerrorstrings.c
+    ${THIRD_PARTY_DIR}/tinycbor/src/cborvalidation.c
+    ${THIRD_PARTY_DIR}/crc/crc32.c
+
+    # Stubs
+    ${STUB_DIR}/bcmp_stub.c
+    ${STUB_DIR}/bm_os_stub.c
+    ${STUB_DIR}/device_stub.c
+    ${STUB_DIR}/packet_stub.c
+)
+create_gtest("config" "${BCMP_CONFIG_SRCS}")
+
 
 # L2 Tests
 set (L2_SRCS

--- a/test/src/config_test.cpp
+++ b/test/src/config_test.cpp
@@ -1,0 +1,197 @@
+#include <gtest/gtest.h>
+#include <helpers.hpp>
+
+#include "fff.h"
+
+DEFINE_FFF_GLOBALS;
+
+extern "C" {
+#include "cbor.h"
+#include "messages/config.h"
+}
+
+#define ENCODE_BUFFER_SIZE 512
+#define DECODE_BUFFER_SIZE (ENCODE_BUFFER_SIZE / 2)
+
+bool bm_config_read(BmConfigPartition partition, uint32_t offset,
+                    uint8_t *buffer, size_t length, uint32_t timeout_ms) {
+  bool ret = false;
+
+  switch (partition) {
+  case BM_CFG_PARTITION_USER:
+  case BM_CFG_PARTITION_SYSTEM:
+  case BM_CFG_PARTITION_HARDWARE:
+    ret = true;
+    break;
+  default:
+    break;
+  }
+
+  return ret;
+}
+bool bm_config_write(BmConfigPartition partition, uint32_t offset,
+                     uint8_t *buffer, size_t length, uint32_t timeout_ms) {
+  bool ret = false;
+
+  switch (partition) {
+  case BM_CFG_PARTITION_USER:
+  case BM_CFG_PARTITION_SYSTEM:
+  case BM_CFG_PARTITION_HARDWARE:
+    ret = true;
+    break;
+  default:
+    break;
+  }
+
+  return ret;
+}
+void bm_config_reset(void) {}
+
+class Config : public ::testing::Test {
+public:
+  rnd_gen RND;
+
+private:
+protected:
+  Config() {}
+  ~Config() override {}
+
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(Config, decode) {
+
+  uint8_t cbor_buf[ENCODE_BUFFER_SIZE] = {0};
+  CborEncoder encoder = {};
+  struct {
+    uint8_t fail;
+    uint32_t get;
+    uint32_t set;
+  } u32;
+  struct {
+    int8_t fail;
+    int32_t get;
+    int32_t set;
+  } s32;
+  struct {
+    uint8_t fail;
+    float get;
+    float set;
+  } f;
+  struct {
+    char large_get[ENCODE_BUFFER_SIZE];
+    char get[DECODE_BUFFER_SIZE];
+    char set[DECODE_BUFFER_SIZE];
+  } str;
+  struct {
+    uint8_t large_get[ENCODE_BUFFER_SIZE];
+    uint8_t get[DECODE_BUFFER_SIZE];
+    uint8_t set[DECODE_BUFFER_SIZE];
+  } bytes;
+
+  uint32_t size = 0;
+
+  // Test uint32
+  u32.fail = 0;
+  u32.get = 0;
+  u32.set = RND.rnd_int(UINT32_MAX, 0);
+  cbor_encoder_init(&encoder, cbor_buf, sizeof(cbor_buf), 0);
+  cbor_encode_uint(&encoder, u32.set);
+
+  size = sizeof(u32.get);
+  EXPECT_EQ(bcmp_config_decode_value(UINT32, cbor_buf, sizeof(cbor_buf),
+                                     (void *)&u32.get, &size),
+            BmOK);
+  EXPECT_EQ(u32.get, u32.set);
+  EXPECT_EQ(size, sizeof(u32.set));
+
+  size = sizeof(u32.fail);
+  EXPECT_NE(bcmp_config_decode_value(UINT32, cbor_buf, sizeof(cbor_buf),
+                                     (void *)&u32.fail, &size),
+            BmOK);
+  EXPECT_EQ(u32.fail, 0);
+  EXPECT_NE(size, sizeof(u32.set));
+
+  // Test int32
+  s32.fail = 0;
+  s32.get = 0;
+  s32.set = RND.rnd_int(INT32_MAX, INT32_MIN);
+  cbor_encoder_init(&encoder, cbor_buf, sizeof(cbor_buf), 0);
+  cbor_encode_int(&encoder, s32.set);
+
+  size = sizeof(s32.get);
+  EXPECT_EQ(bcmp_config_decode_value(INT32, cbor_buf, sizeof(cbor_buf),
+                                     (void *)&s32.get, &size),
+            BmOK);
+  EXPECT_EQ(s32.get, s32.set);
+  EXPECT_EQ(size, sizeof(s32.set));
+
+  size = sizeof(s32.fail);
+  EXPECT_NE(bcmp_config_decode_value(INT32, cbor_buf, sizeof(cbor_buf),
+                                     (void *)&s32.fail, &size),
+            BmOK);
+  EXPECT_EQ(s32.fail, 0);
+  EXPECT_NE(size, sizeof(s32.set));
+
+  // Test float
+  f.fail = 0;
+  f.get = 0;
+  f.set = 1234.56789;
+  cbor_encoder_init(&encoder, cbor_buf, sizeof(cbor_buf), 0);
+  cbor_encode_float(&encoder, f.set);
+
+  size = sizeof(f.get);
+  EXPECT_EQ(bcmp_config_decode_value(FLOAT, cbor_buf, sizeof(cbor_buf),
+                                     (void *)&f.get, &size),
+            BmOK);
+  EXPECT_EQ(f.get, f.set);
+  EXPECT_EQ(size, sizeof(f.set));
+
+  size = sizeof(f.fail);
+  EXPECT_NE(bcmp_config_decode_value(FLOAT, cbor_buf, sizeof(cbor_buf),
+                                     (void *)&f.fail, &size),
+            BmOK);
+  EXPECT_EQ(f.fail, 0);
+  EXPECT_NE(size, sizeof(f.set));
+
+  // Test string
+  memset(str.get, 0, sizeof(str.get));
+  RND.rnd_str(str.set, sizeof(str.set));
+  cbor_encoder_init(&encoder, cbor_buf, sizeof(cbor_buf), 0);
+  cbor_encode_text_string(&encoder, str.set, sizeof(str.set));
+
+  size = sizeof(str.get);
+  EXPECT_EQ(bcmp_config_decode_value(STR, cbor_buf, sizeof(cbor_buf),
+                                     (void *)str.get, &size),
+            BmOK);
+  ASSERT_EQ(size, sizeof(str.set));
+  EXPECT_EQ(memcmp(str.get, str.set, size), 0);
+
+  size = sizeof(str.large_get);
+  EXPECT_EQ(bcmp_config_decode_value(STR, cbor_buf, sizeof(cbor_buf),
+                                     (void *)str.large_get, &size),
+            BmOK);
+  ASSERT_EQ(size, sizeof(str.set));
+  EXPECT_EQ(memcmp(str.large_get, str.set, size), 0);
+
+  // Test byte buffer
+  memset(bytes.get, 0, sizeof(bytes.get));
+  RND.rnd_array(bytes.set, sizeof(bytes.set));
+  cbor_encoder_init(&encoder, cbor_buf, sizeof(cbor_buf), 0);
+  cbor_encode_byte_string(&encoder, bytes.set, sizeof(bytes.set));
+
+  size = sizeof(bytes.get);
+  EXPECT_EQ(bcmp_config_decode_value(BYTES, cbor_buf, sizeof(cbor_buf),
+                                     (void *)bytes.get, &size),
+            BmOK);
+  ASSERT_EQ(size, sizeof(bytes.set));
+  EXPECT_EQ(memcmp(bytes.get, bytes.set, size), 0);
+
+  size = sizeof(bytes.large_get);
+  EXPECT_EQ(bcmp_config_decode_value(BYTES, cbor_buf, sizeof(cbor_buf),
+                                     (void *)bytes.large_get, &size),
+            BmOK);
+  ASSERT_EQ(size, sizeof(bytes.set));
+  EXPECT_EQ(memcmp(bytes.large_get, bytes.set, size), 0);
+}

--- a/test/src/config_test.cpp
+++ b/test/src/config_test.cpp
@@ -6,9 +6,9 @@
 DEFINE_FFF_GLOBALS;
 
 extern "C" {
+#include "bm_os.h"
 #include "cbor.h"
 #include "messages/config.h"
-#include "bm_os.h"
 }
 
 #define ENCODE_BUFFER_SIZE 512
@@ -91,7 +91,7 @@ TEST_F(Config, decode) {
     uint8_t *set;
   } bytes;
 
-  uint32_t size = 0;
+  size_t size = 0;
 
   // Test uint32
   u32.fail = 0;
@@ -157,10 +157,11 @@ TEST_F(Config, decode) {
   EXPECT_NE(size, sizeof(f.set));
 
   // Test string
+  str.large_get = (char *)bm_malloc(ENCODE_BUFFER_SIZE);
   str.get = (char *)bm_malloc(DECODE_BUFFER_SIZE);
   str.set = (char *)bm_malloc(DECODE_BUFFER_SIZE);
-  str.large_get = (char *)bm_malloc(ENCODE_BUFFER_SIZE);
   memset(str.get, 0, DECODE_BUFFER_SIZE);
+  memset(str.large_get, 0, ENCODE_BUFFER_SIZE);
   RND.rnd_str(str.set, DECODE_BUFFER_SIZE);
   cbor_encoder_init(&encoder, cbor_buf, sizeof(cbor_buf), 0);
   cbor_encode_text_string(&encoder, str.set, DECODE_BUFFER_SIZE);
@@ -183,10 +184,11 @@ TEST_F(Config, decode) {
   bm_free(str.large_get);
 
   // Test byte buffer
+  bytes.large_get = (uint8_t *)bm_malloc(ENCODE_BUFFER_SIZE);
   bytes.get = (uint8_t *)bm_malloc(DECODE_BUFFER_SIZE);
   bytes.set = (uint8_t *)bm_malloc(DECODE_BUFFER_SIZE);
-  bytes.large_get = (uint8_t *)bm_malloc(ENCODE_BUFFER_SIZE);
   memset(bytes.get, 0, DECODE_BUFFER_SIZE);
+  memset(bytes.large_get, 0, ENCODE_BUFFER_SIZE);
   RND.rnd_array(bytes.set, DECODE_BUFFER_SIZE);
   cbor_encoder_init(&encoder, cbor_buf, sizeof(cbor_buf), 0);
   cbor_encode_byte_string(&encoder, bytes.set, DECODE_BUFFER_SIZE);


### PR DESCRIPTION
## What changed?
Allows incoming BCMP config value messages to be decoded with newly added API
Adds unit test to test this new API


## How does it make Bristlemouth better?
Provides an integrator/dev kit user a way to decode incoming Bristlemouth config value messages without having to invoke cbor API directly.


## Where should reviewers focus?
The newly added API to ensure the internal logic is sound.
The newly added unit test to ensure the test covers edge cases. 


## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
