### PR TITLE
Prevents Reverse RTC 0 From Occurring On A System

### DIFF
--- a/common/bm_freertos.c
+++ b/common/bm_freertos.c
@@ -160,6 +160,10 @@ BmErr bm_timer_change_period(BmTimer timer, uint32_t period_ms,
   }
 }
 
+uint32_t bm_timer_get_id(BmTimer timer) {
+    return (uint32_t) pvTimerGetTimerID(timer);
+}
+
 uint32_t bm_get_tick_count(void) { return xTaskGetTickCount(); }
 
 uint32_t bm_get_tick_count_from_isr(void) { return xTaskGetTickCountFromISR(); }

--- a/common/bm_os.h
+++ b/common/bm_os.h
@@ -55,12 +55,13 @@ void bm_start_scheduler(void);
 
 // Timer functions
 BmTimer bm_timer_create(const char *name, uint32_t period_ms, bool auto_reload,
-                        void *time_id, BmTimerCallback);
+                        void *time_id, BmTimerCallback cb);
 void bm_timer_delete(BmTimer timer, uint32_t timeout_ms);
 BmErr bm_timer_start(BmTimer timer, uint32_t timeout_ms);
 BmErr bm_timer_stop(BmTimer timer, uint32_t timeout_ms);
 BmErr bm_timer_change_period(BmTimer timer, uint32_t period_ms,
                              uint32_t timeout_ms);
+uint32_t bm_timer_get_id(BmTimer timer);
 uint32_t bm_get_tick_count(void);
 uint32_t bm_get_tick_count_from_isr(void);
 uint32_t bm_ms_to_ticks(uint32_t ms);

--- a/common/util.h
+++ b/common/util.h
@@ -1,6 +1,7 @@
 #ifndef __BM_UTIL_H__
 #define __BM_UTIL_H__
 
+#include <inttypes.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/drivers/adin2111/adin2111.c
+++ b/drivers/adin2111/adin2111.c
@@ -665,6 +665,59 @@ adi_eth_Result_e adin2111_SetTestMode(adin2111_DeviceHandle_t hDevice, adin2111_
 }
 
 /*!
+ * @brief           Trigger autonegotiation on the ADIN device.
+ *
+ * @param [in]      hDevice         Device driver handle.
+ * @param [in]      port            Port number.
+ *
+ * @details         Will retrigger autonegotiation on the ADIN device. The status of the ADIN's autonegotiation should be
+ *                  polled before calling this API to determine if this is an appropriate time to renegotiate.
+ *
+ * @sa              adin2111_AutoNegotiateStatus()
+ */
+adi_eth_Result_e    adin2111_Renegotiate(adin2111_DeviceHandle_t hDevice, adin2111_Port_e port) {
+    adi_eth_Result_e    result = ADI_ETH_SUCCESS;
+
+    if ((port != ADIN2111_PORT_1) && (port != ADIN2111_PORT_2))
+    {
+        result = ADI_ETH_INVALID_PORT;
+    }
+    else
+    {
+        result = phyDriverEntry.Renegotiate(hDevice->pPhyDevice[port]);
+    }
+
+    return result;
+}
+
+/*!
+ * @brief           Get the status of autonegotiation.
+ *
+ * @param [in]      hDevice         Device driver handle.
+ * @param [in]      port            Port number.
+ * @param [out]     status          Status of autonegotiation.
+ *
+ * @details         Determines the status of the current autonegotiation that has occured. Will return ADI_ETH_SUCCESS if status was
+ *                  able to be obtained from the ADIN device.
+ *
+ * @sa
+ */
+adi_eth_Result_e adin2111_AutoNegotiateStatus(adin2111_DeviceHandle_t hDevice, adin2111_Port_e port, adi_phy_AnStatus_t *status) {
+    adi_eth_Result_e    result = ADI_ETH_SUCCESS;
+
+    if ((port != ADIN2111_PORT_1) && (port != ADIN2111_PORT_2))
+    {
+        result = ADI_ETH_INVALID_PORT;
+    }
+    else
+    {
+        result = phyDriverEntry.GetAnStatus(hDevice->pPhyDevice[port], status);
+    }
+
+    return result;
+}
+
+/*!
  * @brief           Set up MAC address filter and corresponding address rules.
  *
  * @param [in]      hDevice         Device driver handle.

--- a/drivers/adin2111/adin2111.h
+++ b/drivers/adin2111/adin2111.h
@@ -181,6 +181,9 @@ adi_eth_Result_e    adin2111_LedEn                   (adin2111_DeviceHandle_t hD
 adi_eth_Result_e    adin2111_SetLoopbackMode         (adin2111_DeviceHandle_t hDevice, adin2111_Port_e port, adi_phy_LoopbackMode_e loopbackMode);
 adi_eth_Result_e    adin2111_SetTestMode             (adin2111_DeviceHandle_t hDevice, adin2111_Port_e port, adi_phy_TestMode_e testMode);
 
+adi_eth_Result_e    adin2111_Renegotiate             (adin2111_DeviceHandle_t hDevice, adin2111_Port_e port);
+adi_eth_Result_e    adin2111_AutoNegotiateStatus     (adin2111_DeviceHandle_t hDevice, adin2111_Port_e port, adi_phy_AnStatus_t *status);
+
 adi_eth_Result_e    adin2111_AddAddressFilter        (adin2111_DeviceHandle_t hDevice, uint8_t *macAddr, uint8_t *macAddrMask, adi_mac_AddressRule_t addrRule);
 adi_eth_Result_e    adin2111_ClearAddressFilter      (adin2111_DeviceHandle_t hDevice, uint32_t addrIndex);
 adi_eth_Result_e    adin2111_SubmitTxBuffer          (adin2111_DeviceHandle_t hDevice, adin2111_TxPort_e port, adi_eth_BufDesc_t *pBufDesc);

--- a/network/network_device.h
+++ b/network/network_device.h
@@ -19,6 +19,7 @@ typedef struct {
   BmErr (*const disable)(void *self);
   BmErr (*const enable_port)(void *self, uint8_t port_num);
   BmErr (*const disable_port)(void *self, uint8_t port_num);
+  BmErr (*const retry_negotiation)(void *self, uint8_t port_index, bool *renegotiated);
   uint8_t (*const num_ports)(void);
   BmErr (*const port_stats)(void *self, uint8_t port_index, void *stats);
   BmErr (*const handle_interrupt)(void *self);

--- a/test/mocks/mock_bm_os.h
+++ b/test/mocks/mock_bm_os.h
@@ -28,6 +28,7 @@ DECLARE_FAKE_VALUE_FUNC(BmErr, bm_timer_start, BmTimer, uint32_t);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_timer_stop, BmTimer, uint32_t);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_timer_change_period, BmTimer, uint32_t,
                         uint32_t);
+DECLARE_FAKE_VALUE_FUNC(uint32_t, bm_timer_get_id, BmTimer);
 DECLARE_FAKE_VALUE_FUNC(BmQueue, bm_queue_create, uint32_t, uint32_t);
 DECLARE_FAKE_VOID_FUNC(bm_queue_delete, BmQueue);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_queue_receive, BmQueue, void *, uint32_t);

--- a/test/stubs/bm_os_stub.c
+++ b/test/stubs/bm_os_stub.c
@@ -38,6 +38,7 @@ DEFINE_FAKE_VALUE_FUNC(BmErr, bm_timer_start, BmTimer, uint32_t);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_timer_stop, BmTimer, uint32_t);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_timer_change_period, BmTimer, uint32_t,
                        uint32_t);
+DEFINE_FAKE_VALUE_FUNC(uint32_t, bm_timer_get_id, BmTimer);
 DEFINE_FAKE_VALUE_FUNC(BmQueue, bm_queue_create, uint32_t, uint32_t);
 DEFINE_FAKE_VOID_FUNC(bm_queue_delete, BmQueue);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_queue_receive, BmQueue, void *, uint32_t);


### PR DESCRIPTION
## What changed?
This adds a renegotiation feature to the ADIN driver and new network device trait to attempt autonegotiation on a port in the event of a fault occurring Whenever a port's link is down, the ADIN will attempt to autonegotiate on that port until it's link is back up

## How does it make Bristlemouth better?

## Testing
I ran 20 tests on a system with 2 PME DO sensor's.
The first DO node was expected to be the problem node (RTC 0 node).
I flashed the first DO node with the code from this PR and v0.13.0.rc.7.
Then I examined the topology print from the Spotter terminal, ex:
```
2025-06-12T22:16:02.074Z [BRIDGE_CFG] [INFO] Bridge toplogy: 49659f5695fc5e15 | 97037b8f3910987e | f9f7ad3e42d9a7d1
No update available for f9f7ad3e42d9a7d1
No update available for 97037b8f3910987e
No update available for 49659f5695fc5e15
```
The following is a result of this testing:

- v0.13.0.rc.7
  - All Nodes Viewable On Topology: 4
  - First DO Viewable On Topology But End Node Was Not: 3
  - Neither DO Viewable On Topology: 3
  
Example behavior of a single port showing up
<img width="1138" alt="Screenshot 2025-06-12 at 2 00 24 PM" src="https://github.com/user-attachments/assets/e339375a-07c1-4ea9-a40c-bfba1c0d89ee" />

- fix/reverse_rtc0
  - All Nodes Viewable On Topology: 10

example behavior of all ports showing up:
<img width="920" alt="Screenshot 2025-06-12 at 2 04 26 PM" src="https://github.com/user-attachments/assets/eebdfb78-c66b-4c12-9966-2c50c1028785" />

As can be seen, this PR reliably brings up all nodes on the network on an expected RTC0 node which was consistently unable to speak to the network.

## Where should reviewers focus?
I updated the ADIN driver as I believed this best fit in the separation of control from l2->bm_adin_2111->adin_2111.

The auto-negotiation check will also run on a disabled port (ex: on port 2). I have done testing with this and it does not hurt anything on the system, but the 100ms timer will be running. I can add some extra code to check for a port that might be disabled and avoid running the timer if so desired.

Let me know your thoughts on both of these things!


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
