### PR TITLE
Add Ability To Turn Off Singular Port On Network Device

### DIFF
--- a/network/l2.h
+++ b/network/l2.h
@@ -20,7 +20,9 @@ void bm_l2_deinit(void);
 BmErr bm_l2_init(NetworkDevice network_device);
 BmErr bm_l2_register_link_change_callback(L2LinkChangeCb cb);
 bool bm_l2_get_port_state(uint8_t port);
+uint8_t bm_l2_get_port_count(void);
 BmErr bm_l2_netif_set_power(bool on);
+BmErr bm_l2_netif_enable_disable_port(uint8_t port_num, bool enable);
 
 #ifdef __cplusplus
 }

--- a/network/network_device.h
+++ b/network/network_device.h
@@ -15,8 +15,8 @@ typedef struct {
 typedef struct {
   // If port=0, send on all ports. Otherwise select a single egress port 1-15.
   BmErr (*const send)(void *self, uint8_t *data, size_t length, uint8_t port);
-  BmErr (*const enable)(void *self);
-  BmErr (*const disable)(void *self);
+  BmErr (*const enable)(void *self, uint8_t port_num);
+  BmErr (*const disable)(void *self, uint8_t port_num);
   uint8_t (*const num_ports)(void);
   BmErr (*const port_stats)(void *self, uint8_t port_index, void *stats);
   BmErr (*const handle_interrupt)(void *self);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -294,6 +294,7 @@ set (L2_SRCS
 
     # Support files
     ${COMMON_DIR}/util.c
+    ${COMMON_DIR}/ll.c
 
     # Stubs
     ${STUB_DIR}/bm_os_stub.c

--- a/test/mocks/mock_bm_adin2111.h
+++ b/test/mocks/mock_bm_adin2111.h
@@ -11,8 +11,8 @@ DECLARE_FAKE_VOID_FUNC(received_data_on_port, uint8_t, uint8_t *, size_t);
 
 DECLARE_FAKE_VALUE_FUNC(BmErr, netdevice_send, void *, uint8_t *, size_t,
                         uint8_t);
-DECLARE_FAKE_VALUE_FUNC(BmErr, netdevice_enable, void *);
-DECLARE_FAKE_VALUE_FUNC(BmErr, netdevice_disable, void *);
+DECLARE_FAKE_VALUE_FUNC(BmErr, netdevice_enable, void *, uint8_t);
+DECLARE_FAKE_VALUE_FUNC(BmErr, netdevice_disable, void *, uint8_t);
 DECLARE_FAKE_VALUE_FUNC(uint8_t, netdevice_num_ports);
 DECLARE_FAKE_VALUE_FUNC(BmErr, netdevice_port_stats, void *, uint8_t, void *);
 

--- a/test/src/bm_adin2111_test.cpp
+++ b/test/src/bm_adin2111_test.cpp
@@ -39,7 +39,7 @@ TEST(Adin2111, send) {
 
 TEST(Adin2111, enable) {
   NetworkDevice device = setup();
-  BmErr err = device.trait->enable(device.self);
+  BmErr err = device.trait->enable(device.self, 0);
   // We're exercising the embedded driver code,
   // but there's no real SPI device on the bus.
   EXPECT_EQ(err, BmENODEV);
@@ -48,7 +48,7 @@ TEST(Adin2111, enable) {
 TEST(Adin2111, disable) {
   NetworkDevice device = setup();
   // SEGFAULT because PHY is NULL, because no real SPI transactions
-  EXPECT_DEATH(device.trait->disable(device.self), "");
+  EXPECT_DEATH(device.trait->disable(device.self, 0), "");
 }
 
 TEST(Adin2111, num_ports) {

--- a/test/src/l2_test.cpp
+++ b/test/src/l2_test.cpp
@@ -9,13 +9,18 @@ DEFINE_FFF_GLOBALS;
 
 extern "C" {
 #include "l2.h"
+#include "mock_bm_adin2111.h"
 #include "mock_bm_ip.h"
 #include "mock_bm_os.h"
-#include "mock_bm_adin2111.h"
 }
 
 #define port_per_device 2
 #define egress_port_offset 51
+
+static struct LinkChangeCbCount {
+  uint8_t down_count;
+  uint8_t up_count;
+} link_change_count;
 
 class L2 : public ::testing::Test {
 public:
@@ -25,6 +30,25 @@ public:
   static BmErr tx_cb(void *device_handle, uint8_t *buf, uint16_t size,
                      uint8_t port_mask, uint8_t port_offset) {
     return BmOK;
+  }
+  static inline void link_change_common_cb(uint8_t state) {
+    if (state) {
+      link_change_count.up_count++;
+    } else {
+      link_change_count.down_count++;
+    }
+  }
+  static void link_change_cb_1(uint8_t port, bool state) {
+    (void)port;
+    link_change_common_cb(state);
+  }
+  static void link_change_cb_2(uint8_t port, bool state) {
+    (void)port;
+    link_change_common_cb(state);
+  }
+  static void link_change_cb_3(uint8_t port, bool state) {
+    (void)port;
+    link_change_common_cb(state);
   }
 
 private:
@@ -41,6 +65,7 @@ protected:
     init_count = 0;
     bm_queue_create_fake.return_val =
         (void *)RND.rnd_int(UINT32_MAX, UINT16_MAX);
+    netdevice_num_ports_fake.return_val = port_per_device;
 
     EXPECT_EQ(bm_l2_init(network_device), BmOK);
   }
@@ -120,4 +145,45 @@ TEST_F(L2, set_power) {
 */
 TEST_F(L2, port_state) {
   bm_l2_get_port_state(RND.rnd_int(port_per_device, 1));
+}
+
+/*!
+ @brief Disable/enable ports
+ */
+TEST_F(L2, enable_disable_ports) {
+  netdevice_enable_fake.return_val = BmOK;
+  netdevice_disable_fake.return_val = BmOK;
+  for (uint8_t i = 0; i < port_per_device; i++) {
+    EXPECT_EQ(bm_l2_netif_enable_disable_port(i + 1, false), BmOK);
+    EXPECT_EQ(bm_l2_netif_enable_disable_port(i + 1, true), BmOK);
+  }
+
+  // Test failures
+  netdevice_enable_fake.return_val = BmENOMEM;
+  netdevice_disable_fake.return_val = BmENOMEM;
+  for (uint8_t i = 0; i < port_per_device; i++) {
+    EXPECT_NE(bm_l2_netif_enable_disable_port(i + 1, false), BmOK);
+    EXPECT_NE(bm_l2_netif_enable_disable_port(i + 1, true), BmOK);
+  }
+  EXPECT_NE(bm_l2_netif_enable_disable_port(port_per_device + 1, true), BmOK);
+}
+
+/*!
+ @brief Exercise link change callbacks
+ */
+TEST_F(L2, link_change) {
+  EXPECT_EQ(bm_l2_register_link_change_callback(link_change_cb_1), BmOK);
+  EXPECT_EQ(bm_l2_register_link_change_callback(link_change_cb_2), BmOK);
+  EXPECT_EQ(bm_l2_register_link_change_callback(link_change_cb_3), BmOK);
+  EXPECT_NE(bm_l2_register_link_change_callback(NULL), BmOK);
+
+  link_change_count = (struct LinkChangeCbCount){};
+  network_device.callbacks->link_change(RND.rnd_int(port_per_device, 1), false);
+  ASSERT_EQ(link_change_count.down_count, 3);
+  ASSERT_EQ(link_change_count.up_count, 0);
+
+  link_change_count = (struct LinkChangeCbCount){};
+  network_device.callbacks->link_change(RND.rnd_int(port_per_device, 1), true);
+  ASSERT_EQ(link_change_count.down_count, 0);
+  ASSERT_EQ(link_change_count.up_count, 3);
 }

--- a/test/stubs/bm_adin2111_stub.c
+++ b/test/stubs/bm_adin2111_stub.c
@@ -7,8 +7,8 @@ DEFINE_FAKE_VOID_FUNC(received_data_on_port, uint8_t, uint8_t *, size_t);
 
 DEFINE_FAKE_VALUE_FUNC(BmErr, netdevice_send, void *, uint8_t *, size_t,
                        uint8_t);
-DEFINE_FAKE_VALUE_FUNC(BmErr, netdevice_enable, void *);
-DEFINE_FAKE_VALUE_FUNC(BmErr, netdevice_disable, void *);
+DEFINE_FAKE_VALUE_FUNC(BmErr, netdevice_enable, void *, uint8_t);
+DEFINE_FAKE_VALUE_FUNC(BmErr, netdevice_disable, void *, uint8_t);
 DEFINE_FAKE_VALUE_FUNC(uint8_t, netdevice_num_ports);
 DEFINE_FAKE_VALUE_FUNC(BmErr, netdevice_port_stats, void *, uint8_t, void *);
 


### PR DESCRIPTION
## What changed?
AAdds PI that can enable/disable a single port on a network device
Adds API to get the number of ports on a network device
Allows multiple link change callbacks to be utilized in L2
Adds unit tests to test new L2 API

## How does it make Bristlemouth better?
This allows nodes to enable/disable a singular port unlocking power savings.
Scalable link change callbacks,
allowing other modules beside bcmp.c to utilize this great callback.

## Where should reviewers focus?
When reading the datasheet, I stumbled across this gem:
<img width="995" alt="image" src="https://github.com/user-attachments/assets/8a3012ac-88ef-464b-94bb-d07e23da2437" />
Should we not allow port one to be turned off if only trying to disable a single port?
Other than that, the `bm_adin2111.c` changes could use a good eye.
I am confident in the L2 changes as unit tests have been added to support new/changed API.

## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
