### PR TITLE
Feature/mutex abstraction

### DIFF
--- a/bcmp/packet.c
+++ b/bcmp/packet.c
@@ -350,7 +350,7 @@ BmErr packet_init(BcmpGetIPAddr src_ip, BcmpGetIPAddr dst_ip, BcmpGetData data,
 
     // Create timer and semaphore for sequenced packet handling
     err = BmENOMEM;
-    PACKET.sequence_list_semaphore = bm_semaphore_create();
+    PACKET.sequence_list_semaphore = bm_mutex_create();
     if (PACKET.sequence_list_semaphore) {
       PACKET.timer = bm_timer_create("bcmp_message_expiration",
                                      message_timer_expiry_period_ms, true, NULL,

--- a/bcmp/resource_discovery.c
+++ b/bcmp/resource_discovery.c
@@ -213,11 +213,11 @@ BmErr bcmp_resource_discovery_init(void) {
   PUB_LIST.start = NULL;
   PUB_LIST.end = NULL;
   PUB_LIST.num_resources = 0;
-  PUB_LIST.lock = bm_semaphore_create();
+  PUB_LIST.lock = bm_mutex_create();
   SUB_LIST.start = NULL;
   SUB_LIST.end = NULL;
   SUB_LIST.num_resources = 0;
-  SUB_LIST.lock = bm_semaphore_create();
+  SUB_LIST.lock = bm_mutex_create();
   if (PUB_LIST.lock && SUB_LIST.lock) {
     err = BmOK;
   }

--- a/common/bm_freertos.c
+++ b/common/bm_freertos.c
@@ -85,7 +85,9 @@ BmErr bm_stream_buffer_receive(BmBuffer buf, uint8_t *data, uint32_t *size,
   return err;
 }
 
-BmSemaphore bm_semaphore_create(void) { return xSemaphoreCreateMutex(); }
+BmSemaphore bm_mutex_create(void) { return xSemaphoreCreateMutex(); }
+
+BmSemaphore bm_semaphore_create(void) { return xSemaphoreCreateBinary(); }
 
 void bm_semaphore_delete(BmSemaphore semaphore) {
   vSemaphoreDelete((SemaphoreHandle_t)semaphore);

--- a/common/bm_os.h
+++ b/common/bm_os.h
@@ -41,6 +41,9 @@ BmErr bm_stream_buffer_send(BmBuffer buf, uint8_t *data, uint32_t size,
 BmErr bm_stream_buffer_receive(BmBuffer buf, uint8_t *data, uint32_t *size,
                                uint32_t timeout_ms);
 
+// Mutex functions
+BmSemaphore bm_mutex_create(void);
+
 // Semaphore functions
 BmSemaphore bm_semaphore_create(void);
 void bm_semaphore_delete(BmSemaphore semaphore);

--- a/middleware/bm_service.c
+++ b/middleware/bm_service.c
@@ -96,7 +96,7 @@ bool bm_service_unregister(size_t service_strlen, const char *service) {
  */
 BmErr bm_service_init(void) {
   BmErr err = BmENOMEM;
-  BM_SERVICE_CONTEXT.lock = bm_semaphore_create();
+  BM_SERVICE_CONTEXT.lock = bm_mutex_create();
   if (BM_SERVICE_CONTEXT.lock) {
     err = bm_service_request_init();
   }

--- a/middleware/bm_service_request.c
+++ b/middleware/bm_service_request.c
@@ -61,7 +61,7 @@ static void _service_request_timer_expiry_cb(void *arg);
 BmErr bm_service_request_init(void) {
   BmErr err = BmENOMEM;
 
-  CTX.lock = bm_semaphore_create();
+  CTX.lock = bm_mutex_create();
   CTX.expiry_timer_handle = bm_timer_create(
       "Service request expiry timer", bm_ms_to_ticks(ExpiryTimerPeriodMs), true,
       NULL, _service_request_timer_callback);

--- a/test/mocks/mock_bm_os.h
+++ b/test/mocks/mock_bm_os.h
@@ -17,6 +17,7 @@ typedef void (*BmTaskCb)(void *);
 
 DECLARE_FAKE_VALUE_FUNC(void *, bm_malloc, size_t);
 DECLARE_FAKE_VOID_FUNC(bm_free, void *);
+DECLARE_FAKE_VALUE_FUNC(BmSemaphore, bm_mutex_create);
 DECLARE_FAKE_VALUE_FUNC(BmSemaphore, bm_semaphore_create);
 DECLARE_FAKE_VOID_FUNC(bm_semaphore_delete, BmSemaphore);
 DECLARE_FAKE_VALUE_FUNC(BmErr, bm_semaphore_give, BmSemaphore);

--- a/test/src/bm_service_request_test.cpp
+++ b/test/src/bm_service_request_test.cpp
@@ -39,15 +39,13 @@ protected:
 };
 
 TEST_F(BmServiceRequest, init) {
-  bm_semaphore_create_fake.return_val =
-      (void *)RND.rnd_int(UINT64_MAX, UINT32_MAX);
+  bm_mutex_create_fake.return_val = (void *)RND.rnd_int(UINT64_MAX, UINT32_MAX);
   bm_timer_create_fake.return_val = (void *)RND.rnd_int(UINT64_MAX, UINT32_MAX);
   ASSERT_EQ(bm_service_request_init(), BmOK);
 
-  bm_semaphore_create_fake.return_val = 0;
+  bm_mutex_create_fake.return_val = 0;
   ASSERT_NE(bm_service_request_init(), BmOK);
-  bm_semaphore_create_fake.return_val =
-      (void *)RND.rnd_int(UINT64_MAX, UINT32_MAX);
+  bm_mutex_create_fake.return_val = (void *)RND.rnd_int(UINT64_MAX, UINT32_MAX);
 
   bm_timer_create_fake.return_val = 0;
   ASSERT_NE(bm_service_request_init(), BmOK);

--- a/test/src/bm_service_test.cpp
+++ b/test/src/bm_service_test.cpp
@@ -39,15 +39,14 @@ protected:
 };
 
 TEST_F(BmService, init) {
-  bm_semaphore_create_fake.return_val =
-      (void *)RND.rnd_int(UINT64_MAX, UINT32_MAX);
+  bm_mutex_create_fake.return_val = (void *)RND.rnd_int(UINT64_MAX, UINT32_MAX);
   bm_service_request_init_fake.return_val = BmOK;
   ASSERT_EQ(bm_service_init(), BmOK);
 
   bm_service_request_init_fake.return_val = BmENOMEM;
   ASSERT_NE(bm_service_init(), BmOK);
 
-  bm_semaphore_create_fake.return_val = 0;
+  bm_mutex_create_fake.return_val = 0;
   ASSERT_NE(bm_service_init(), BmOK);
 }
 

--- a/test/src/packet_test.cpp
+++ b/test/src/packet_test.cpp
@@ -62,11 +62,11 @@ protected:
     test_payload_size = RND.rnd_int(max_payload_size, min_payload_size);
     test_payload = (uint8_t *)calloc(test_payload_size, sizeof(uint8_t));
 
-    RESET_FAKE(bm_semaphore_create);
+    RESET_FAKE(bm_mutex_create);
     RESET_FAKE(bm_timer_create);
     RESET_FAKE(bm_timer_start);
     RESET_FAKE(bcmp_process_heartbeat);
-    bm_semaphore_create_fake.return_val =
+    bm_mutex_create_fake.return_val =
         (BmSemaphore)RND.rnd_int(UINT32_MAX, UINT16_MAX);
     bm_timer_create_fake.return_val =
         (BmTimer)RND.rnd_int(UINT32_MAX, UINT16_MAX);

--- a/test/src/resource_discovery_test.cpp
+++ b/test/src/resource_discovery_test.cpp
@@ -48,7 +48,7 @@ TEST_F(ResourceDiscovery, resource_process_request) {
   };
 
   // Initialize callbacks
-  bm_semaphore_create_fake.return_val = (uint64_t *)RND.rnd_int(UINT64_MAX, 1);
+  bm_mutex_create_fake.return_val = (uint64_t *)RND.rnd_int(UINT64_MAX, 1);
   bm_semaphore_take_fake.return_val = BmOK;
   bm_semaphore_give_fake.return_val = BmOK;
   ASSERT_EQ(bcmp_resource_discovery_init(), BmOK);
@@ -141,7 +141,7 @@ TEST_F(ResourceDiscovery, resource_process_reply) {
   data.payload = (uint8_t *)reply;
 
   // Initialize callbacks
-  bm_semaphore_create_fake.return_val = (uint64_t *)RND.rnd_int(UINT64_MAX, 1);
+  bm_mutex_create_fake.return_val = (uint64_t *)RND.rnd_int(UINT64_MAX, 1);
   bm_semaphore_take_fake.return_val = BmOK;
   bm_semaphore_give_fake.return_val = BmOK;
   ASSERT_EQ(bcmp_resource_discovery_init(), BmOK);

--- a/test/stubs/bm_os_stub.c
+++ b/test/stubs/bm_os_stub.c
@@ -23,6 +23,7 @@ void *bm_malloc(size_t size) {
   return ret;
 }
 void bm_free(void *p) { return free(p); }
+DEFINE_FAKE_VALUE_FUNC(BmSemaphore, bm_mutex_create);
 DEFINE_FAKE_VALUE_FUNC(BmSemaphore, bm_semaphore_create);
 DEFINE_FAKE_VOID_FUNC(bm_semaphore_delete, BmSemaphore);
 DEFINE_FAKE_VALUE_FUNC(BmErr, bm_semaphore_give, BmSemaphore);


### PR DESCRIPTION
## What changed?
Add BM OS abstraction for mutex creation.
Utilzes `bm_semaphore_create` for binary semaphores.
Renames instances of `bm_semaphore_create` to `bm_mutex_create` due to the fact they are actually being used as mutexes.


## How does it make Bristlemouth better?
Create mutex under more direct API call to increase clarity when invoking the API.


## Where should reviewers focus?
All files are important. Good to validate that all API in `bm_core` have been renamed properly.


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
