### PR TITLE
fix: Apple's pthread lib doesn't have timedlock

### DIFF
--- a/common/bm_posix.c
+++ b/common/bm_posix.c
@@ -568,6 +568,7 @@ BmTimer bm_timer_create(const char *name, uint32_t period_ms, bool auto_reload,
 
 // Acquire a timer mutex with a bounded wait.  Returns 0 on success, ETIMEDOUT
 // if the lock could not be acquired within timeout_ms milliseconds.
+// Uses trylock+sleep instead of pthread_mutex_timedlock (absent on Darwin).
 static int timed_mutex_lock(pthread_mutex_t *lock, uint32_t timeout_ms) {
   if (timeout_ms == UINT32_MAX) {
     return pthread_mutex_lock(lock);
@@ -575,9 +576,21 @@ static int timed_mutex_lock(pthread_mutex_t *lock, uint32_t timeout_ms) {
   if (timeout_ms == 0) {
     return pthread_mutex_trylock(lock) == 0 ? 0 : ETIMEDOUT;
   }
-  struct timespec ts;
-  deadline_from_ms(timeout_ms, &ts);
-  return pthread_mutex_timedlock(lock, &ts);
+  struct timespec deadline;
+  deadline_from_ms(timeout_ms, &deadline);
+  static const struct timespec sleep_interval = {0, 1000000L}; // 1 ms
+  for (;;) {
+    if (pthread_mutex_trylock(lock) == 0) {
+      return 0;
+    }
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME, &now);
+    if (now.tv_sec > deadline.tv_sec ||
+        (now.tv_sec == deadline.tv_sec && now.tv_nsec >= deadline.tv_nsec)) {
+      return ETIMEDOUT;
+    }
+    nanosleep(&sleep_interval, NULL);
+  }
 }
 
 void bm_timer_delete(BmTimer timer, uint32_t timeout_ms) {


### PR DESCRIPTION
## What changed?

Fix the POSIX build on macOS. Work around Apple's lack of a `pthread_mutex_timedlock` implementation by repeatedly making a non-blocking attempt and then sleeping 1 ms until the deadline.

## How does it make Bristlemouth better?

When developing `bm_sbc`, it's nice to be able to build on macOS.

## Where should reviewers focus?

🤷 small change, build failure only triggered in a posix container app like in `bm_sbc`

## Checklist

- [ ] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
