### PR TITLE
Subscribe To Wildcard Patterns

### DIFF
--- a/common/util.c
+++ b/common/util.c
@@ -120,12 +120,12 @@ bool bm_wildcard_match(const char *str, uint16_t str_len, const char *pattern,
   int32_t star_idx = -1;
   uint16_t i = 0, j = 0;
 
-  while (i < str_len) {
+  while (i < str_len && j < pattern_len) {
     if (str[i] == pattern[j]) {
       i++;
       j++;
       star_idx = -1;
-    } else if (j < pattern_len && pattern[j] == '*') {
+    } else if (pattern[j] == '*') {
       star_idx = j++;
       // Keep index of string
     } else if (star_idx != -1) {
@@ -139,6 +139,11 @@ bool bm_wildcard_match(const char *str, uint16_t str_len, const char *pattern,
   // Skip trailing '*' in pattern
   while (j < pattern_len && pattern[j] == '*') {
     j++;
+  }
+
+  // If final pattern char is '*', match to the end of the string
+  if (star_idx == pattern_len - 1) {
+    i = str_len;
   }
 
   return j == pattern_len && i == str_len;

--- a/common/util.c
+++ b/common/util.c
@@ -105,8 +105,8 @@ size_t bm_strnlen(const char *s, size_t max_length) {
 /*!
  @brief Match A Wildcard Pattern To A String
 
- @details Matches a wildcard pattern (currently only supports '*') to a string,
-          can also be used as a memcmp function.
+ @details Matches a wildcard pattern (currently only supports '*' and '?') to a
+          string, can also be used as a memcmp function.
 
  @param str string to match to pattern
  @param str_len length of string
@@ -122,7 +122,7 @@ bool bm_wildcard_match(const char *str, uint16_t str_len, const char *pattern,
   uint16_t i = 0, j = 0;
 
   while (i < str_len) {
-    if (j < pattern_len && str[i] == pattern[j]) {
+    if (j < pattern_len && (pattern[j] == '?' || str[i] == pattern[j])) {
       i++;
       j++;
     } else if (j < pattern_len && pattern[j] == '*') {

--- a/common/util.c
+++ b/common/util.c
@@ -118,19 +118,21 @@ size_t bm_strnlen(const char *s, size_t max_length) {
 bool bm_wildcard_match(const char *str, uint16_t str_len, const char *pattern,
                        uint16_t pattern_len) {
   int32_t star_idx = -1;
+  uint16_t match_idx = 0;
   uint16_t i = 0, j = 0;
 
-  while (i < str_len && j < pattern_len) {
-    if (str[i] == pattern[j]) {
+  while (i < str_len) {
+    if (j < pattern_len && str[i] == pattern[j]) {
       i++;
       j++;
-      star_idx = -1;
-    } else if (pattern[j] == '*') {
+    } else if (j < pattern_len && pattern[j] == '*') {
       star_idx = j++;
+      match_idx = i;
       // Keep index of string
     } else if (star_idx != -1) {
       // Keep iterating until next character in pattern matches next character in string
-      i++;
+      j = star_idx + 1;
+      i = ++match_idx;
     } else {
       break;
     }

--- a/common/util.c
+++ b/common/util.c
@@ -105,7 +105,7 @@ size_t bm_strnlen(const char *s, size_t max_length) {
 /*!
  @brief Match A Wildcard Pattern To A String
 
- @details Matches a wildcard patter (currently only supports '*') to a string,
+ @details Matches a wildcard pattern (currently only supports '*') to a string,
           can also be used as a memcmp function.
 
  @param str string to match to pattern
@@ -126,17 +126,17 @@ bool bm_wildcard_match(const char *str, uint16_t str_len, const char *pattern,
     ret = true;
   }
 
-  while (i < str_len && j < pattern_len) {
+  while (i < str_len) {
     if (str[i] == pattern[j]) {
       i++;
       j++;
       star_idx = -1;
-    } else if (pattern[j] == '*') {
+    } else if (j < pattern_len && pattern[j] == '*') {
       star_idx = j++;
       // Keep index of string
       str_lookback_idx = i;
     } else if (star_idx != -1) {
-      // Keep iterating until next character pattern matches item in str
+      // Keep iterating until next character in pattern matches next character in string
       j = star_idx + 1;
       i = ++str_lookback_idx;
     } else {
@@ -145,12 +145,12 @@ bool bm_wildcard_match(const char *str, uint16_t str_len, const char *pattern,
     }
   }
 
-  // Prevent substrings from being a pattern match
-  if (j != pattern_len || (star_idx == -1 && i != str_len)) {
-    ret = false;
+  // Skip trailing '*' in pattern
+  while (j < pattern_len && pattern[j] == '*') {
+    j++;
   }
 
-  return ret;
+  return j == pattern_len;
 }
 
 // leap year calulator expects year argument as years offset from 1970

--- a/common/util.c
+++ b/common/util.c
@@ -142,7 +142,7 @@ bool bm_wildcard_match(const char *str, uint16_t str_len, const char *pattern,
     j++;
   }
 
-  return j == pattern_len;
+  return j == pattern_len && i == str_len;
 }
 
 // leap year calulator expects year argument as years offset from 1970

--- a/common/util.c
+++ b/common/util.c
@@ -117,13 +117,8 @@ size_t bm_strnlen(const char *s, size_t max_length) {
  */
 bool bm_wildcard_match(const char *str, uint16_t str_len, const char *pattern,
                        uint16_t pattern_len) {
-  bool ret = false;
   int32_t star_idx = -1;
   uint16_t i = 0, j = 0;
-
-  if (str_len && pattern_len) {
-    ret = true;
-  }
 
   while (i < str_len) {
     if (str[i] == pattern[j]) {
@@ -138,7 +133,6 @@ bool bm_wildcard_match(const char *str, uint16_t str_len, const char *pattern,
       j = star_idx + 1;
       i++;
     } else {
-      ret = false;
       break;
     }
   }

--- a/common/util.c
+++ b/common/util.c
@@ -102,6 +102,57 @@ size_t bm_strnlen(const char *s, size_t max_length) {
   return s - start;
 }
 
+/*!
+ @brief Match A Wildcard Pattern To A String
+
+ @details Matches a wildcard patter (currently only supports '*') to a string,
+          can also be used as a memcmp function.
+
+ @param str string to match to pattern
+ @param str_len length of string
+ @param pattern pattern string to compare against str
+ @param pattern_len length of pattern string
+
+ @return true if match, false if it does not match
+ */
+bool bm_wildcard_match(const char *str, uint16_t str_len, const char *pattern,
+                       uint16_t pattern_len) {
+  bool ret = false;
+  int32_t star_idx = -1;
+  uint16_t str_lookback_idx = 0;
+  uint16_t i = 0, j = 0;
+
+  if (str_len && pattern_len) {
+    ret = true;
+  }
+
+  while (i < str_len && j < pattern_len) {
+    if (str[i] == pattern[j]) {
+      i++;
+      j++;
+      star_idx = -1;
+    } else if (pattern[j] == '*') {
+      star_idx = j++;
+      // Keep index of string
+      str_lookback_idx = i;
+    } else if (star_idx != -1) {
+      // Keep iterating until next character pattern matches item in str
+      j = star_idx + 1;
+      i = ++str_lookback_idx;
+    } else {
+      ret = false;
+      break;
+    }
+  }
+
+  // Prevent substrings from being a pattern match
+  if (j != pattern_len || (star_idx == -1 && i != str_len)) {
+    ret = false;
+  }
+
+  return ret;
+}
+
 // leap year calulator expects year argument as years offset from 1970
 #define leap_year(Y)                                                           \
   (((1970 + Y) > 0) && !((1970 + Y) % 4) &&                                    \

--- a/common/util.c
+++ b/common/util.c
@@ -128,9 +128,8 @@ bool bm_wildcard_match(const char *str, uint16_t str_len, const char *pattern,
     } else if (j < pattern_len && pattern[j] == '*') {
       star_idx = j++;
       match_idx = i;
-      // Keep index of string
     } else if (star_idx != -1) {
-      // Keep iterating until next character in pattern matches next character in string
+      // No match but a previous wildcard is found, backtrack to last '*'
       j = star_idx + 1;
       i = ++match_idx;
     } else {
@@ -143,12 +142,7 @@ bool bm_wildcard_match(const char *str, uint16_t str_len, const char *pattern,
     j++;
   }
 
-  // If final pattern char is '*', match to the end of the string
-  if (star_idx == pattern_len - 1) {
-    i = str_len;
-  }
-
-  return j == pattern_len && i == str_len;
+  return j == pattern_len;
 }
 
 // leap year calulator expects year argument as years offset from 1970

--- a/common/util.c
+++ b/common/util.c
@@ -130,7 +130,6 @@ bool bm_wildcard_match(const char *str, uint16_t str_len, const char *pattern,
       // Keep index of string
     } else if (star_idx != -1) {
       // Keep iterating until next character in pattern matches next character in string
-      j = star_idx + 1;
       i++;
     } else {
       break;

--- a/common/util.c
+++ b/common/util.c
@@ -119,7 +119,6 @@ bool bm_wildcard_match(const char *str, uint16_t str_len, const char *pattern,
                        uint16_t pattern_len) {
   bool ret = false;
   int32_t star_idx = -1;
-  uint16_t str_lookback_idx = 0;
   uint16_t i = 0, j = 0;
 
   if (str_len && pattern_len) {
@@ -134,11 +133,10 @@ bool bm_wildcard_match(const char *str, uint16_t str_len, const char *pattern,
     } else if (j < pattern_len && pattern[j] == '*') {
       star_idx = j++;
       // Keep index of string
-      str_lookback_idx = i;
     } else if (star_idx != -1) {
       // Keep iterating until next character in pattern matches next character in string
       j = star_idx + 1;
-      i = ++str_lookback_idx;
+      i++;
     } else {
       ret = false;
       break;

--- a/common/util.h
+++ b/common/util.h
@@ -108,6 +108,8 @@ void swap_16bit(void *x);
 void swap_32bit(void *x);
 void swap_64bit(void *x);
 size_t bm_strnlen(const char *s, size_t max_length);
+bool bm_wildcard_match(const char *str, uint16_t str_len, const char *pattern,
+                       uint16_t pattern_len);
 
 static inline uint16_t uint8_to_uint16(uint8_t *buf) {
   return (uint16_t)(buf[1] | buf[0] << 8);

--- a/middleware/pubsub.c
+++ b/middleware/pubsub.c
@@ -514,12 +514,13 @@ static BmSubNode *get_sub(const char *topic, uint16_t topic_len) {
   BmSubNode *node = CTX.subscription_list.next;
 
   while (node != NULL) {
-    if ((node->sub.topic_len == topic_len) &&
-        (memcmp(node->sub.topic, topic, topic_len) == 0)) {
+    if (bm_wildcard_match(topic, topic_len, node->sub.topic,
+                          node->sub.topic_len)) {
       break;
     }
     node = node->next;
   }
+
   return node;
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -577,3 +577,10 @@ set(BRISTLEMOUTH_SRCS
     ${STUB_DIR}/topology_stub.c
 )
 create_gtest("bristlemouth" "${BRISTLEMOUTH_SRCS}")
+
+# Utility functions
+set (UTIL_SRCS
+    # File we're testing
+    ${COMMON_DIR}/util.c
+)
+create_gtest("util" "${UTIL_SRCS}")

--- a/test/src/pubsub_test.cpp
+++ b/test/src/pubsub_test.cpp
@@ -324,3 +324,7 @@ TEST_F(PubSub, utility) {
   ASSERT_EQ(bm_unsub(test_topic_1, sub_callback_2), BmOK);
   RESET_FAKE(bcmp_resource_discovery_add_resource);
 }
+
+TEST_F(PubSub, wildcard_match) {
+  ASSERT_TRUE(bm_wildcard_match("aaaa", 4, "a*a", 3));
+}

--- a/test/src/pubsub_test.cpp
+++ b/test/src/pubsub_test.cpp
@@ -88,8 +88,7 @@ protected:
     CB2_CALLED++;
   }
 
-  void sub_search_helper(const char *str, std::vector<uint32_t> &count,
-                         uint8_t mask = 0x7) {
+  void sub_search_helper(const char *str, std::vector<uint32_t> &count) {
     ASSERT_EQ(count.size(), 3);
     uint8_t buf[UINT8_MAX] = {0};
     BmPubSubData *data = NULL;
@@ -102,15 +101,9 @@ protected:
     memcpy((void *)data->topic, str, strlen(str));
     bm_udp_get_payload_fake.return_val = data;
     bm_handle_msg(RND.rnd_int(UINT64_MAX, UINT32_MAX), buf, array_size(buf));
-    if (mask & 0x1) {
-      EXPECT_EQ(CB0_CALLED, count[0]);
-    }
-    if (mask & 0x2) {
-      EXPECT_EQ(CB1_CALLED, count[1]);
-    }
-    if (mask & 0x4) {
-      EXPECT_EQ(CB2_CALLED, count[2]);
-    }
+    EXPECT_EQ(CB0_CALLED, count[0]);
+    EXPECT_EQ(CB1_CALLED, count[1]);
+    EXPECT_EQ(CB2_CALLED, count[2]);
     bm_free(data);
   }
 };

--- a/test/src/pubsub_test.cpp
+++ b/test/src/pubsub_test.cpp
@@ -324,7 +324,3 @@ TEST_F(PubSub, utility) {
   ASSERT_EQ(bm_unsub(test_topic_1, sub_callback_2), BmOK);
   RESET_FAKE(bcmp_resource_discovery_add_resource);
 }
-
-TEST_F(PubSub, wildcard_match) {
-  ASSERT_TRUE(bm_wildcard_match("aaaa", 4, "a*a", 3));
-}

--- a/test/src/pubsub_test.cpp
+++ b/test/src/pubsub_test.cpp
@@ -88,8 +88,9 @@ protected:
     CB2_CALLED++;
   }
 
-  void sub_search_helper(const char *str, uint32_t count[3],
+  void sub_search_helper(const char *str, std::vector<uint32_t> &count,
                          uint8_t mask = 0x7) {
+    ASSERT_EQ(count.size(), 3);
     uint8_t buf[UINT8_MAX] = {0};
     BmPubSubData *data = NULL;
 
@@ -115,6 +116,8 @@ protected:
 };
 
 TEST_F(PubSub, subscribe) {
+  std::vector<uint32_t> count_checks = {1, 1, 1};
+
   // Add topics and associate multiple callbacks with topics
   bcmp_resource_discovery_add_resource_fake.return_val = BmOK;
   ASSERT_EQ(bm_sub(test_topic_0, sub_callback_0), BmOK);
@@ -128,8 +131,9 @@ TEST_F(PubSub, subscribe) {
   ASSERT_EQ(bm_sub(test_topic_1, sub_callback_2), BmOK);
 
   // Test making sure that callbacks are called properly
-  sub_search_helper(test_topic_0, (uint32_t[]){1, 1, 1});
-  sub_search_helper(test_topic_1, (uint32_t[]){2, 2, 2});
+  sub_search_helper(test_topic_0, count_checks);
+  count_checks = {2, 2, 2};
+  sub_search_helper(test_topic_1, count_checks);
 
   // Unsubscribe from all topics
   ASSERT_EQ(bm_unsub(test_topic_0, sub_callback_2), BmOK);
@@ -146,7 +150,8 @@ TEST_F(PubSub, subscribe) {
   ASSERT_EQ(bm_sub(test_topic_2, sub_callback_1), BmOK);
   ASSERT_EQ(bm_sub(test_topic_2, sub_callback_2), BmOK);
 
-  sub_search_helper(test_topic_1, (uint32_t[]){3, 3, 3});
+  count_checks = {3, 3, 3};
+  sub_search_helper(test_topic_1, count_checks);
   ASSERT_EQ(bm_unsub(test_topic_2, sub_callback_2), BmOK);
   ASSERT_EQ(bm_unsub(test_topic_2, sub_callback_1), BmOK);
   ASSERT_EQ(bm_unsub(test_topic_2, sub_callback_0), BmOK);
@@ -157,11 +162,12 @@ TEST_F(PubSub, subscribe) {
   ASSERT_EQ(bm_sub(test_topic_3, sub_callback_1), BmOK);
   ASSERT_EQ(bm_sub(test_topic_3, sub_callback_2), BmOK);
 
-  sub_search_helper(test_topic_3_helper, (uint32_t[]){4, 4, 4});
+  count_checks = {4, 4, 4};
+  sub_search_helper(test_topic_3_helper, count_checks);
   // Ensure failures on strings that do not exactly match pattern
-  sub_search_helper(test_topic_3_fail_helper_1, (uint32_t[]){4, 4, 4});
-  sub_search_helper(test_topic_3_fail_helper_2, (uint32_t[]){4, 4, 4});
-  sub_search_helper(test_topic_3_fail_helper_3, (uint32_t[]){4, 4, 4});
+  sub_search_helper(test_topic_3_fail_helper_1, count_checks);
+  sub_search_helper(test_topic_3_fail_helper_2, count_checks);
+  sub_search_helper(test_topic_3_fail_helper_3, count_checks);
 
   ASSERT_EQ(bm_unsub(test_topic_3, sub_callback_1), BmOK);
   ASSERT_EQ(bm_unsub(test_topic_3, sub_callback_0), BmOK);
@@ -173,9 +179,10 @@ TEST_F(PubSub, subscribe) {
   ASSERT_EQ(bm_sub(test_topic_4, sub_callback_1), BmOK);
   ASSERT_EQ(bm_sub(test_topic_4, sub_callback_2), BmOK);
 
-  sub_search_helper(test_topic_4_helper, (uint32_t[]){5, 5, 5});
+  count_checks = {5, 5, 5};
+  sub_search_helper(test_topic_4_helper, count_checks);
   // Ensure failures on strings that does not exactly match pattern
-  sub_search_helper(test_topic_4_fail_helper, (uint32_t[]){5, 5, 5});
+  sub_search_helper(test_topic_4_fail_helper, count_checks);
   ASSERT_EQ(bm_unsub(test_topic_4, sub_callback_1), BmOK);
   ASSERT_EQ(bm_unsub(test_topic_4, sub_callback_0), BmOK);
   ASSERT_EQ(bm_unsub(test_topic_4, sub_callback_2), BmOK);
@@ -186,9 +193,10 @@ TEST_F(PubSub, subscribe) {
   ASSERT_EQ(bm_sub(test_topic_5, sub_callback_1), BmOK);
   ASSERT_EQ(bm_sub(test_topic_5, sub_callback_2), BmOK);
 
-  sub_search_helper(test_topic_5_helper, (uint32_t[]){6, 6, 6});
+  count_checks = {6, 6, 6};
+  sub_search_helper(test_topic_5_helper, count_checks);
   // Ensure failures on string that does not exactly match pattern
-  sub_search_helper(test_topic_5_fail_helper, (uint32_t[]){6, 6, 6});
+  sub_search_helper(test_topic_5_fail_helper, count_checks);
 
   ASSERT_EQ(bm_unsub(test_topic_5, sub_callback_1), BmOK);
   ASSERT_EQ(bm_unsub(test_topic_5, sub_callback_0), BmOK);
@@ -200,10 +208,11 @@ TEST_F(PubSub, subscribe) {
   ASSERT_EQ(bm_sub(test_topic_6, sub_callback_1), BmOK);
   ASSERT_EQ(bm_sub(test_topic_6, sub_callback_2), BmOK);
 
-  sub_search_helper(test_topic_6_helper, (uint32_t[]){7, 7, 7});
+  count_checks = {7, 7, 7};
+  sub_search_helper(test_topic_6_helper, count_checks);
   // Ensure failures on strings that do not exactly match pattern
-  sub_search_helper(test_topic_6_fail_helper_1, (uint32_t[]){7, 7, 7});
-  sub_search_helper(test_topic_6_fail_helper_2, (uint32_t[]){7, 7, 7});
+  sub_search_helper(test_topic_6_fail_helper_1, count_checks);
+  sub_search_helper(test_topic_6_fail_helper_2, count_checks);
 
   ASSERT_EQ(bm_unsub(test_topic_6, sub_callback_1), BmOK);
   ASSERT_EQ(bm_unsub(test_topic_6, sub_callback_0), BmOK);
@@ -214,12 +223,15 @@ TEST_F(PubSub, subscribe) {
   ASSERT_EQ(bm_sub(test_topic_2, sub_callback_0), BmOK);
   ASSERT_EQ(bm_sub(test_topic_3, sub_callback_1), BmOK);
   ASSERT_EQ(bm_sub(test_topic_6, sub_callback_2), BmOK);
-  sub_search_helper(test_topic_3_helper, (uint32_t[]){7, 8, 7});
-  sub_search_helper(test_topic_4_helper, (uint32_t[]){7, 8, 7});
-  sub_search_helper(test_topic_5_helper, (uint32_t[]){7, 8, 7});
-  sub_search_helper(test_topic_1, (uint32_t[]){8, 8, 7});
-  sub_search_helper(test_topic_0, (uint32_t[]){8, 8, 7});
-  sub_search_helper(test_topic_6_helper, (uint32_t[]){8, 8, 8});
+  count_checks = {7, 8, 7};
+  sub_search_helper(test_topic_3_helper, count_checks);
+  sub_search_helper(test_topic_4_helper, count_checks);
+  sub_search_helper(test_topic_5_helper, count_checks);
+  count_checks = {8, 8, 7};
+  sub_search_helper(test_topic_1, count_checks);
+  sub_search_helper(test_topic_0, count_checks);
+  count_checks = {8, 8, 8};
+  sub_search_helper(test_topic_6_helper, count_checks);
   ASSERT_EQ(bm_unsub(test_topic_2, sub_callback_0), BmOK);
   ASSERT_EQ(bm_unsub(test_topic_3, sub_callback_1), BmOK);
   ASSERT_EQ(bm_unsub(test_topic_6, sub_callback_2), BmOK);

--- a/test/src/pubsub_test.cpp
+++ b/test/src/pubsub_test.cpp
@@ -10,13 +10,22 @@ DEFINE_FFF_GLOBALS;
 #define test_topic_1 "example/sub1/topic"
 #define test_topic_2 "example/**/topic"
 #define test_topic_3 "example/*/difficult/str/*/*test"
-#define test_topic_3_helper "example/really/difficult/str/0123456789ABCDEF/test"
+#define test_topic_3_helper                                                    \
+  "example/really/difficult/str/0123456789ABCDEF/here/test"
+#define test_topic_3_fail_helper_1 "example/difficult/str/0123456789ABCDEF/test"
+#define test_topic_3_fail_helper_2                                             \
+  "example/really/difficult/str/0123456789ABCDEF/"
+#define test_topic_3_fail_helper_3 "example/really/difficult/str/test"
 #define test_topic_4 "example/end/str/*"
 #define test_topic_4_helper "example/end/str/0123456789ABCDEF"
+#define test_topic_4_fail_helper "example/end/str"
 #define test_topic_5 "*/begin/str"
 #define test_topic_5_helper "0123456789ABCDEF/begin/str"
-#define test_topic_6 "*four*/wildcards/*crazy*"
-#define test_topic_6_helper "wowfourisacrazy/wildcards/amountcrazy/"
+#define test_topic_5_fail_helper "begin/str"
+#define test_topic_6 "*fouris/*/wildcards/*crazy*"
+#define test_topic_6_helper "wowfouris/acrazy/wildcards/amountcrazy/"
+#define test_topic_6_fail_helper_1 "wowfouris/acrazy/wildcards/amount"
+#define test_topic_6_fail_helper_2 "wowisacrazy/wildcards/amountcrazy/"
 
 extern "C" {
 #include "mock_bm_ip.h"
@@ -149,6 +158,11 @@ TEST_F(PubSub, subscribe) {
   ASSERT_EQ(bm_sub(test_topic_3, sub_callback_2), BmOK);
 
   sub_search_helper(test_topic_3_helper, (uint32_t[]){4, 4, 4});
+  // Ensure failures on strings that do not exactly match pattern
+  sub_search_helper(test_topic_3_fail_helper_1, (uint32_t[]){4, 4, 4});
+  sub_search_helper(test_topic_3_fail_helper_2, (uint32_t[]){4, 4, 4});
+  sub_search_helper(test_topic_3_fail_helper_3, (uint32_t[]){4, 4, 4});
+
   ASSERT_EQ(bm_unsub(test_topic_3, sub_callback_1), BmOK);
   ASSERT_EQ(bm_unsub(test_topic_3, sub_callback_0), BmOK);
   ASSERT_EQ(bm_unsub(test_topic_3, sub_callback_2), BmOK);
@@ -160,6 +174,8 @@ TEST_F(PubSub, subscribe) {
   ASSERT_EQ(bm_sub(test_topic_4, sub_callback_2), BmOK);
 
   sub_search_helper(test_topic_4_helper, (uint32_t[]){5, 5, 5});
+  // Ensure failures on strings that does not exactly match pattern
+  sub_search_helper(test_topic_4_fail_helper, (uint32_t[]){5, 5, 5});
   ASSERT_EQ(bm_unsub(test_topic_4, sub_callback_1), BmOK);
   ASSERT_EQ(bm_unsub(test_topic_4, sub_callback_0), BmOK);
   ASSERT_EQ(bm_unsub(test_topic_4, sub_callback_2), BmOK);
@@ -171,6 +187,8 @@ TEST_F(PubSub, subscribe) {
   ASSERT_EQ(bm_sub(test_topic_5, sub_callback_2), BmOK);
 
   sub_search_helper(test_topic_5_helper, (uint32_t[]){6, 6, 6});
+  // Ensure failures on string that does not exactly match pattern
+  sub_search_helper(test_topic_5_fail_helper, (uint32_t[]){6, 6, 6});
 
   ASSERT_EQ(bm_unsub(test_topic_5, sub_callback_1), BmOK);
   ASSERT_EQ(bm_unsub(test_topic_5, sub_callback_0), BmOK);
@@ -183,6 +201,9 @@ TEST_F(PubSub, subscribe) {
   ASSERT_EQ(bm_sub(test_topic_6, sub_callback_2), BmOK);
 
   sub_search_helper(test_topic_6_helper, (uint32_t[]){7, 7, 7});
+  // Ensure failures on strings that do not exactly match pattern
+  sub_search_helper(test_topic_6_fail_helper_1, (uint32_t[]){7, 7, 7});
+  sub_search_helper(test_topic_6_fail_helper_2, (uint32_t[]){7, 7, 7});
 
   ASSERT_EQ(bm_unsub(test_topic_6, sub_callback_1), BmOK);
   ASSERT_EQ(bm_unsub(test_topic_6, sub_callback_0), BmOK);

--- a/test/src/util_test.cpp
+++ b/test/src/util_test.cpp
@@ -1,0 +1,29 @@
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "util.h"
+}
+
+class Util : public ::testing::Test {
+
+protected:
+  Util() {}
+  ~Util() override {}
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(Util, wildcard_match) {
+  EXPECT_TRUE(bm_wildcard_match("aaaa", 4, "a*a", 3));
+
+  EXPECT_TRUE(bm_wildcard_match("aaabxc_file.txt", 15, "*a*b?c*.txt", 11));
+  EXPECT_TRUE(bm_wildcard_match("xaxbxc_something.txt", 20, "*a*b?c*.txt", 11));
+
+  EXPECT_FALSE(bm_wildcard_match("alpha_betaXc123.txt", 19, "*a*b?c*.txt", 11));
+  EXPECT_TRUE(bm_wildcard_match("alpha_betaXc123.txt", 19, "*a*b*c*.txt", 11));
+
+  EXPECT_TRUE(
+      bm_wildcard_match("report-2023-Xsummary", 20, "report-????-*y", 14));
+  EXPECT_TRUE(bm_wildcard_match("report-1925-diary", 17, "report-????-*y", 14));
+  EXPECT_FALSE(bm_wildcard_match("report-2023-Xbad", 16, "report-????-*y", 14));
+}


### PR DESCRIPTION
## What changed?
Added utility function to check for wildcard strings
Added capability to subscribe to wildcard pattern
Update pubsub unit test to validate that wildcard patterns work as expected

## How does it make Bristlemouth better?
Allows wildcard patterns to be used with multiple `*` for subscribed topics!

## Where should reviewers focus?
Check the unit test to see if there are any other edge cases for pattern matching that I may have missed!

## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
