### PR TITLE
fix: linked list tail cleanup

### DIFF
--- a/common/ll.c
+++ b/common/ll.c
@@ -223,6 +223,9 @@ BmErr ll_remove(LL *ll, uint32_t id) {
     if (current) {
       if (current == ll->head) {
         ll->head = current->next;
+        if (current == ll->tail) {
+          ll->tail = NULL;
+        }
       } else {
         ret = BmOK;
         if (current == ll->tail) {

--- a/test/src/ll_test.cpp
+++ b/test/src/ll_test.cpp
@@ -175,6 +175,15 @@ TEST_F(ll_test, remove) {
   ll = create_test_helper(ll_remove_test_helper, true);
   ASSERT_NE(ll_remove(&ll, NOREACH), BmOK);
   ll_clean_up_helper(&ll);
+
+  // Test all pointers null after removing all items
+  ll = create_test_helper(NULL, true);
+  while (ll.head != nullptr) {
+    ASSERT_EQ(ll_remove(&ll, ll.head->id), BmOK);
+  }
+  ASSERT_EQ(ll.head, nullptr);
+  ASSERT_EQ(ll.tail, nullptr);
+  ASSERT_EQ(ll.cursor, nullptr);
 }
 
 static BmErr ll_traverse_test_helper(void *data, void *arg) {


### PR DESCRIPTION
## What changed?

We now ensure a linked list tail pointer gets cleaned up after all items are removed.

## How does it make Bristlemouth better?

This prevents a user of the linked list library from accidentally accessing a pointer to memory that has already been freed.

## Where should reviewers focus?

It's a small change, so look at the whole thing. Are there edge cases I missed? Did I use the test helpers correctly?

## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
