### PR TITLE
fix: a couple cppcheck errors

### DIFF
--- a/drivers/adin2111/adi_hal_port_specific.h
+++ b/drivers/adin2111/adi_hal_port_specific.h
@@ -35,7 +35,7 @@ extern "C" {
 #elif defined (__CC_ARM)
   /* Keil uses a decorator which is placed in the same position as pragmas */
   #define HAL_ALIGNED_ATTRIBUTE(num)
-  #define HAL_ALIGNED_PRAGMA(num) __align(##num)
+  #define HAL_ALIGNED_PRAGMA(num) __align(num)
   #define HAL_UNUSED_ATTRIBUTE ATTRIBUTE(unused)
 #else
 #error "Toolchain not supported"

--- a/integrations/spotter.c
+++ b/integrations/spotter.c
@@ -48,9 +48,11 @@ BmErr spotter_log(uint64_t target_node_id, const char *file_name,
   va_list va;
 
   do {
-    va_start(va, format);
     // check how long the string we are printing will be
+    va_start(va, format);
     int32_t data_len = vsnprintf(NULL, 0, format, va);
+    va_end(va);
+
     va_start(va, format);
     if (data_len == 0) {
       err = BmENODATA;

--- a/integrations/spotter.c
+++ b/integrations/spotter.c
@@ -45,15 +45,16 @@ BmErr spotter_log(uint64_t target_node_id, const char *file_name,
                   uint8_t print_time, const char *format, ...) {
   BmErr err = BmOK;
   bm_print_publication_t *printf_pub = NULL;
+
+  va_list va_len_check;
   va_list va;
+
+  va_start(va_len_check, format);
+  va_copy(va, va_len_check);
 
   do {
     // check how long the string we are printing will be
-    va_start(va, format);
-    int32_t data_len = vsnprintf(NULL, 0, format, va);
-    va_end(va);
-
-    va_start(va, format);
+    int32_t data_len = vsnprintf(NULL, 0, format, va_len_check);
     if (data_len == 0) {
       err = BmENODATA;
       break;
@@ -116,6 +117,7 @@ BmErr spotter_log(uint64_t target_node_id, const char *file_name,
   } while (0);
 
   va_end(va);
+  va_end(va_len_check);
 
   if (printf_pub) {
     bm_free(printf_pub);


### PR DESCRIPTION
## What changed?

I happened to be watching a webinar that mentioned static analysis briefly. So I just ran cppcheck on more of the Bristlemouth codebase than we usually do and looked more closely at the output. It found a couple small things that were easy to fix.

First this misuse of the token-pasting operator:

```
bm_protocol/src/lib/bm_core/drivers/adin2111/adi_hal_port_specific.h:38:0: error: failed to expand 'DMA_BUFFER_ALIGN', Invalid ## usage when expanding 'HAL_ALIGNED_PRAGMA': Unexpected token '(' [preprocessorErrorDirective]
  #define HAL_ALIGNED_PRAGMA(num) __align(##num)
^
```

Second, this misuse of a variable argument list:

```
bm_protocol/src/lib/bm_core/integrations/spotter.c:54:5: error: va_start() or va_copy() called subsequently on 'va' without va_end() in between. [va_start_subsequentCalls]
    va_start(va, format);
    ^
```

## How does it make Bristlemouth better?

Small improvements in code quality and preventing undefined behavior.

## Where should reviewers focus?

Can you see any way these changes would cause problems?

## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
