### PR TITLE
fix: use explicit uint8_t for partition in packed wire structs

### DIFF
--- a/bcmp/messages.h
+++ b/bcmp/messages.h
@@ -370,7 +370,7 @@ typedef struct {
 typedef struct {
   BmConfigHeader header;
   // Partition id
-  BmConfigPartition partition;
+  uint8_t partition; // BmConfigPartition value
   // String length of the key (without terminator)
   uint8_t key_length;
   // Key string
@@ -380,7 +380,7 @@ typedef struct {
 typedef struct {
   BmConfigHeader header;
   // Partition id
-  BmConfigPartition partition;
+  uint8_t partition; // BmConfigPartition value
   // Length of cbor buffer
   uint32_t data_length;
   // cbor buffer
@@ -390,7 +390,7 @@ typedef struct {
 typedef struct {
   BmConfigHeader header;
   // Partition id
-  BmConfigPartition partition;
+  uint8_t partition; // BmConfigPartition value
   // String length of the key (without terminator)
   uint8_t key_length;
   // Length of cbor encoded data buffer
@@ -402,13 +402,13 @@ typedef struct {
 typedef struct {
   BmConfigHeader header;
   // Partition id
-  BmConfigPartition partition;
+  uint8_t partition; // BmConfigPartition value
 } __attribute__((packed)) BmConfigCommit;
 
 typedef struct {
   BmConfigHeader header;
   // Partition id
-  BmConfigPartition partition;
+  uint8_t partition; // BmConfigPartition value
 } __attribute__((packed)) BmConfigStatusRequest;
 
 typedef struct {
@@ -421,7 +421,7 @@ typedef struct {
 typedef struct {
   BmConfigHeader header;
   // Partition id
-  BmConfigPartition partition;
+  uint8_t partition; // BmConfigPartition value
   // True if there are changes to be committed, false otherwise.
   bool committed;
   // Number of keys
@@ -433,7 +433,7 @@ typedef struct {
 typedef struct {
   BmConfigHeader header;
   // Partition id
-  BmConfigPartition partition;
+  uint8_t partition; // BmConfigPartition value
   // String length of the key (without terminator)
   uint8_t key_length;
   // Key string
@@ -445,7 +445,7 @@ typedef struct {
   // success
   bool success;
   // Partition id
-  BmConfigPartition partition;
+  uint8_t partition; // BmConfigPartition value
   // String length of the key (without terminator)
   uint8_t key_length;
   // Key string
@@ -455,7 +455,7 @@ typedef struct {
 typedef struct {
   BmConfigHeader header;
   // Partition id
-  BmConfigPartition partition;
+  uint8_t partition; // BmConfigPartition value
 } __attribute__((packed)) BmConfigClearRequest;
 
 typedef struct {
@@ -463,7 +463,7 @@ typedef struct {
   // success
   bool success;
   // Partition id
-  BmConfigPartition partition;
+  uint8_t partition; // BmConfigPartition value
 } __attribute__((packed)) BmConfigClearResponse;
 
 typedef enum {

--- a/common/bm_common_structs.h
+++ b/common/bm_common_structs.h
@@ -24,7 +24,7 @@ typedef struct {
 
 typedef struct {
   // Partition id
-  BmConfigPartition partition;
+  uint8_t partition; // BmConfigPartition value
   // Partion crc
   uint32_t crc32;
 } __attribute__((packed)) BmConfigCrc;
@@ -55,7 +55,7 @@ typedef enum {
 
 typedef struct {
   // Log level
-  BmLogLevel level;
+  uint8_t level; // BmLogLevel value
   // String length of the message (without terminator)
   uint32_t message_length;
   // print header (true) or not (false)


### PR DESCRIPTION
## What changed?

BmConfigPartition is a plain enum with no fixed underlying type. Used as a field inside __attribute__((packed)) wire-format structs, its size depends on the compilation unit's flags: STM32 firmware builds with -fshort-enums (1 byte) while Linux/Pi consumers of bm_core default to int (4 bytes). This caused bcmp config messages to fail between a Raspberry Pi gateway and an STM32 mote neighbor: the Pi serialised partition as 4 bytes but the STM32 only consumed 1, slicing the remaining 3 bytes of partition into the next fields and returning an unrelated config key's value.

Switching the wire-format fields to uint8_t locks the layout at 1 byte on both sides, matching the existing STM32 behaviour, without changing the enum type itself or affecting any non-wire uses.

Also applies to BmConfigCrc.partition, which is embedded in the packed BmNetworkInfo wire struct.

Also fixed same class of bug in BmLog.level.

## How does it make Bristlemouth better?

Allows wire-protocol equivalence across architectures and compile flags.

## Where should reviewers focus?

Pretty straightforward. Don't hesitate to ask questions.

## Checklist

- [ ] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
