### PR TITLE
Standardizes A bm_core IP Address Format

### DIFF
--- a/bcmp/bcmp.c
+++ b/bcmp/bcmp.c
@@ -143,7 +143,7 @@ void *bcmp_get_queue(void) { return CTX.queue; }
   @return BmOK on success
   @return BmErr on failure
 */
-BmErr bcmp_tx(const void *dst, BcmpMessageType type, uint8_t *data,
+BmErr bcmp_tx(const BmIpAddr *dst, BcmpMessageType type, uint8_t *data,
               uint16_t size, uint32_t seq_num,
               BmErr (*reply_cb)(uint8_t *payload)) {
   BmErr err = BmEINVAL;
@@ -211,7 +211,7 @@ BmErr bcmp_ll_forward(BcmpHeader *header, void *payload, uint32_t size,
       header->checksum = packet_checksum(forward, size + sizeof(BcmpHeader));
       bm_ip_tx_copy(forward, header, sizeof(BcmpHeader), 0);
 
-      err = bm_ip_tx_perform(forward, &port_specific_dst);
+      err = bm_ip_tx_perform(forward, (BmIpAddr *)&port_specific_dst);
       if (err != BmOK) {
         bm_debug("Error forwarding BMCP packet link-locally: %d\n", err);
       }

--- a/bcmp/bcmp.h
+++ b/bcmp/bcmp.h
@@ -25,7 +25,7 @@ typedef struct {
 
 BmErr bcmp_init(NetworkDevice network_device);
 void *bcmp_get_queue(void);
-BmErr bcmp_tx(const void *dst, BcmpMessageType type, uint8_t *data,
+BmErr bcmp_tx(const BmIpAddr *dst, BcmpMessageType type, uint8_t *data,
               uint16_t size, uint32_t seq_num,
               BmErr (*reply_cb)(uint8_t *payload));
 BmErr bcmp_ll_forward(BcmpHeader *header, void *data, uint32_t size,

--- a/bcmp/packet.h
+++ b/bcmp/packet.h
@@ -6,13 +6,13 @@ typedef struct {
   BcmpHeader *header;
   uint8_t *payload;
   uint32_t size;
-  void *src;
-  void *dst;
+  BmIpAddr *src;
+  BmIpAddr *dst;
   uint8_t ingress_port;
 } BcmpProcessData;
 
 typedef void *(*BcmpGetData)(void *payload);
-typedef void *(*BcmpGetIPAddr)(void *payload);
+typedef BmIpAddr *(*BcmpGetIPAddr)(void *payload);
 typedef uint16_t (*BcmpGetChecksum)(void *payload, uint32_t size);
 typedef BmErr (*BcmpProcessCb)(BcmpProcessData data);
 typedef BmErr (*BcmpSequencedRequestCb)(uint8_t *payload);

--- a/common/util.c
+++ b/common/util.c
@@ -1,8 +1,42 @@
 #include "util.h"
 #include <stdint.h>
 
-const bm_ip_addr multicast_global_addr = {{0x3FF, 0x0, 0x0, 0x1000000}, 0};
-const bm_ip_addr multicast_ll_addr = {{0x2FF, 0x0, 0x0, 0x1000000}, 0};
+const BmIpAddr multicast_global_addr = {{
+    0xFF,
+    0x03,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x01,
+}};
+const BmIpAddr multicast_ll_addr = {{
+    0xFF,
+    0x02,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x01,
+}};
 
 uint32_t time_remaining(uint32_t start, uint32_t current, uint32_t timeout) {
   int32_t remaining = (int32_t)((start + timeout) - current);
@@ -14,26 +48,24 @@ uint32_t time_remaining(uint32_t start, uint32_t current, uint32_t timeout) {
   return remaining;
 }
 
-bool is_global_multicast(const uint8_t *dst_ip) {
+bool is_global_multicast(const BmIpAddr *dst_ip) {
   bool is_global_multi = false;
   if (dst_ip != NULL) {
     // Global multicast address is FF03::1
-    uint8_t *global_multi_bytes = (uint8_t *)&multicast_global_addr;
-    is_global_multi = dst_ip[0] == global_multi_bytes[0] && // FF
-                      dst_ip[1] == global_multi_bytes[1] && // 03
-                      dst_ip[15] == global_multi_bytes[15]; // 01
+    is_global_multi = dst_ip->addr[0] == multicast_global_addr.addr[0] && // FF
+                      dst_ip->addr[1] == multicast_global_addr.addr[1] && // 03
+                      dst_ip->addr[15] == multicast_global_addr.addr[15]; // 01
   }
   return is_global_multi;
 }
 
-bool is_link_local_multicast(const uint8_t *dst_ip) {
+bool is_link_local_multicast(const BmIpAddr *dst_ip) {
   bool is_ll_multi = false;
   if (dst_ip != NULL) {
     // Link-local multicast address is FF02::1
-    uint8_t *ll_multi_bytes = (uint8_t *)&multicast_ll_addr;
-    is_ll_multi = dst_ip[0] == ll_multi_bytes[0] && // FF
-                  dst_ip[1] == ll_multi_bytes[1] && // 02
-                  dst_ip[15] == ll_multi_bytes[15]; // 01
+    is_ll_multi = dst_ip->addr[0] == multicast_ll_addr.addr[0] && // FF
+                  dst_ip->addr[1] == multicast_ll_addr.addr[1] && // 02
+                  dst_ip->addr[15] == multicast_ll_addr.addr[15]; // 01
   }
   return is_ll_multi;
 }

--- a/common/util.h
+++ b/common/util.h
@@ -94,17 +94,15 @@ void date_time_from_utc(uint64_t utc_us, UtcDateTime *date_time);
     }                                                                          \
   }
 
-//TODO: this is a placeholder until ip addresses are figured out
 typedef struct {
-  uint32_t addr[4];
-  uint8_t reserved;
-} bm_ip_addr;
+  uint8_t addr[16];
+} BmIpAddr;
 
-extern const bm_ip_addr multicast_global_addr;
-extern const bm_ip_addr multicast_ll_addr;
+extern const BmIpAddr multicast_global_addr;
+extern const BmIpAddr multicast_ll_addr;
 
-bool is_global_multicast(const uint8_t *dst_ip);
-bool is_link_local_multicast(const uint8_t *dst_ip);
+bool is_global_multicast(const BmIpAddr *dst_ip);
+bool is_link_local_multicast(const BmIpAddr *dst_ip);
 bool is_little_endian(void);
 void swap_16bit(void *x);
 void swap_32bit(void *x);
@@ -126,7 +124,7 @@ static inline uint32_t uint8_to_uint32(uint8_t *buf) {
   \param *ip address to extract node id from
   \return node id
 */
-static inline uint64_t ip_to_nodeid(void *ip) {
+static inline uint64_t ip_to_nodeid(const BmIpAddr *ip) {
   uint32_t high_word = 0;
   uint32_t low_word = 0;
   if (ip && is_little_endian()) {

--- a/middleware/middleware.c
+++ b/middleware/middleware.c
@@ -138,7 +138,7 @@ BmErr bm_middleware_local_pub(void *buf, uint32_t size) {
 
   if (buf) {
     queue_item.buf = buf;
-    queue_item.node_id = ip_to_nodeid((void *)bm_ip_get(1));
+    queue_item.node_id = ip_to_nodeid(bm_ip_get(1));
     queue_item.size = size;
 
     // add one to reference count since we'll be using it in two places

--- a/network/bm_ip.h
+++ b/network/bm_ip.h
@@ -9,17 +9,17 @@ void bm_l2_free(void *buf);
 BmErr bm_l2_submit(void *buf, uint32_t size);
 BmErr bm_l2_set_netif(bool up);
 const char *bm_ip_get_str(uint8_t idx);
-const void *bm_ip_get(uint8_t idx);
+const BmIpAddr *bm_ip_get(uint8_t idx);
 void bm_ip_rx_cleanup(void *payload);
-void *bm_ip_tx_new(const void *dst, uint32_t size);
+void *bm_ip_tx_new(const BmIpAddr *dst, uint32_t size);
 BmErr bm_ip_tx_copy(void *payload, const void *data, uint32_t size,
                     uint32_t offset);
-BmErr bm_ip_tx_perform(void *payload, const void *dst);
+BmErr bm_ip_tx_perform(void *payload, const BmIpAddr *dst);
 void bm_ip_tx_cleanup(void *payload);
 void *bm_udp_bind_port(uint16_t port, BmErr (*cb)(void *, uint64_t, uint32_t));
 void *bm_udp_new(uint32_t size);
 void *bm_udp_get_payload(void *buf);
 BmErr bm_udp_reference_update(void *buf);
 void bm_udp_cleanup(void *buf);
-BmErr bm_udp_tx_perform(void *pcb, void *buf, uint32_t size, const void *addr,
-                        uint16_t port);
+BmErr bm_udp_tx_perform(void *pcb, void *buf, uint32_t size,
+                        const BmIpAddr *addr, uint16_t port);

--- a/network/bm_lwip.c
+++ b/network/bm_lwip.c
@@ -23,7 +23,7 @@
 #define ifname0 'b'
 #define ifname1 'm'
 #define ethernet_mtu 1500
-#define bm_ip_to_lwip_ip_compound(ip)                                          \
+#define bm_ip_to_lwip_ip(ip)                                                   \
   (&(const ip_addr_t){{ip_uint8_to_uint32((uint8_t *)&ip->addr[0]),            \
                        ip_uint8_to_uint32((uint8_t *)&ip->addr[4]),            \
                        ip_uint8_to_uint32((uint8_t *)&ip->addr[8]),            \
@@ -537,10 +537,9 @@ BmErr bm_ip_tx_perform(void *payload, const BmIpAddr *dst) {
   if (payload) {
     layout = (LwipLayout *)payload;
     err = raw_sendto_if_src(CTX.raw_pcb, layout->pbuf,
-                            dst == NULL ? bm_ip_to_lwip_ip_compound(layout->dst)
-                                        : bm_ip_to_lwip_ip_compound(dst),
-                            CTX.netif,
-                            bm_ip_to_lwip_ip_compound(layout->src)) == ERR_OK
+                            dst == NULL ? bm_ip_to_lwip_ip(layout->dst)
+                                        : bm_ip_to_lwip_ip(dst),
+                            CTX.netif, bm_ip_to_lwip_ip(layout->src)) == ERR_OK
               ? BmOK
               : BmEBADMSG;
   }
@@ -674,7 +673,7 @@ BmErr bm_udp_tx_perform(void *pcb, void *buf, uint32_t size,
 
   if (buf && pcb && dest_addr) {
     err = safe_udp_sendto_if((struct udp_pcb *)pcb, (struct pbuf *)buf,
-                             bm_ip_to_lwip_ip_compound(dest_addr), port,
+                             bm_ip_to_lwip_ip(dest_addr), port,
                              CTX.netif) == ERR_OK
               ? BmOK
               : BmEBADMSG;

--- a/network/l2.c
+++ b/network/l2.c
@@ -264,7 +264,8 @@ static void bm_l2_process_tx_evt(L2QueueElement *tx_evt) {
   }
 
   uint8_t *payload = (uint8_t *)bm_l2_get_payload(tx_evt->buf);
-  const uint8_t *dst_ip = &payload[ipv6_destination_address_offset];
+  const BmIpAddr *dst_ip =
+      (BmIpAddr *)&payload[ipv6_destination_address_offset];
   if (is_global_multicast(dst_ip)) {
     send_global_multicast_packet(payload, tx_evt->length, tx_evt->port_mask);
   } else if (is_link_local_multicast(dst_ip)) {
@@ -301,7 +302,8 @@ static void bm_l2_process_rx_evt(L2QueueElement *rx_evt) {
     return;
   }
 
-  const uint8_t *dst_ip = &payload[ipv6_destination_address_offset];
+  const BmIpAddr *dst_ip =
+      (BmIpAddr *)&payload[ipv6_destination_address_offset];
   if (is_global_multicast(dst_ip)) {
     clear_ingress_port(payload);
     const uint16_t new_ports_mask = CTX.all_ports_mask & ~(rx_evt->port_mask);

--- a/test/mocks/mock_bcmp.h
+++ b/test/mocks/mock_bcmp.h
@@ -6,7 +6,7 @@
 typedef BmErr (*BcmpReplyCb)(uint8_t *);
 
 DECLARE_FAKE_VALUE_FUNC(BmErr, bcmp_init, NetworkDevice);
-DECLARE_FAKE_VALUE_FUNC(BmErr, bcmp_tx, const void *, BcmpMessageType,
+DECLARE_FAKE_VALUE_FUNC(BmErr, bcmp_tx, const BmIpAddr *, BcmpMessageType,
                         uint8_t *, uint16_t, uint32_t, BcmpReplyCb)
 DECLARE_FAKE_VALUE_FUNC(BmErr, bcmp_ll_forward, BcmpHeader *, void *, uint32_t,
                         uint8_t);

--- a/test/mocks/mock_bm_ip.h
+++ b/test/mocks/mock_bm_ip.h
@@ -12,12 +12,12 @@ DECLARE_FAKE_VOID_FUNC(bm_l2_free, void *);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_l2_submit, void *, uint32_t);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_l2_set_netif, bool);
 DECLARE_FAKE_VALUE_FUNC(const char *, bm_ip_get_str, uint8_t);
-DECLARE_FAKE_VALUE_FUNC(const void *, bm_ip_get, uint8_t);
+DECLARE_FAKE_VALUE_FUNC(const BmIpAddr *, bm_ip_get, uint8_t);
 DECLARE_FAKE_VOID_FUNC(bm_ip_rx_cleanup, void *);
-DECLARE_FAKE_VALUE_FUNC(void *, bm_ip_tx_new, const void *, uint32_t);
+DECLARE_FAKE_VALUE_FUNC(void *, bm_ip_tx_new, const BmIpAddr *, uint32_t);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_ip_tx_copy, void *, const void *, uint32_t,
                         uint32_t);
-DECLARE_FAKE_VALUE_FUNC(BmErr, bm_ip_tx_perform, void *, const void *);
+DECLARE_FAKE_VALUE_FUNC(BmErr, bm_ip_tx_perform, void *, const BmIpAddr *);
 DECLARE_FAKE_VOID_FUNC(bm_ip_tx_cleanup, void *);
 DECLARE_FAKE_VALUE_FUNC(void *, bm_udp_bind_port, uint16_t, BmUdpPortBindCb);
 DECLARE_FAKE_VALUE_FUNC(void *, bm_udp_new, uint32_t);
@@ -25,4 +25,4 @@ DECLARE_FAKE_VALUE_FUNC(void *, bm_udp_get_payload, void *);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_udp_reference_update, void *);
 DECLARE_FAKE_VOID_FUNC(bm_udp_cleanup, void *);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_udp_tx_perform, void *, void *, uint32_t,
-                        const void *, uint16_t);
+                        const BmIpAddr *, uint16_t);

--- a/test/src/bcmp_test.cpp
+++ b/test/src/bcmp_test.cpp
@@ -71,12 +71,14 @@ TEST_F(Bcmp, init) {
 }
 
 TEST_F(Bcmp, bcmp_tx) {
-  const uint32_t dst = RND.rnd_int(UINT32_MAX, 1);
+  BmIpAddr dst = {0};
   const uint16_t size =
       RND.rnd_int(max_payload_len - sizeof(BcmpHeader), UINT8_MAX);
   BcmpMessageType type = (BcmpMessageType)RND.rnd_int(UINT8_MAX, 0);
   uint8_t seq_num = RND.rnd_int(UINT8_MAX, 0);
   uint8_t *data = (uint8_t *)bm_malloc(size);
+
+  RND.rnd_array((uint8_t *)&dst.addr[0], sizeof(BmIpAddr));
 
   // Test success
   bm_ip_tx_new_fake.return_val = data;

--- a/test/src/dfu_test.cpp
+++ b/test/src/dfu_test.cpp
@@ -1192,7 +1192,7 @@ TEST_F(BcmpDfu, forward_ll_msg_for_other) {
       .header = (BcmpHeader *)fwd_start_msg,
       .payload = (uint8_t *)fwd_start_msg,
       .size = sizeof(BcmpDfuStart),
-      .dst = (void *)&multicast_ll_addr,
+      .dst = (BmIpAddr *)&multicast_ll_addr,
   };
   dfu_copy_and_process_message(data);
   EXPECT_EQ(bcmp_ll_forward_fake.call_count, 1);
@@ -1205,7 +1205,7 @@ TEST_F(BcmpDfu, forward_ll_msg_for_other) {
 
   // Do not forward global multicast message not intended for this node
   // Already forwarded in L2 before being passed to BCMP
-  data.dst = (void *)&multicast_global_addr;
+  data.dst = (BmIpAddr *)&multicast_global_addr;
   fwd_start_msg->info.addresses.dst_node_id = other;
   dfu_copy_and_process_message(data);
   EXPECT_EQ(bcmp_ll_forward_fake.call_count, 0);

--- a/test/src/packet_test.cpp
+++ b/test/src/packet_test.cpp
@@ -29,8 +29,8 @@ class Packet : public ::testing::Test {
 public:
   typedef struct {
     uint8_t *payload;
-    uint32_t src_addr[4];
-    uint32_t dst_addr[4];
+    uint8_t src_addr[16];
+    uint8_t dst_addr[16];
   } PacketTestData;
   uint8_t *test_payload;
   size_t test_payload_size;
@@ -42,13 +42,13 @@ protected:
     PacketTestData *ret = (PacketTestData *)payload;
     return (void *)ret->payload;
   }
-  static void *src_ip(void *payload) {
+  static BmIpAddr *src_ip(void *payload) {
     PacketTestData *ret = (PacketTestData *)payload;
-    return (void *)ret->src_addr;
+    return (BmIpAddr *)&ret->src_addr;
   }
-  static void *dst_ip(void *payload) {
+  static BmIpAddr *dst_ip(void *payload) {
     PacketTestData *ret = (PacketTestData *)payload;
-    return (void *)ret->dst_addr;
+    return (BmIpAddr *)&ret->dst_addr;
   }
   static uint16_t calc_checksum(void *payload, uint32_t size) {
     if (fail_checksum) {

--- a/test/stubs/bcmp_stub.c
+++ b/test/stubs/bcmp_stub.c
@@ -1,8 +1,8 @@
 #include "mock_bcmp.h"
 
 DEFINE_FAKE_VALUE_FUNC(BmErr, bcmp_init, NetworkDevice);
-DEFINE_FAKE_VALUE_FUNC(BmErr, bcmp_tx, const void *, BcmpMessageType, uint8_t *,
-                       uint16_t, uint32_t, BcmpReplyCb)
+DEFINE_FAKE_VALUE_FUNC(BmErr, bcmp_tx, const BmIpAddr *, BcmpMessageType,
+                       uint8_t *, uint16_t, uint32_t, BcmpReplyCb)
 DEFINE_FAKE_VALUE_FUNC(BmErr, bcmp_ll_forward, BcmpHeader *, void *, uint32_t,
                        uint8_t);
 DEFINE_FAKE_VOID_FUNC(bcmp_link_change, uint8_t, bool);

--- a/test/stubs/bm_ip_stub.c
+++ b/test/stubs/bm_ip_stub.c
@@ -9,12 +9,12 @@ DEFINE_FAKE_VOID_FUNC(bm_l2_free, void *);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_l2_submit, void *, uint32_t);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_l2_set_netif, bool);
 DEFINE_FAKE_VALUE_FUNC(const char *, bm_ip_get_str, uint8_t);
-DEFINE_FAKE_VALUE_FUNC(const void *, bm_ip_get, uint8_t);
+DEFINE_FAKE_VALUE_FUNC(const BmIpAddr *, bm_ip_get, uint8_t);
 DEFINE_FAKE_VOID_FUNC(bm_ip_rx_cleanup, void *);
-DEFINE_FAKE_VALUE_FUNC(void *, bm_ip_tx_new, const void *, uint32_t);
+DEFINE_FAKE_VALUE_FUNC(void *, bm_ip_tx_new, const BmIpAddr *, uint32_t);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_ip_tx_copy, void *, const void *, uint32_t,
                        uint32_t);
-DEFINE_FAKE_VALUE_FUNC(BmErr, bm_ip_tx_perform, void *, const void *);
+DEFINE_FAKE_VALUE_FUNC(BmErr, bm_ip_tx_perform, void *, const BmIpAddr *);
 DEFINE_FAKE_VOID_FUNC(bm_ip_tx_cleanup, void *);
 DEFINE_FAKE_VALUE_FUNC(void *, bm_udp_bind_port, uint16_t, BmUdpPortBindCb);
 DEFINE_FAKE_VALUE_FUNC(void *, bm_udp_new, uint32_t);
@@ -22,4 +22,4 @@ DEFINE_FAKE_VALUE_FUNC(void *, bm_udp_get_payload, void *);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_udp_reference_update, void *);
 DEFINE_FAKE_VOID_FUNC(bm_udp_cleanup, void *);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_udp_tx_perform, void *, void *, uint32_t,
-                       const void *, uint16_t);
+                       const BmIpAddr *, uint16_t);


### PR DESCRIPTION
## What changed?
Changes lwip IP Address format to a 16 byte buffer rather than a buffer of 4 `uint32_t` values (to emulate LWIP).


## How does it make Bristlemouth better?
- Standardizes IP Address variable throughout 
- Simplifies IPv6 address handling


## Where should reviewers focus?
`bm_lwip.c` has changes that could be potentially breaking (I have tested and did not see any strange behavior across sending data/running bcmp CLI commands, etc.).


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
