### PR TITLE
fix: handle linked list malloc failure

### DIFF
--- a/common/ll.c
+++ b/common/ll.c
@@ -82,8 +82,8 @@ BmErr ll_create_item_static(LLItem *item, void *data, uint32_t id) {
 /*!
  @brief Create A Dynamic Linked List Item
 
- @param item pointer to item to create
- @param data data the item will point to
+ @param item pointer to item to create, should be NULL
+ @param data data the item will point to, may be NULL
  @param size length of data in bytes
  @param id unique identifier the item represents
  
@@ -91,17 +91,21 @@ BmErr ll_create_item_static(LLItem *item, void *data, uint32_t id) {
  @return NULL on failure
  */
 LLItem *ll_create_item(LLItem *item, void *data, uint32_t size, uint32_t id) {
-  void *tmp = NULL;
   item = (LLItem *)bm_malloc(sizeof(LLItem));
+  if (!item)
+    return NULL;
 
-  if (item) {
-    if (data) {
-      tmp = bm_malloc(size);
-      memcpy(tmp, data, size);
+  item->data = NULL;
+  item->id = id;
+  item->dynamic = 1;
+
+  if (data) {
+    item->data = bm_malloc(size);
+    if (!item->data) {
+      bm_free(item);
+      return NULL;
     }
-    item->data = tmp;
-    item->id = id;
-    item->dynamic = 1;
+    memcpy(item->data, data, size);
   }
 
   return item;


### PR DESCRIPTION
## What changed?

- Check whether `bm_malloc` returned NULL when attempting to create a linked list item with data. If so, free the item we already allocated and return NULL.
- I wanted to test drive the change, but there's no straightforward way in the current linked list unit tests to fake bm_malloc failing. Improvements for another time.
- Removed the need for a temporary variable.
- Use early returns to avoid repeated error checking.

## How does it make Bristlemouth better?

This prevents an assertion (and thus MCU reset) at runtime if there's insufficient memory to allocate the given data size.

## Where should reviewers focus?

It's a small change, so scrutinize the whole thing.

## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
