### PR TITLE
fix: sphinx-notes/pages action pinned to working commit

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,4 +16,4 @@ jobs:
       id-token: write
     steps:
     - id: deployment
-      uses: sphinx-notes/pages@v3
+      uses: sphinx-notes/pages@a82c349d744aae9913f1a41a597ea753f96b3030


### PR DESCRIPTION
Work around this issue:
https://github.com/sphinx-notes/pages/issues/53

Because the merge of the following PR broke the github action, even in its own CI:
https://github.com/sphinx-notes/pages/pull/52

![Screenshot 2025-06-10 at 4 06 41 PM](https://github.com/user-attachments/assets/d8a71198-6b87-4ee1-bc3b-3ab36e209c5d)
