### PR TITLE
fix: config str decode length

### DIFF
--- a/bcmp/config.c
+++ b/bcmp/config.c
@@ -81,7 +81,7 @@ BmErr bcmp_config_decode_value(ConfigDataTypes type, uint8_t *data,
           if (*buf_length > init_length) {
             break;
           }
-          p[*buf_length - 1] = '\0';
+          p[*buf_length] = '\0';
           err = BmOK;
         }
       } break;

--- a/test/src/config_test.cpp
+++ b/test/src/config_test.cpp
@@ -157,6 +157,10 @@ TEST_F(Config, decode) {
   EXPECT_NE(size, sizeof(f.set));
 
   // Test string
+  //
+  // Wire strings do not include a trailing '\0'; the decoder appends one at
+  // p[*buf_length], so the destination must have room for payload_len + 1.
+  const size_t str_payload_len = DECODE_BUFFER_SIZE - 1;
   str.large_get = (char *)bm_malloc(ENCODE_BUFFER_SIZE);
   str.get = (char *)bm_malloc(DECODE_BUFFER_SIZE);
   str.set = (char *)bm_malloc(DECODE_BUFFER_SIZE);
@@ -164,21 +168,23 @@ TEST_F(Config, decode) {
   memset(str.large_get, 0, ENCODE_BUFFER_SIZE);
   RND.rnd_str(str.set, DECODE_BUFFER_SIZE);
   cbor_encoder_init(&encoder, cbor_buf, sizeof(cbor_buf), 0);
-  cbor_encode_text_string(&encoder, str.set, DECODE_BUFFER_SIZE);
+  cbor_encode_text_string(&encoder, str.set, str_payload_len);
 
   size = DECODE_BUFFER_SIZE;
   EXPECT_EQ(bcmp_config_decode_value(STR, cbor_buf, sizeof(cbor_buf),
                                      (void *)str.get, &size),
             BmOK);
-  ASSERT_EQ(size, DECODE_BUFFER_SIZE);
+  ASSERT_EQ(size, str_payload_len);
   EXPECT_EQ(memcmp(str.get, str.set, size), 0);
+  EXPECT_EQ(str.get[size], '\0');
 
   size = ENCODE_BUFFER_SIZE;
   EXPECT_EQ(bcmp_config_decode_value(STR, cbor_buf, sizeof(cbor_buf),
                                      (void *)str.large_get, &size),
             BmOK);
-  ASSERT_EQ(size, DECODE_BUFFER_SIZE);
+  ASSERT_EQ(size, str_payload_len);
   EXPECT_EQ(memcmp(str.large_get, str.set, size), 0);
+  EXPECT_EQ(str.large_get[size], '\0');
   bm_free(str.get);
   bm_free(str.set);
   bm_free(str.large_get);


### PR DESCRIPTION
## What changed?

When we call `bcmp_config_decode_value(STR, ...` to decode a string config value fetched from another node (which was not something we have been exercising until now) the placement of the null terminator byte in the decoded string had an off-by-one error, chopping off the last character of the string.

The unit tests passed before because the random test strings got constructed with a final null byte that was allegedly supposed to be part of the decoded string, so the "chopping off" only overwrote the final null byte with a null byte.

The unit tests started failing when I made the fix because the test buffers were sized exactly to the decoded strings and didn't have room for an additional null byte. The fix there is to make the payload one byte smaller than the buffer.

## How does it make Bristlemouth better?

Allows correct `bcmp_config_get` and decoding for string configs.

## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
