### PR TITLE
Adds bm_timer_reset abstraction to os abstraction

### DIFF
--- a/common/bm_freertos.c
+++ b/common/bm_freertos.c
@@ -134,6 +134,14 @@ void bm_timer_delete(BmTimer timer, uint32_t timeout_ms) {
   xTimerDelete((TimerHandle_t)timer, timeout_ms);
 }
 
+BmErr bm_timer_reset(BmTimer timer, uint32_t timeout_ms) {
+  if (xTimerReset(timer, pdMS_TO_TICKS(timeout_ms)) == pdPASS) {
+    return BmOK;
+  } else {
+    return BmETIMEDOUT;
+  }
+}
+
 BmErr bm_timer_start(BmTimer timer, uint32_t timeout_ms) {
   if (xTimerStart(timer, pdMS_TO_TICKS(timeout_ms)) == pdPASS) {
     return BmOK;

--- a/common/bm_os.h
+++ b/common/bm_os.h
@@ -57,6 +57,7 @@ void bm_start_scheduler(void);
 BmTimer bm_timer_create(const char *name, uint32_t period_ms, bool auto_reload,
                         void *time_id, BmTimerCallback);
 void bm_timer_delete(BmTimer timer, uint32_t timeout_ms);
+BmErr bm_timer_reset(BmTimer timer, uint32_t timeout_ms);
 BmErr bm_timer_start(BmTimer timer, uint32_t timeout_ms);
 BmErr bm_timer_stop(BmTimer timer, uint32_t timeout_ms);
 BmErr bm_timer_change_period(BmTimer timer, uint32_t period_ms,

--- a/test/mocks/mock_bm_os.h
+++ b/test/mocks/mock_bm_os.h
@@ -3,6 +3,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef void *BmQueue;
 typedef void *BmSemaphore;
 typedef void *BmTimer;
@@ -24,6 +28,7 @@ DECLARE_FAKE_VALUE_FUNC(uint32_t, bm_ticks_to_ms, uint32_t);
 DECLARE_FAKE_VALUE_FUNC(BmTimer, bm_timer_create, const char *, uint32_t, bool,
                         void *, BmTimerCb);
 DECLARE_FAKE_VOID_FUNC(bm_timer_delete, BmTimer, uint32_t);
+DECLARE_FAKE_VALUE_FUNC(BmErr, bm_timer_reset, BmTimer, uint32_t);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_timer_start, BmTimer, uint32_t);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_timer_stop, BmTimer, uint32_t);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_timer_change_period, BmTimer, uint32_t,
@@ -43,3 +48,7 @@ DECLARE_FAKE_VALUE_FUNC(BmErr, bm_stream_buffer_receive, BmBuffer, uint8_t *,
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_task_create, BmTaskCb, const char *, uint32_t,
                         void *, uint32_t, BmTaskHandle);
 DECLARE_FAKE_VOID_FUNC(bm_task_delete, BmTaskHandle);
+
+#ifdef __cplusplus
+}
+#endif

--- a/test/stubs/bm_os_stub.c
+++ b/test/stubs/bm_os_stub.c
@@ -34,6 +34,7 @@ DEFINE_FAKE_VALUE_FUNC(uint32_t, bm_ticks_to_ms, uint32_t);
 DEFINE_FAKE_VALUE_FUNC(BmTimer, bm_timer_create, const char *, uint32_t, bool,
                        void *, BmTimerCb);
 DEFINE_FAKE_VOID_FUNC(bm_timer_delete, BmTimer, uint32_t);
+DEFINE_FAKE_VALUE_FUNC(BmErr, bm_timer_reset, BmTimer, uint32_t);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_timer_start, BmTimer, uint32_t);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_timer_stop, BmTimer, uint32_t);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_timer_change_period, BmTimer, uint32_t,


### PR DESCRIPTION
## What changed?
Adds timer reset API abstraction.


## How does it make Bristlemouth better?
Provides abstraction for OS timer reset which can be used throughout the Bristlemouth ecosystem.


## Where should reviewers focus?
Rubber stamp 


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
