### PR TITLE
Allows NULL Data To Be Used When Publishing Messages

### DIFF
--- a/middleware/pubsub.c
+++ b/middleware/pubsub.c
@@ -309,7 +309,7 @@ BmErr bm_pub_wl(const char *topic, uint16_t topic_len, const void *data,
 
   do {
 
-    if (!topic || !topic_len || !data || !len) {
+    if (!topic || !topic_len) {
       break;
     }
 
@@ -335,7 +335,10 @@ BmErr bm_pub_wl(const char *topic, uint16_t topic_len, const void *data,
     header->ext_header.version = version;
 
     memcpy((void *)header->topic, topic, topic_len);
-    memcpy((void *)&header->topic[header->topic_len], data, len);
+
+    if (data && len) {
+      memcpy((void *)&header->topic[header->topic_len], data, len);
+    }
 
     // If we have a local subscription, submit it to the local queue as well
     if (get_sub(topic, topic_len)) {
@@ -373,7 +376,7 @@ BmErr bm_pub_wl(const char *topic, uint16_t topic_len, const void *data,
   } while (0);
 
   if (err != BmOK) {
-    bm_debug("Unable to publish to topic\n");
+    bm_debug("Unable to publish to topic, err: %d\n", err);
   } else {
     if (bcmp_resource_discovery_add_resource(
             topic, topic_len, PUB, default_resource_add_timeout_ms) == BmOK) {

--- a/test/src/pubsub_test.cpp
+++ b/test/src/pubsub_test.cpp
@@ -177,11 +177,15 @@ TEST_F(PubSub, publish) {
   ASSERT_EQ(bm_pub(topic, buf, array_size(buf), type, version), BmOK);
   ASSERT_EQ(bm_unsub(topic, sub_callback_0), BmOK);
 
+  // Test publishing without data (ensure it doesn't break with strange use cases)
+  ASSERT_EQ(bm_pub(topic, NULL, 0, type, version), BmOK);
+  ASSERT_EQ(bm_pub(topic, NULL, array_size(buf), type, version), BmOK);
+  ASSERT_EQ(bm_pub(topic, buf, 0, type, version), BmOK);
+
   // Test improper use cases
   ASSERT_NE(bm_pub(NULL, buf, array_size(buf), type, version), BmOK);
-  ASSERT_NE(bm_pub(topic, NULL, array_size(buf), type, version), BmOK);
-  ASSERT_NE(bm_pub(topic, buf, 0, type, version), BmOK);
   ASSERT_NE(bm_pub_wl(topic, 0, buf, array_size(buf), type, version), BmOK);
+
   ASSERT_NE(
       bm_pub_wl(topic, BM_TOPIC_MAX_LEN, buf, array_size(buf), type, version),
       BmOK);


### PR DESCRIPTION
## What changed?
Removes the requirement for data and data length to be actual values when publishing a message on the Bristlemouth network.

## How does it make Bristlemouth better?
I noticed that `smsync` messages to the Spotter console were not being properly processed on the Bristlemouth network.
This is due to the requirement of having data be apart of a Bristlemouth published message.
This allows published messages to be used as notifications.


## Where should reviewers focus?
Mainly a rubber stamp, is this something we are aligned on? Or should the change be that an `smsync` publish does require some sort of data.

## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
