### PR TITLE
Add Undefined Macro To Power Info Timing Service

### DIFF
--- a/docs/reference/middleware.md
+++ b/docs/reference/middleware.md
@@ -84,3 +84,14 @@ Power information timing is reported in the following format when requested:
 ```
 
 This information is useful to ensure that critical operations on a node will be finalized before the power turns off.
+If one of the values are undefined,
+it is standard to indicate this by utilizing the macro `POWER_SERVICE_UNDEFINED`.
+When an undefined value is given,
+it is the responsibility of the requestor to handle this accordingly.
+For example,
+if `upcoming_off_s` is equivalent to `POWER_SERVICE_UNDEFINED`,
+then the requestor should prepare for the power to potentially never return.
+Another example of this is if the power is on indefinitely for the time being,
+`POWER_SERVICE_UNDEFINED` shall be used to indicate that there is a potential for the bus power timing to change.
+In this use case,
+the requestor should continue to request the service to ensure this value does not change.

--- a/middleware/power_info_service.h
+++ b/middleware/power_info_service.h
@@ -4,6 +4,8 @@
 #include "power_info_reply_msg.h"
 #include "util.h"
 
+#define POWER_SERVICE_UNDEFINED UINT32_MAX
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
## What changed?
Adds undefined macro and updates documentation with use cases for this macro


## How does it make Bristlemouth better?
Allows service to utilize macro for undefined situations and adds documentation to indicate its usage.


## Where should reviewers focus?
Documentation clarity mainly.


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
