### PR TITLE
Hot Swapping Nodes Will Replace Ports That Are Already Populated

### DIFF
--- a/bcmp/neighbors.c
+++ b/bcmp/neighbors.c
@@ -14,7 +14,7 @@
 #define bcmp_table_max_len 1024
 
 // Pointer to neighbor linked-list
-static BcmpNeighbor *NEIGHBORS;
+static BcmpNeighbor *NEIGHBORS = NULL;
 static uint8_t NUM_NEIGHBORS = 0;
 static NeighborDiscoveryCallback NEIGHBOR_DISCOVERY_CB = NULL;
 static NeighborRequestCallback NEIGHBOR_REQUEST_CB = NULL;
@@ -238,6 +238,22 @@ static BcmpNeighbor *bcmp_add_neighbor(uint64_t node_id, uint8_t port) {
     new_neighbor->port = port;
 
     BcmpNeighbor *neighbor = NULL;
+
+    // Check to see if port is already populated, remove if so
+    if (NEIGHBORS) {
+      uint64_t node_id = 0;
+      neighbor = NEIGHBORS;
+      do {
+        node_id = neighbor->next ? neighbor->next->node_id : neighbor->node_id;
+        if (neighbor->port == port) {
+          bcmp_remove_neighbor_from_table(neighbor);
+          neighbor = bcmp_find_neighbor(node_id);
+        }
+        neighbor = neighbor ? neighbor->next : NULL;
+      } while (neighbor);
+      neighbor = NULL;
+    }
+
     if (NEIGHBORS == NULL) {
       // First neighbor!
       NEIGHBORS = new_neighbor;


### PR DESCRIPTION
## What changed?
If a node is hot-swapped on a port, remove the old node ID


## How does it make Bristlemouth better?
If a node is hot swapped on a port, the neighbor port info will no longer hold the old node ID plus the new node ID, rather, just the new node ID.

Previously if a node was hot swapped we would have this result:
![image](https://github.com/user-attachments/assets/147fe919-1746-44ba-b6eb-527cfe482d40)

This does not allow us to properly get the topology of a system (as we will only evaluate the first node in the above list):
![image](https://github.com/user-attachments/assets/eb5e92da-b06b-48a1-a41e-ec689b81342e)

With this fix we eliminate this situation by removing the old node:

- Before hotswap:
![image](https://github.com/user-attachments/assets/17de766c-7b4b-495f-af47-0e4917aac4e7)

- After hotswap:
![image](https://github.com/user-attachments/assets/1ea52024-51e8-4fdb-bb7c-0bd404d058fb)

And we can now get the proper topology:
![image](https://github.com/user-attachments/assets/0ab2dbba-be7c-4bd1-9763-a07bebfebcab)


## Where should reviewers focus?
Strength of unit test mainly, I tried to stress swapping many nodes  on 3 ports.


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
