### PR TITLE
Fix Checksum Re-calculation For Second Port On BCMP Messages

### DIFF
--- a/bcmp/packet.c
+++ b/bcmp/packet.c
@@ -454,7 +454,8 @@ BmErr process_received_message(void *payload, uint32_t size) {
     data.header->checksum = 0;
     checksum_calc = PACKET.cb.checksum(payload, size + sizeof(BcmpHeader));
     if (checksum_calc != checksum_read) {
-      bm_debug("Packet checksum mismatch!\n");
+      bm_debug("Packet checksum mismatch, read 0x%X, calculated 0x%X!\n",
+               checksum_read, checksum_calc);
       err = BmEBADMSG;
       return err;
     }

--- a/network/l2.c
+++ b/network/l2.c
@@ -75,7 +75,6 @@
   (addr[ipv6_ingress_egress_ports_offset] |= (port << 4))
 #define clear_ports(addr) (addr[ipv6_ingress_egress_ports_offset] = 0)
 #define clear_ingress_port(addr) (addr[ipv6_ingress_egress_ports_offset] &= 0xF)
-#define clear_egress_port(addr) (addr[ipv6_ingress_egress_ports_offset] &= 0xF0)
 
 #define evt_queue_len (32)
 


### PR DESCRIPTION
## What changed?
Adds a fix to ensure that the checksum is reverted between messages outgoing on multiple ports on L2.
When multiple messages are going out on the same port, the payload is updated twice and needs to be reset in between transmissions on each port.


## How does it make Bristlemouth better?
Properly re-calculates the checksum on each port to avoid packet checksum mismatches on receiving nodes.


## Where should reviewers focus?
Is this the best way to handle this?
I thought of doing a deep copy of the payload buffer, but that is very costly in both resources and time.
Let me know your thoughts!


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
