### PR TITLE
Updates bm_common_messages reference and prevents double free on an item

### DIFF
--- a/network/bm_lwip.c
+++ b/network/bm_lwip.c
@@ -362,6 +362,7 @@ BmErr bm_l2_submit(void *buf, uint32_t size) {
   // need for additional locking
   if (CTX.netif->input((struct pbuf *)buf, CTX.netif) != ERR_OK) {
     err = BmEBADMSG;
+    // Do not need to free memory here as it is handled in L2
   }
 
   return err;

--- a/network/bm_lwip.c
+++ b/network/bm_lwip.c
@@ -346,8 +346,10 @@ void bm_l2_free(void *buf) { pbuf_free((struct pbuf *)buf); }
 /*!
   @brief Submit A Buffer Up Bristlemouth Stack
 
-  @details This shall handle transmitted the L2 (raw) data up to
-           the bcmp and middleware implementations
+  @details This shall handle transmitting the L2 (raw) data up to
+           the bcmp and middleware implementations. L2 is responsible for
+           freeing any memory that might have been allocated if this function
+           returns an error.
 
   @param buf buffer created with bm_l2_new
   @param size size of buffer to submite up the stack in bytes

--- a/network/bm_lwip.c
+++ b/network/bm_lwip.c
@@ -362,7 +362,6 @@ BmErr bm_l2_submit(void *buf, uint32_t size) {
   // need for additional locking
   if (CTX.netif->input((struct pbuf *)buf, CTX.netif) != ERR_OK) {
     err = BmEBADMSG;
-    bm_l2_free(buf);
   }
 
   return err;


### PR DESCRIPTION
## What changed?
Updated bm_common_messages and fixed a double free condition that could occur on the L2 layer.


## How does it make Bristlemouth better?
Prevents the processor from crashing on a double free, adds new messages for BOREALIS, updates message structure for BOREALIS.

## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
