### PR TITLE
fix: check length of dfu chunk before memcpy

### DIFF
--- a/bcmp/dfu_client.c
+++ b/bcmp/dfu_client.c
@@ -370,8 +370,8 @@ BmErr s_client_receiving_run(void) {
 
     if (image_chunk_evt->payload_length > bm_dfu_max_chunk_size) {
       // Ignore this malformed chunk
-      // Return BmEINVAL while keeping the timer running awaiting a valid chunk
-      goto error;
+      // Return early, keeping the timer running awaiting a valid chunk
+      return BmEINVAL;
     }
 
     /* Stop Chunk Timer */
@@ -439,7 +439,6 @@ BmErr s_client_receiving_run(void) {
     timer_err_check_and_return(err, bm_timer_start(CLIENT_CTX.chunk_timer, 10));
   }
 
-error:
   return err;
 }
 

--- a/bcmp/dfu_client.c
+++ b/bcmp/dfu_client.c
@@ -368,6 +368,12 @@ BmErr s_client_receiving_run(void) {
     BmDfuEventImageChunk *image_chunk_evt =
         (BmDfuEventImageChunk *)&((uint8_t *)(frame))[1];
 
+    if (image_chunk_evt->payload_length > bm_dfu_max_chunk_size) {
+      // Ignore this malformed chunk
+      // Return BmEINVAL while keeping the timer running awaiting a valid chunk
+      goto error;
+    }
+
     /* Stop Chunk Timer */
     timer_err_check_and_return(err, bm_timer_stop(CLIENT_CTX.chunk_timer, 10));
 
@@ -433,6 +439,7 @@ BmErr s_client_receiving_run(void) {
     timer_err_check_and_return(err, bm_timer_start(CLIENT_CTX.chunk_timer, 10));
   }
 
+error:
   return err;
 }
 


### PR DESCRIPTION
## What changed?

Added a bounds check on the encoded length of a DFU image chunk before using it as an argument to memcpy.

Shout out to @drwcx who works at https://metalware.com/ which I've been beta testing — this is what they were trying to disclose in https://github.com/bristlemouth/bm_core/issues/130

In slack they sent me this PDF report: [bristlemouth-april8-2026-disclosure.pdf](https://github.com/user-attachments/files/26588685/bristlemouth-april8-2026-disclosure.pdf)

My fix is slightly different than the suggested one in the PDF because the suggested one would abort the whole DFU process, which would be a denial of service from a single attacker-controlled packet. Instead, we just drop the bad packet and keep the timer running awaiting a good one.

This isn't in our threat model, since the attack would have to take place within a wired network floating in the ocean, but bounds checking is clearly a good idea anyway!

## How does it make Bristlemouth better?

Prevent crashes and out-of-bounds writes into memory.

## Where should reviewers focus?

We don't typically use `goto`, but I didn't want to indent the entire block again. Seem ok?

## Checklist

- [ ] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.

