### PR TITLE
Fix Improper Cast From Pointer To Integer Of Different Size On 64 Bit Platforms

### DIFF
--- a/common/bm_freertos.c
+++ b/common/bm_freertos.c
@@ -161,7 +161,7 @@ BmErr bm_timer_change_period(BmTimer timer, uint32_t period_ms,
 }
 
 uint32_t bm_timer_get_id(BmTimer timer) {
-    return (uint32_t) pvTimerGetTimerID(timer);
+  return (uint32_t)(uintptr_t)pvTimerGetTimerID(timer);
 }
 
 uint32_t bm_get_tick_count(void) { return xTaskGetTickCount(); }


### PR DESCRIPTION
## What changed?
In bm_timer_get_id fix error for assigning a pointer to different integer length by casting to uintptr_t first


## How does it make Bristlemouth better?
Does not fail 64 bit unit tests.



## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
