### PR TITLE
fix: gcc format warnings

### DIFF
--- a/bcmp/packet.c
+++ b/bcmp/packet.c
@@ -320,7 +320,7 @@ static BcmpRequestElement *sequence_list_find_message(uint32_t seq_num) {
                         default_message_timeout_ms) == BmOK) {
     err = ll_get_item(&PACKET.sequence_list, seq_num, (void *)&element);
     if (err == BmOK && element) {
-      bm_debug("Bcmp message with seq_num %d\n", seq_num);
+      bm_debug("Bcmp message with seq_num %lu\n", seq_num);
     }
     bm_semaphore_give(PACKET.sequence_list_semaphore);
   }
@@ -476,7 +476,7 @@ BmErr process_received_message(void *payload, uint32_t size) {
         request_message = sequence_list_find_message(data.header->seq_num);
         if (request_message) {
           bm_debug(
-              "BCMP - Received reply to our request message with seq_num %d\n",
+              "BCMP - Received reply to our request message with seq_num %lu\n",
               data.header->seq_num);
           if (bm_semaphore_take(PACKET.sequence_list_semaphore,
                                 default_message_timeout_ms) == BmOK) {
@@ -558,7 +558,7 @@ BmErr serialize(void *payload, void *data, uint32_t size, BcmpMessageType type,
         request_message = new_sequence_list_item(
             header->type, default_message_timeout_ms, header->seq_num, cb);
         sequence_list_add_message(request_message, header->seq_num);
-        bm_debug("BCMP - Serializing message with seq_num %d\n",
+        bm_debug("BCMP - Serializing message with seq_num %lu\n",
                  header->seq_num);
       } else {
         // If the message doesn't use sequence numbers, set it to 0

--- a/middleware/cbor_service_helper.c
+++ b/middleware/cbor_service_helper.c
@@ -147,7 +147,7 @@ uint8_t *services_cbor_as_map(size_t *buffer_size, BmConfigPartition type) {
     } else if (err == CborNoError) {
       *buffer_size = cbor_encoder_get_buffer_size(&encoder, buffer);
     } else {
-      bm_debug("Failed to encode config as cbor map, err=%" PRIu32 "\n", err);
+      bm_debug("Failed to encode config as cbor map, err=%d\n", err);
       bm_free(buffer);
       buffer = NULL;
     }

--- a/middleware/echo_service.c
+++ b/middleware/echo_service.c
@@ -31,7 +31,7 @@ static bool echo_service_handler(size_t service_strlen, const char *service,
                                  size_t req_data_len, uint8_t *req_data,
                                  size_t *buffer_len, uint8_t *reply_data) {
   bool rval = true;
-  bm_debug("Data received on service: %.*s\n", (uint32_t)service_strlen,
+  bm_debug("Data received on service: %.*s\n", (int)service_strlen,
            service);
   if (*buffer_len <= MAX_BM_SERVICE_DATA_SIZE) {
     *buffer_len = req_data_len;


### PR DESCRIPTION
## What changed?

I fixed compiler warnings regarding printf format specifiers. Thanks @campbellaos for the tip!

## How does it make Bristlemouth better?

This helps ensure that our printed strings contain the types and widths that we expect and helps us avoid memory corruption.

## Where should reviewers focus?

If any of my format specifier changes look wrong or should be handled differently, let me know. This PR is small, but the incoming corresponding one in bm_protocol is much bigger.

## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
