### PR TITLE
Fix BCMP Checksum Mismatch Bug After Ingress/Egress Port Alignment

### DIFF
--- a/bcmp/bcmp.h
+++ b/bcmp/bcmp.h
@@ -6,9 +6,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-/* Ingress and Egress ports are mapped to the 5th and 6th byte of the IPv6 src address as per
-    the bristlemouth protocol spec */
-#define clear_ports(x) (x[1] &= (~(0xFFFFU)))
 // FIXME: Remove when we can split payloads.
 #define bcmp_max_payload_size_bytes (1500)
 #define ipv6_header_length (40)

--- a/bcmp/packet.c
+++ b/bcmp/packet.c
@@ -11,8 +11,8 @@
 #define message_timer_expiry_period_ms 12
 
 /* This is to maintain backwards compatibility with older versions of
- * bm_core < v14, TODO: remove once resource based routing is
- * available */
+ * bm_core < v0.13.0, TODO: remove once resource based routing is
+ * implemented */
 #define clear_ports_legacy(x) (x[1] &= (~(0xFFFFU)))
 
 /* Ingress port is mapped to the first four bits of 3rd byte of the of the

--- a/bcmp/packet.c
+++ b/bcmp/packet.c
@@ -9,9 +9,16 @@
 
 #define default_message_timeout_ms 24
 #define message_timer_expiry_period_ms 12
-/* Ingress and Egress ports are mapped to the 5th and 6th byte of the IPv6 src address as per
-    the bristlemouth protocol spec */
-#define clear_ports(x) (x[1] &= (~(0xFFFFU)))
+
+/* This is to maintain backwards compatibility with older versions of
+ * bm_core < v14, TODO: remove once resource based routing is
+ * available */
+#define clear_ports_legacy(x) (x[1] &= (~(0xFFFFU)))
+
+/* Ingress port is mapped to the first four bits of 3rd byte of the of the
+ * global all-node source address as per the bristlemouth protocol spec
+ * v5.4.4.1/2, use this marcro to clear the ingress port */
+#define clear_ingress_port(x) (((uint8_t *)x)[2] &= 0xF)
 
 typedef struct BcmpRequestElement {
   uint16_t type;
@@ -440,7 +447,8 @@ BmErr process_received_message(void *payload, uint32_t size) {
     data.dst = PACKET.cb.dst_ip(payload);
     data.size = size;
     data.ingress_port = (((uint8_t *)data.src)[2] >> 4) & 0xF;
-    clear_ports(((uint32_t *)data.src));
+    clear_ports_legacy(((uint32_t *)data.src));
+    clear_ingress_port(data.src);
 
     checksum_read = data.header->checksum;
     data.header->checksum = 0;


### PR DESCRIPTION
## What changed?
Fixes BCMP failing checksum when ingress and egress port alignment fails

Updates BCMP checksum to account for change in source IP address after adding egress port

Retains clearing legacy ports when calculating the checksum of BCMP messages to preserve backwards compatibility


## How does it make Bristlemouth better?
Allows incoming BCMP messages to be handled properly without failing the calculated checksum.
Preserves backwards compatibility with nodes referencing `bm_core` before commit `44d35c5`.


## Where should reviewers focus?
Testing the following configurations with 2 (or more) nodes:
- All nodes with this branch checked out on `bm_core`
- One (or more) node(s) on this branch and one (or more) node(s) on commit `d0d1697` on `bm_core`

Ensure that the print statement `Packet checksum mismatch!` is not apparent in any of the nodes.

## Checklist

- [ ] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
