### PR TITLE
Protects Against Configuration New Keys With Invalid Characters And Ability To Clear Partitions

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -29,7 +29,7 @@ jobs:
     - name: test
       working-directory: ./build
       run: |
-        ctest -C --output-on-failure --verbose
+        ctest --output-on-failure --verbose
     - name: setup python
       if: contains(matrix.os, 'ubuntu')
       uses: actions/setup-python@v4

--- a/bcmp/configuration.c
+++ b/bcmp/configuration.c
@@ -754,6 +754,7 @@ bool clear_partition(BmConfigPartition partition) {
 
     config_partition->header.numKeys = 0;
     config_partition->header.version = CONFIG_VERSION;
+    CONFIGS[partition].needs_commit = true;
   }
 
   return ret;
@@ -776,6 +777,7 @@ bool save_config(BmConfigPartition partition, bool restart) {
     if (restart) {
       bm_config_reset();
     }
+    CONFIGS[partition].needs_commit = false;
     ret = true;
   } while (0);
 
@@ -832,5 +834,11 @@ bool get_value_size(BmConfigPartition partition, const char *key,
 }
 
 bool needs_commit(BmConfigPartition partition) {
-  return CONFIGS[partition].needs_commit;
+  bool ret = false;
+
+  if (partition < BM_CFG_PARTITION_COUNT) {
+    ret = CONFIGS[partition].needs_commit;
+  }
+
+  return ret;
 }

--- a/bcmp/configuration.c
+++ b/bcmp/configuration.c
@@ -2,6 +2,7 @@
 #include "bm_config.h"
 #include "bm_configs_generic.h"
 #include "crc.h"
+#include <inttypes.h>
 #include <stdio.h>
 #ifndef CBOR_CUSTOM_ALLOC_INCLUDE
 #error "CBOR_CUSTOM_ALLOC_INCLUDE must be defined!"configuration.c
@@ -35,6 +36,34 @@ static bool find_key_idx(BmConfigPartition partition, const char *key,
   return ret;
 }
 
+/*!
+ @brief Determines if a key is valid or not
+
+ @details Key must have alphabetical or numerical numbers, key can also have
+          underscores and terminating characters
+
+ @param key Key to evaluate
+ @param key_len Length of key to evaluat
+
+ @return true if key is valid, false if key is not valid
+ */
+static inline bool is_key_valid(const char *key, uint32_t key_len) {
+  bool ret = true;
+
+  for (uint32_t i = 0; i < key_len; i++) {
+    if (!(key[i] >= '0' && key[i] <= '9') &&
+        !(key[i] >= 'a' && key[i] <= 'z') &&
+        !(key[i] >= 'A' && key[i] <= 'Z') && key[i] != '_' && key[i] != '\0') {
+      bm_debug("Improper character in key at index: %" PRIu32 "\n",
+               (uint32_t)i);
+      ret = false;
+      break;
+    }
+  }
+
+  return ret;
+}
+
 static bool prepare_cbor_encoder(BmConfigPartition partition, const char *key,
                                  size_t key_len, CborEncoder *encoder,
                                  uint8_t *key_idx, bool *key_exists) {
@@ -52,6 +81,9 @@ static bool prepare_cbor_encoder(BmConfigPartition partition, const char *key,
       }
       *key_exists = find_key_idx(partition, key, key_len, key_idx);
       if (!*key_exists) {
+        if (!is_key_valid(key, key_len)) {
+          break;
+        }
         *key_idx = config_partition->header.numKeys;
       }
       if (snprintf(config_partition->keys[*key_idx].key_buf,
@@ -560,6 +592,9 @@ bool set_config_cbor(BmConfigPartition partition, const char *key,
         break;
       }
       if (!find_key_idx(partition, key, key_len, &key_idx)) {
+        if (!is_key_valid(key, key_len)) {
+          break;
+        }
         if (config_partition->header.numKeys >= MAX_NUM_KV) {
           break;
         }
@@ -694,6 +729,31 @@ const char *data_type_enum_to_str(ConfigDataTypes type) {
   case ARRAY:
     ret = "array";
     break;
+  }
+
+  return ret;
+}
+
+/*!
+ @brief Clear a partition
+
+ @details Erases all keys and values in a partition.
+
+ @param partition Partition to erase
+
+ @return true if partition was successfully erased, false otherwise
+ */
+bool clear_partition(BmConfigPartition partition) {
+  bool ret = false;
+
+  if (partition < BM_CFG_PARTITION_COUNT) {
+    ConfigPartition *config_partition =
+        (ConfigPartition *)CONFIGS[partition].ram_buffer;
+    ret = true;
+    memset(config_partition, 0, sizeof(CONFIGS[partition].ram_buffer));
+
+    config_partition->header.numKeys = 0;
+    config_partition->header.version = CONFIG_VERSION;
   }
 
   return ret;

--- a/bcmp/configuration.h
+++ b/bcmp/configuration.h
@@ -76,6 +76,7 @@ const ConfigKey *get_stored_keys(BmConfigPartition partition,
                                  uint8_t *num_stored_keys);
 bool remove_key(BmConfigPartition partition, const char *key, size_t key_len);
 const char *data_type_enum_to_str(ConfigDataTypes type);
+bool clear_partition(BmConfigPartition partition);
 bool save_config(BmConfigPartition partition, bool restart);
 bool get_value_size(BmConfigPartition partition, const char *key,
                     size_t key_len, size_t *size);

--- a/bcmp/messages.h
+++ b/bcmp/messages.h
@@ -452,6 +452,20 @@ typedef struct {
   char key[0];
 } __attribute__((packed)) BmConfigDeleteKeyResponse;
 
+typedef struct {
+  BmConfigHeader header;
+  // Partition id
+  BmConfigPartition partition;
+} __attribute__((packed)) BmConfigClearRequest;
+
+typedef struct {
+  BmConfigHeader header;
+  // success
+  bool success;
+  // Partition id
+  BmConfigPartition partition;
+} __attribute__((packed)) BmConfigClearResponse;
+
 typedef enum {
   BcmpAckMessage = 0x00,
   BcmpHeartbeatMessage = 0x01,
@@ -490,6 +504,8 @@ typedef enum {
   BcmpConfigStatusResponseMessage = 0xA5,
   BcmpConfigDeleteRequestMessage = 0xA6,
   BcmpConfigDeleteResponseMessage = 0xA7,
+  BcmpConfigClearRequestMessage = 0xA8,
+  BcmpConfigClearResponseMessage = 0xA9,
 
   BcmpDFUStartMessage = 0xD0,
   BcmpDFUPayloadReqMessage = 0xD1,

--- a/bcmp/messages/config.h
+++ b/bcmp/messages/config.h
@@ -26,6 +26,9 @@ bool bcmp_config_status_request(uint64_t target_node_id,
 bool bcmp_config_del_key(uint64_t target_node_id, BmConfigPartition partition,
                          size_t key_len, const char *key,
                          BmErr (*reply_cb)(uint8_t *));
+bool bcmp_config_clear_partition(uint64_t target_node_id,
+                                 BmConfigPartition partition,
+                                 BmErr (*reply_cb)(uint8_t *));
 
 #ifdef __cplusplus
 }

--- a/bcmp/packet.c
+++ b/bcmp/packet.c
@@ -180,6 +180,8 @@ static void check_endianness(void *buf, BcmpMessageType type) {
     case BcmpConfigStatusResponseMessage:
     case BcmpConfigDeleteRequestMessage:
     case BcmpConfigDeleteResponseMessage:
+    case BcmpConfigClearRequestMessage:
+    case BcmpConfigClearResponseMessage:
     case BcmpDFUStartMessage:
     case BcmpDFUPayloadReqMessage:
     case BcmpDFUPayloadMessage:

--- a/docs/api/configs.md
+++ b/docs/api/configs.md
@@ -449,3 +449,23 @@ Public API supported by the BCMP configuration module is as follows:
 
   :returns: true if delete message is sent properly, false otherwise
 ```
+```{eval-rst}
+.. cpp:function:: bool bcmp_config_clear_partition(uint64_t target_node_id,
+                                 BmConfigPartition partition,
+                                 BmErr (*reply_cb)(uint8_t *));
+  Removes all keys from a partition
+
+  :param target_node_id: Target node id to remove configuration values from
+  :param partition: Partition to delete configuration values from
+  :param reply_cb: Callback when a reply is received over the bus, can be NULL
+                   the uint8_t buffer should be cast to BmConfigClearRequest * before
+                   use, ex:
+
+                   BmErr my_cb_function(uint8_t *data) {
+                     BmConfigClearRequest *msg = (BmConfigClearRequest *)data;
+
+                     // ... insert other logic here ...
+                   }
+
+  :return true if clear partition message is sent properly, false otherwise
+```

--- a/test/src/config_test.cpp
+++ b/test/src/config_test.cpp
@@ -210,3 +210,14 @@ TEST_F(Config, decode) {
   bm_free(bytes.set);
   bm_free(bytes.large_get);
 }
+
+TEST_F(Config, ClearPartitionRequest) {
+  uint64_t target_node_id = RND.rnd_int(UINT64_MAX, 0);
+
+  EXPECT_EQ(
+      bcmp_config_clear_partition(target_node_id, BM_CFG_PARTITION_USER, NULL),
+      true);
+  EXPECT_EQ(
+      bcmp_config_clear_partition(target_node_id, BM_CFG_PARTITION_COUNT, NULL),
+      false);
+}

--- a/test/src/configuration_test.cpp
+++ b/test/src/configuration_test.cpp
@@ -451,6 +451,9 @@ TEST_F(ConfigurationTest, ClearingPartition) {
   EXPECT_EQ(clear_partition(BM_CFG_PARTITION_SYSTEM), true);
   key_list = get_stored_keys(BM_CFG_PARTITION_SYSTEM, &num_keys);
   EXPECT_EQ(num_keys, 0);
+  EXPECT_EQ(needs_commit(BM_CFG_PARTITION_SYSTEM), true);
+  EXPECT_EQ(save_config(BM_CFG_PARTITION_SYSTEM, false), true);
+  EXPECT_EQ(needs_commit(BM_CFG_PARTITION_SYSTEM), false);
 
   // Test improper argument
   EXPECT_EQ(clear_partition(BM_CFG_PARTITION_COUNT), false);


### PR DESCRIPTION
## What changed?
Logic that prevents new keys in configuration from using invalid characters (non-alphanumeric or underscore)
Adds feature to clear a partition on a node (system/user/hardware)


## How does it make Bristlemouth better?
New keys for configuration key pair values may only be numeric or alphabetical characters with underscore characters which standardizes key names that can be used.
Allows wiping a whole partition to delete keys that cannot be accessed and adds a nice feature to the ecosystem.


## Where should reviewers focus?
`config.c` and `configuration.c` (maybe we should rename these someday?). These have the logic changes, there also is a new message added to `bcmp/messages.h` for clearing partitions.


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
