### PR TITLE
Add L2 Port Disable Mock

### DIFF
--- a/test/mocks/mock_l2.h
+++ b/test/mocks/mock_l2.h
@@ -9,3 +9,4 @@ DECLARE_FAKE_VALUE_FUNC(BmErr, bm_l2_register_link_change_callback,
                         L2LinkChangeCb);
 DECLARE_FAKE_VALUE_FUNC(bool, bm_l2_get_port_state, uint8_t);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_l2_netif_set_power, bool);
+DECLARE_FAKE_VALUE_FUNC(BmErr, bm_l2_netif_enable_disable_port, uint8_t, bool);

--- a/test/stubs/l2_stub.c
+++ b/test/stubs/l2_stub.c
@@ -7,3 +7,4 @@ DEFINE_FAKE_VALUE_FUNC(BmErr, bm_l2_register_link_change_callback,
                        L2LinkChangeCb);
 DEFINE_FAKE_VALUE_FUNC(bool, bm_l2_get_port_state, uint8_t);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_l2_netif_set_power, bool);
+DEFINE_FAKE_VALUE_FUNC(BmErr, bm_l2_netif_enable_disable_port, uint8_t, bool);


### PR DESCRIPTION
## What changed?
Add mock for l2 port disable/enable mock


## How does it make Bristlemouth better?
Allows this mock to be used in unit tests


## Where should reviewers focus?
Rubber stamp


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
