### PR TITLE
test: add ctest preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -21,5 +21,11 @@
             "name": "unit-tests",
             "jobs": 8
         }
+    ],
+    "testPresets": [
+        {
+            "configurePreset": "unit-tests",
+            "name": "unit-tests"
+        }
     ]
 }


### PR DESCRIPTION
## What changed?

I learned that ctest also makes use of the cmake presets.

## How does it make Bristlemouth better?

This helps more tooling integrate better. You can also run `ctest --preset unit-tests` on the command line at the repo root without needing to know where the build directory is or any other info about the build environment.

## Where should reviewers focus?

Any downsides?

## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
