### PR TITLE
Check if lengths match in get_sub

### DIFF
--- a/middleware/pubsub.c
+++ b/middleware/pubsub.c
@@ -532,7 +532,7 @@ static BmSubNode *delete_sub(const char *topic, uint16_t topic_len) {
 
   @param *topic topic string
   @param topic_len byte length of topic
-  @param wildcard_search should the search be based on wildcard topics 
+  @param wildcard_search should the search be based on wildcard topics
 
   @return pointer to BmSubNode
   @return NULL if not found
@@ -548,8 +548,8 @@ static BmSubNode *get_sub(const char *topic, uint16_t topic_len,
         break;
       }
     } else {
-      if (!memcmp(topic, node->sub.topic,
-                  bm_min(topic_len, node->sub.topic_len))) {
+      if (topic_len == node->sub.topic_len &&
+          !memcmp(topic, node->sub.topic, topic_len)) {
         break;
       }
     }

--- a/test/src/pubsub_test.cpp
+++ b/test/src/pubsub_test.cpp
@@ -291,7 +291,7 @@ TEST_F(PubSub, subscribe) {
   count_checks = {9, 10, 10};
   sub_search_helper("sensor/abcdabcdabcdabcd/sofar/newthing", count_checks);
   sub_search_helper("other/abcdabcdabcdabcd/sofar/newthing", count_checks);
-  count_checks = {9, 11, 11};
+  count_checks = {9, 11, 10};
   sub_search_helper("sensor", count_checks);
 
   RESET_FAKE(bcmp_resource_discovery_add_resource);


### PR DESCRIPTION
## What changed?
Small change to get_sub that checks if topic lengths match instead of using the min length. The previous behavior caused callbacks that should be attached to a topic like `sensor/*/power/battery/averages` to be attached to the sub-strings (when also subscribed to) such as `sensor/*/power/battery`. This would then mean that battery averages messages would not be processed ever because the wildcard match that is used to check for them upon receipt will not have the averages topic, since the sub-string topic will be used for the averages callback. This also means that the regular battery message would be processed by both the regular battery callback AND the averages callback, thus resulting in a decoding error since the second callback is not actually meant for this message type.

Edit: So the current behavior will assign the callback to whichever string is subscribed to first. So that means if `sensor/*/power/battery` is subscribed to first, the callbacks for both `sensor/*/power/battery` and `sensor/*/power/battery/averages` will be called for `sensor/*/power/battery` messages, and no callbacks will be called when a `sensor/*/power/battery/averages` message comes in. Reverse the order of subscribing and you get the opposite behavior.

Here is an example where the battery averages was subscribed to first, so now it is failing to decode the battery power (non-averaged) message because it is expecting the number of fields that are in the averages message (15, but it is getting 16).
<img width="605" height="383" alt="Screenshot 2026-04-27 at 10 25 39 AM" src="https://github.com/user-attachments/assets/d450846c-36cd-4802-bad1-984917466f91" />

TBD, still not sure on the details/downsides to this "fix" and if it even is a "fix" or if the current behavior is actually the expected behavior.

Talked IRL and discussed that we use get_sub with the memcmp when we want to see if our existing list has a specific subscription already, so we should make sure the lengths match.


## How does it make Bristlemouth better?



## Where should reviewers focus?



## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
