### PR TITLE
If Wildcard Subscriptions Are Used With Non-Wilcard Subscriptions Prevent Subscribing To Only The Wildcard Topic

### DIFF
--- a/common/util.h
+++ b/common/util.h
@@ -62,6 +62,8 @@ typedef struct {
 #define member_size(type, member) (sizeof(((type *)0)->member))
 #define s_to_ms(x) (x * 1000)
 #define ms_to_s(x) (x / 1000)
+#define bm_min(a, b) (((a) < (b)) ? (a) : (b))
+#define bm_max(a, b) (((a) > (b)) ? (a) : (b))
 
 uint32_t time_remaining(uint32_t start, uint32_t current, uint32_t timeout);
 uint32_t utc_from_date_time(uint16_t year, uint8_t month, uint8_t day,


### PR DESCRIPTION
## What changed?
Updates the way Bristlemouth subscribes to topics and handles incoming publishes to topics


## How does it make Bristlemouth better?
If there are multiple subscriptions that would fulfill a wildcard and a non-wildcard condition, ensure that they are subscribe to separately
This way multiple callbacks will not be assigned to the wildcard topic if they are not meant to.
Allows multiple topics that are subscribed to with a wildcard/non-wildcard pattern to handle callbacks separately by ensuring all topics are iterated through when handling an incoming publish


## Where should reviewers focus?
Are there any cases that this logic still might have an improper subscribe?

The one I was worried about (but not after writing this) was the following case:
In `bm_pub_wl`, `get_sub` is called with the `wildcard_search` parameter set to see if the publisher is interested in this topic as well (the publisher might have a wildcard that it cares about, or a non-wildcard item), by using `get_sub` here, the publisher will only submit the message once to be handled by itself.


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
