### PR TITLE
Power Information Timing Service Implementation

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
     aligned_malloc.c
+    cb_queue.c
     device.c
     lib_state_machine.c
     ll.c

--- a/common/cb_queue.c
+++ b/common/cb_queue.c
@@ -1,0 +1,65 @@
+#include "cb_queue.h"
+
+/*!
+  @brief Enqueue A Callback Onto The Queue
+
+  @param q queue instance
+  @param cb callback to enqueue
+
+  @return BmOK on success, BmErr on failure
+ */
+BmErr queue_cb_enqueue(BmCbQueue *q, BmQueueCb cb) {
+  BmErr err = BmEINVAL;
+  LLItem *cb_item = NULL;
+
+  if (q) {
+    err = BmENOMEM;
+    cb_item = ll_create_item(cb_item, &cb, sizeof(&cb), q->add_id);
+
+    if (cb_item) {
+      err = ll_item_add(&q->cb_list, cb_item);
+      if (err == BmOK) {
+        q->add_id++;
+      }
+    }
+  }
+
+  return err;
+}
+
+/*!
+  @brief Dequeue A Callback From The Queue
+
+  @details The callback from the queue does not need to be invoked, it can be
+           bypassed if necessary
+
+  @param q queue instance
+  @param arg argument to pass to the callback invoked
+  @param invoke true if the callback is to be invoked, false otherwise
+
+  @return BmOK on success, BmErr on failure
+ */
+BmErr queue_cb_dequeue(BmCbQueue *q, void *arg, bool invoke) {
+  BmErr err = BmEINVAL;
+  BmQueueCb *cb = NULL;
+
+  if (!q) {
+    return err;
+  }
+
+  err = BmECANCELED;
+  if (q->add_id != q->get_id) {
+    err = ll_get_item(&q->cb_list, q->get_id, (void **)&cb);
+
+    if (err == BmOK) {
+      if (*cb && invoke) {
+        err = (*cb)(arg);
+      }
+      ll_remove(&q->cb_list, q->get_id);
+    }
+
+    q->get_id++;
+  }
+
+  return err;
+}

--- a/common/cb_queue.h
+++ b/common/cb_queue.h
@@ -1,0 +1,18 @@
+#ifndef __CB_QUEUE_H__
+#define __CB_QUEUE_H__
+
+#include "ll.h"
+#include "util.h"
+
+typedef BmErr (*BmQueueCb)(const void *arg);
+
+typedef struct {
+  LL cb_list;
+  uint32_t add_id;
+  uint32_t get_id;
+} BmCbQueue;
+
+BmErr queue_cb_enqueue(BmCbQueue *q, BmQueueCb cb);
+BmErr queue_cb_dequeue(BmCbQueue *q, void *arg, bool invoke);
+
+#endif

--- a/common/ll.c
+++ b/common/ll.c
@@ -39,7 +39,7 @@ static BmErr ll_advance_cursor(LL *ll, void **data) {
  @brief Reset List Cursor
 
  @details Resets list cursor to begin iterative operations from the list's
-          head. This should be used once the pop API has reached the end
+          head. This should be used once the advance API has reached the end
           of the list.
  
  @param ll list to reset cursor

--- a/common/util.h
+++ b/common/util.h
@@ -59,6 +59,8 @@ typedef struct {
 
 #define array_size(x) (sizeof(x) / sizeof(x[0]))
 #define member_size(type, member) (sizeof(((type *)0)->member))
+#define s_to_ms(x) (x * 1000)
+#define ms_to_s(x) (x / 1000)
 
 uint32_t time_remaining(uint32_t start, uint32_t current, uint32_t timeout);
 uint32_t utc_from_date_time(uint16_t year, uint8_t month, uint8_t day,

--- a/docs/reference/middleware.md
+++ b/docs/reference/middleware.md
@@ -25,12 +25,14 @@ the following diagram shows how these components work together:
 ## Supported Services
 
 These services offer a request/reply form of communication.
-This allows for applications to publish to certain topics when information is requested or replied
-and obtain information from a specific node ID.
+This allows for applications to publish to certain topics when information is requested or replied to.
+Please view the [Bristlemouth Specification](https://bristlemouth.notion.site/The-Bristlemouth-Standard-Specification-f5449080f5c940cabbd0512b4d2aeb82)
+for further information on services.
 The following services are supported on Bristlemouth:
 
 - config_cbor_map
 - sys_info
+- power_info
 
 ### Config CBOR Map Service
 The replier to this service will generate a key-pair table of all configuration values on the system
@@ -65,3 +67,20 @@ the system information provided from a node is as follows:
 - The GIT SHA of the node
 - The node's ID
 - The crc of the device's config CBOR map (see above)
+
+### Power Information Timing Service
+A service to provide a node information on how long the bus will be on,
+the time remaining for the bus to be on,
+and the upcoming off time.
+This service is available on the following topic: `bus_power_controller/timing`.
+Power information timing is reported in the following format when requested:
+
+```
+    {
+      "total_on_s": 310,
+      "remaining_on_s": 121,
+      ”upcoming_off_s”: 1500
+    }
+```
+
+This information is useful to ensure that critical operations on a node will be finalized before the power turns off.

--- a/docs/reference/middleware.md
+++ b/docs/reference/middleware.md
@@ -69,9 +69,9 @@ the system information provided from a node is as follows:
 - The crc of the device's config CBOR map (see above)
 
 ### Power Information Timing Service
-A service to provide a node information on how long the bus will be on,
-the time remaining for the bus to be on,
-and the upcoming off time.
+A service to provide a node information total time the bus power will be on,
+the time remaining for the bus power to be on,
+and the upcoming time the bus power will be off.
 This service is available on the following topic: `bus_power_controller/timing`.
 Power information timing is reported in the following format when requested:
 

--- a/middleware/CMakeLists.txt
+++ b/middleware/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
     config_cbor_map_service.c
     echo_service.c
     middleware.c
+    power_info_service.c
     pubsub.c
     sys_info_service.c
 )

--- a/middleware/bm_service.h
+++ b/middleware/bm_service.h
@@ -14,14 +14,16 @@ extern "C" {
   (BM_TOPIC_MAX_LEN - 4) // 4 is from strlen(BM_SERVICE_REQ_STR)
 
 /*!
- * @brief Callback function for bm_service
- * @param[in] service_strlen The length of the service string.
- * @param[in] service The service string.
- * @param[in] req_data_len The length of the request data.
- * @param[in] req_data The request data.
- * @param[in,out] buffer_len Passed in, this param is the size of the data buffer. On return, this param is the length of the reply data.
- * @param[out] reply_data The reply data buffer to be filled in.
- * @return True if the request was handled, false otherwise.
+  @brief Callback function for bm_service
+
+  @param[in] service_strlen The length of the service string.
+  @param[in] service The service string.
+  @param[in] req_data_len The length of the request data.
+  @param[in] req_data The request data.
+  @param[in,out] buffer_len Passed in, this param is the size of the data buffer. On return, this param is the length of the reply data.
+  @param[out] reply_data The reply data buffer to be filled in.
+
+  @return True if the request was handled, false otherwise.
  */
 typedef bool (*BmServiceHandler)(size_t service_strlen, const char *service,
                                  size_t req_data_len, uint8_t *req_data,

--- a/middleware/power_info_service.c
+++ b/middleware/power_info_service.c
@@ -1,0 +1,165 @@
+#include "power_info_service.h"
+#include "bm_config.h"
+#include "bm_os.h"
+#include "bm_service.h"
+#include "bm_service_request.h"
+#include "cb_queue.h"
+#include <inttypes.h>
+#include <string.h>
+
+#define bus_power_service "bus_power_controller"
+#define power_info_service_suffix "/timing"
+#define power_info_service bus_power_service power_info_service_suffix
+
+typedef struct {
+  BmPowerInfoStatsCb power_cb;
+  void *arg;
+} PowerInfoServiceCtx;
+
+static BmCbQueue service_queue = {0};
+static PowerInfoServiceCtx service_ctx = {0};
+
+/*!
+  @brief Callback Handler For "bus_power_controller/timing/req" Topic
+
+  @details Responsible for obtaining the power information via a callback
+           and CBOR encoding that information to be sent on the
+           "bus_power_controller/timing/rep" topic
+
+  @param service_strlen service string length
+  @param service service string
+  @param req_data_len length of data for request
+  @param req_data data for the request (unused, should not have any data)
+  @param buffer_len length of reply data buffer
+  @param reply_data reply data buffer
+
+  @return true on success, false on failure
+ */
+static bool power_info_request_cb(size_t service_strlen, const char *service,
+                                  size_t req_data_len, uint8_t *req_data,
+                                  size_t *buffer_len, uint8_t *reply_data) {
+  bool ret = false;
+  PowerInfoReplyData d = {0};
+  size_t encoded_len = 0;
+  (void)(req_data);
+
+  bm_debug("Data received on service: %.*s\n", (int)service_strlen, service);
+
+  if (!req_data_len) {
+    if (service_ctx.power_cb) {
+      d = service_ctx.power_cb(service_ctx.arg);
+      if (power_info_reply_encode(&d, reply_data, *buffer_len, &encoded_len) ==
+          CborNoError) {
+        *buffer_len = encoded_len;
+        ret = true;
+      } else {
+        bm_debug("Could not properly encode data on service\n");
+      }
+    } else {
+      bm_debug("Callback invalid, cannot reply on service\n");
+    }
+  } else {
+    bm_debug("Invalid data received on %.*s\n", (int)service_strlen, service);
+  }
+
+  return ret;
+}
+
+/*!
+  @brief Callback Handler For "bus_power_controller/timing/rep" Topic
+
+  @details This is responsible for handling replies from the service request 
+           to the "bus_power_controller/timing/req" topic. If a timeout did
+           not occur, will invoke a callback passed into the
+           power_info_service_request function.
+
+  @param ack whether a reply was received or not
+  @param msg_id id of message sent
+  @param service_strlen service string length
+  @param service service string
+  @param reply_len reply buffer length
+  @param reply_data reply buffer to be decoded
+
+  @return true if message was handled properly, false if it was not
+ */
+static bool power_info_reply_cb(bool ack, uint32_t msg_id,
+                                size_t service_strlen, const char *service,
+                                size_t reply_len, uint8_t *reply_data) {
+  bool ret = false;
+  (void)msg_id;
+
+  PowerInfoReplyData d = {0};
+  if (ack &&
+      power_info_reply_decode(&d, reply_data, reply_len) == CborNoError) {
+    bm_debug("Service: %.*s\n", (int)service_strlen, service);
+    bm_debug("Reply: \n");
+    bm_debug(" * total_on_s: %" PRIu32 "\n", d.total_on_s);
+    bm_debug(" * remaining_on_s: %" PRIu32 "\n", d.remaining_on_s);
+    bm_debug(" * upcoming_off_s: %" PRIu32 "\n", d.upcoming_off_s);
+    ret = true;
+  } else {
+    bm_debug("Power info service request failure, ack: %d\n", ack);
+  }
+
+  ret = queue_cb_dequeue(&service_queue, &d, ret) == BmOK;
+
+  return ret;
+}
+
+/*!
+  @brief Initialize The Power Information Timing Service
+
+  @details Registers a service that informs other nodes on the network of
+           the timing information for the power on the network. This
+           information has the following layout:
+
+           {
+             "total_on_s": 310,
+             "remaining_on_s": 121,
+             ”upcoming_off_s”: 1500
+           }
+
+  @param power_cb callback necessary to obtain power info timing on the network
+  @param arg argument to pass to callback function
+
+  @return BmOK on success, BmErr on failure
+ */
+BmErr power_info_service_init(BmPowerInfoStatsCb power_cb, void *arg) {
+  BmErr err = BmEINVAL;
+
+  if (power_cb) {
+    err = bm_service_register(strlen(power_info_service), power_info_service,
+                              power_info_request_cb) == true
+              ? BmOK
+              : BmECANCELED;
+    service_ctx.power_cb = power_cb;
+    service_ctx.arg = arg;
+  }
+
+  return err;
+}
+
+/*!
+  @brief Make A Power Information Timing Request
+
+  @details Makes a request on the "bus_power_controller/timing/rep" topic and
+           invokes a callback if a reply was received.
+
+  @param reply_cb callback function if a reply is received
+  @param timeout_s timeout in seconds to wait for reply
+
+  @return BmOK on success, BmErr on failure
+ */
+BmErr power_info_service_request(BmPowerInfoReplyCb reply_cb,
+                                 uint32_t timeout_s) {
+  BmErr err = queue_cb_enqueue(&service_queue, (BmQueueCb)reply_cb);
+
+  if (err == BmOK) {
+    err = bm_service_request(strlen(power_info_service), power_info_service, 0,
+                             NULL, power_info_reply_cb, timeout_s) == true
+              ? BmOK
+              : BmEBADMSG;
+  }
+
+  return err;
+}

--- a/middleware/power_info_service.h
+++ b/middleware/power_info_service.h
@@ -1,0 +1,22 @@
+#ifndef __POWER_INFO_SERVICE_H__
+#define __POWER_INFO_SERVICE_H__
+
+#include "power_info_reply_msg.h"
+#include "util.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef BmErr (*BmPowerInfoReplyCb)(const PowerInfoReplyData *d);
+typedef PowerInfoReplyData (*BmPowerInfoStatsCb)(void *arg);
+
+BmErr power_info_service_init(BmPowerInfoStatsCb power_cb, void *arg);
+BmErr power_info_service_request(BmPowerInfoReplyCb reply_cb,
+                                 uint32_t timeout_s);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -102,10 +102,23 @@ set (ALIGNED_MALLOC_TEST_SRCS
     # File we are testing
     ${COMMON_DIR}/aligned_malloc.c
 
-    # Supporting files
+    # Stubs
     ${STUB_DIR}/bm_os_stub.c
 )
 create_gtest("aligned_malloc" "${ALIGNED_MALLOC_TEST_SRCS}")
+
+# Callback Queue unit tests
+set (CB_QUEUE_TEST_SRCS
+    # File we are testing
+    ${COMMON_DIR}/cb_queue.c
+
+    # Supporting Files
+    ${COMMON_DIR}/ll.c
+
+    # Stubs
+    ${STUB_DIR}/bm_os_stub.c
+)
+create_gtest("cb_queue" "${CB_QUEUE_TEST_SRCS}")
 
 # PACKET TESTS
 set (PACKET_SRCS
@@ -375,6 +388,20 @@ set (CONFIG_CBOR_MAP_SRCS
     ${STUB_DIR}/device_stub.c
 )
 create_gtest("config_cbor_map_service" "${CONFIG_CBOR_MAP_SRCS}")
+
+# POWER_INFO TESTS
+set (POWER_INFO_SRCS
+    # File we're testing
+    ${MIDDLEWARE_DIR}/power_info_service.c
+
+    # Stubs
+    ${STUB_DIR}/bm_os_stub.c
+    ${STUB_DIR}/bm_service_stub.c
+    ${STUB_DIR}/bm_service_request_stub.c
+    ${STUB_DIR}/cb_queue_stub.c
+    ${STUB_DIR}/power_info_reply_msg_stub.c
+)
+create_gtest("power_info_service" "${POWER_INFO_SRCS}")
 
 # SYS INFO SERVICE TESTS
 set (SYS_INFO_SERVICE_SRCS

--- a/test/mocks/mock_cb_queue.h
+++ b/test/mocks/mock_cb_queue.h
@@ -1,0 +1,5 @@
+#include "cb_queue.h"
+#include "fff.h"
+
+DECLARE_FAKE_VALUE_FUNC(BmErr, queue_cb_enqueue, BmCbQueue *, BmQueueCb);
+DECLARE_FAKE_VALUE_FUNC(BmErr, queue_cb_dequeue, BmCbQueue *, void *, bool);

--- a/test/mocks/mock_power_info_reply_msg.h
+++ b/test/mocks/mock_power_info_reply_msg.h
@@ -1,0 +1,7 @@
+#include "fff.h"
+#include "power_info_reply_msg.h"
+
+DECLARE_FAKE_VALUE_FUNC(CborError, power_info_reply_encode,
+                        PowerInfoReplyData *, uint8_t *, size_t, size_t *);
+DECLARE_FAKE_VALUE_FUNC(CborError, power_info_reply_decode,
+                        PowerInfoReplyData *, const uint8_t *, size_t);

--- a/test/mocks/mock_power_info_service.h
+++ b/test/mocks/mock_power_info_service.h
@@ -1,0 +1,8 @@
+#include "fff.h"
+#include "power_info_reply_msg.h"
+#include "power_info_service.h"
+
+DECLARE_FAKE_VALUE_FUNC(BmErr, power_info_service_init, BmPowerInfoStatsCb,
+                        void *);
+DECLARE_FAKE_VALUE_FUNC(BmErr, power_info_service_request, BmPowerInfoReplyCb,
+                        uint32_t);

--- a/test/src/cb_queue_test.cpp
+++ b/test/src/cb_queue_test.cpp
@@ -1,0 +1,82 @@
+#include "fff.h"
+#include "gtest/gtest.h"
+#include <helpers.hpp>
+
+DEFINE_FFF_GLOBALS;
+
+extern "C" {
+#include "cb_queue.h"
+}
+
+static uint16_t CB_COUNT = 0;
+static uint32_t TEST_ARG = 0;
+
+static BmErr cb_ok(const void *arg) {
+  BmErr err = BmOK;
+  uint32_t cmp_val = *(uint32_t *)arg;
+  CB_COUNT++;
+  EXPECT_EQ(cmp_val, TEST_ARG);
+  return err;
+}
+
+static BmErr cb_fail(const void *arg) { return BmEBADMSG; }
+
+TEST(CbQueue, enqueue_dequeue_ok) {
+  BmCbQueue q = {};
+  rnd_gen RND;
+  uint16_t queue_size = (uint16_t)RND.rnd_int(UINT16_MAX, 1000);
+
+  // Test NULL cbs
+  for (uint32_t i = 0; i < queue_size; i++) {
+    ASSERT_EQ(queue_cb_enqueue(&q, NULL), BmOK);
+  }
+  for (uint32_t i = 0; i < queue_size; i++) {
+    ASSERT_EQ(queue_cb_dequeue(&q, &TEST_ARG, true), BmOK);
+  }
+  ASSERT_EQ(CB_COUNT, 0);
+
+  // Test successful cbs
+  for (uint32_t i = 0; i < queue_size; i++) {
+    ASSERT_EQ(queue_cb_enqueue(&q, cb_ok), BmOK);
+  }
+  for (uint32_t i = 0; i < queue_size; i++) {
+    TEST_ARG = (uint32_t)RND.rnd_int(UINT32_MAX, 0);
+    ASSERT_EQ(queue_cb_dequeue(&q, &TEST_ARG, true), BmOK);
+  }
+  ASSERT_EQ(CB_COUNT, queue_size);
+
+  // Test not invoking callbacks
+  for (uint32_t i = 0; i < queue_size; i++) {
+    ASSERT_EQ(queue_cb_enqueue(&q, cb_ok), BmOK);
+  }
+  for (uint32_t i = 0; i < queue_size; i++) {
+    TEST_ARG = (uint32_t)RND.rnd_int(UINT32_MAX, 0);
+    ASSERT_EQ(queue_cb_dequeue(&q, &TEST_ARG, false), BmOK);
+  }
+  ASSERT_EQ(CB_COUNT, queue_size);
+
+  // Cleanup
+  CB_COUNT = 0;
+  TEST_ARG = 0;
+}
+
+TEST(CbQueue, enqueue_dequeue_fail) {
+  BmCbQueue q = {};
+  rnd_gen RND;
+  uint16_t queue_size = (uint16_t)RND.rnd_int(UINT16_MAX, 1000);
+
+  // Test dequeueing when there is nothing in the queue
+  for (uint32_t i = 0; i < queue_size; i++) {
+    ASSERT_EQ(queue_cb_enqueue(&q, NULL), BmOK);
+  }
+  for (uint32_t i = 0; i < queue_size; i++) {
+    ASSERT_EQ(queue_cb_dequeue(&q, &TEST_ARG, false), BmOK);
+  }
+  for (uint32_t i = 0; i < queue_size; i++) {
+    ASSERT_EQ(queue_cb_dequeue(&q, &TEST_ARG, false), BmECANCELED);
+  }
+
+  // Test callback failure
+  ASSERT_EQ(queue_cb_enqueue(&q, cb_fail), BmOK);
+  ASSERT_EQ(queue_cb_dequeue(&q, NULL, true), BmEBADMSG);
+}

--- a/test/src/power_info_service_test.cpp
+++ b/test/src/power_info_service_test.cpp
@@ -1,0 +1,60 @@
+#include <gtest/gtest.h>
+#include <helpers.hpp>
+
+#include "fff.h"
+
+DEFINE_FFF_GLOBALS;
+
+extern "C" {
+#include "mock_bm_service.h"
+#include "mock_bm_service_request.h"
+#include "mock_cb_queue.h"
+}
+
+#include "power_info_service.h"
+
+class PowerInfoService : public ::testing::Test {
+
+protected:
+  PowerInfoService() {}
+  ~PowerInfoService() override {}
+  void SetUp() override {}
+  void TearDown() override {}
+  static PowerInfoReplyData data_cb(void *arg) {
+    PowerInfoReplyData d = {};
+    return d;
+  }
+};
+
+TEST_F(PowerInfoService, init) {
+  // Test initialization failures
+  ASSERT_EQ(power_info_service_init(NULL, NULL), BmEINVAL);
+
+  bm_service_register_fake.return_val = false;
+  ASSERT_EQ(power_info_service_init(data_cb, NULL), BmECANCELED);
+  RESET_FAKE(bm_service_register);
+
+  // Test initialization success
+  bm_service_register_fake.return_val = true;
+  ASSERT_EQ(power_info_service_init(data_cb, NULL), BmOK);
+  RESET_FAKE(bm_service_register);
+}
+
+TEST_F(PowerInfoService, request) {
+  // Test request failures
+  queue_cb_enqueue_fake.return_val = BmEINVAL;
+  EXPECT_EQ(power_info_service_request(NULL, 1), BmEINVAL);
+  RESET_FAKE(queue_cb_enqueue);
+  queue_cb_enqueue_fake.return_val = BmOK;
+  bm_service_request_fake.return_val = false;
+  EXPECT_EQ(power_info_service_request(NULL, 1), BmEBADMSG);
+  RESET_FAKE(queue_cb_enqueue);
+  RESET_FAKE(bm_service_request);
+
+  // Test request success
+  queue_cb_enqueue_fake.return_val = BmOK;
+  bm_service_request_fake.return_val = true;
+  EXPECT_EQ(power_info_service_request(NULL, 1), BmOK);
+  RESET_FAKE(queue_cb_enqueue);
+  RESET_FAKE(bm_service_request);
+}

--- a/test/stubs/cb_queue_stub.c
+++ b/test/stubs/cb_queue_stub.c
@@ -1,0 +1,4 @@
+#include "mock_cb_queue.h"
+
+DEFINE_FAKE_VALUE_FUNC(BmErr, queue_cb_enqueue, BmCbQueue *, BmQueueCb);
+DEFINE_FAKE_VALUE_FUNC(BmErr, queue_cb_dequeue, BmCbQueue *, void *, bool);

--- a/test/stubs/power_info_reply_msg_stub.c
+++ b/test/stubs/power_info_reply_msg_stub.c
@@ -1,0 +1,6 @@
+#include "mock_power_info_reply_msg.h"
+
+DEFINE_FAKE_VALUE_FUNC(CborError, power_info_reply_encode, PowerInfoReplyData *,
+                       uint8_t *, size_t, size_t *);
+DEFINE_FAKE_VALUE_FUNC(CborError, power_info_reply_decode, PowerInfoReplyData *,
+                       const uint8_t *, size_t);

--- a/test/stubs/power_info_service_stub.c
+++ b/test/stubs/power_info_service_stub.c
@@ -1,0 +1,6 @@
+#include "mock_power_info_service.h"
+
+DEFINE_FAKE_VALUE_FUNC(BmErr, power_info_service_init, BmPowerInfoStatsCb,
+                       void *);
+DEFINE_FAKE_VALUE_FUNC(BmErr, power_info_service_request, BmPowerInfoReplyCb,
+                       uint32_t);


### PR DESCRIPTION
## What changed?
- Adds power info timing service to inform nodes of how long the bus will be on, off and time left before the bus powers down
- Adds a cb queue module for queueing/dequeuing callbacks for general purpose
Adds unit tests for new modules
- Updates documentation of new power info timing service
- Adds unit tests for new modules


## How does it make Bristlemouth better?
This helps informs nodes downstream from the network's power source how long they will have to complete critical operations!
Saving/writing to files, performing atomic operations, etc.

Adds new callback queue module that has many use cases in `bm_core` and can help reduce code in some spots (example: `info.c` in `bcmp`)

## Where should reviewers focus?
One thing I wanted to provide the user of this module with is a nice callback function when creating a request for the power info timing service, see: `BmPowerInfoReplyCb` which has one function parameter.
Typically the `BmServiceReplyCb` is utilized in service requests, which has 6 parameters for the user to parse and try to grok. Let me know your thoughts on this shift in paradigm.


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
