### PR TITLE
Fix Memory Leak In bm_linux.c

### DIFF
--- a/network/bm_linux.c
+++ b/network/bm_linux.c
@@ -661,10 +661,12 @@ BmErr bm_udp_tx_perform(void *pcb, void *buf, uint32_t size,
     udp[7] = (uint8_t)(cksum);
   }
 
+  // Increments the ref count of l2_buf, if fails must free twice
   err = bm_l2_link_output(l2_buf, frame_size);
   if (err != BmOK) {
     bm_l2_free(l2_buf);
   }
+  bm_l2_free(l2_buf);
   return err;
 }
 

--- a/network/bm_linux.c
+++ b/network/bm_linux.c
@@ -541,6 +541,7 @@ BmErr bm_ip_tx_perform(void *payload, const BmIpAddr *dst) {
   if (err != BmOK) {
     bm_l2_free(l2_buf);
   }
+  bm_l2_free(l2_buf);
   return err;
 }
 


### PR DESCRIPTION
## What changed?
Invoke `bm_l2_free` at the end of `bm_udp_tx_perform`.


## How does it make Bristlemouth better?
Because the `ref` member of `LinuxBuf` gets incremented in `bm_l2_link_output` and in `bm_l2_new`, the `l2_buf` needs`bm_l2_free` to be called on it twice before the resources are actually freed (decrementing `ref` twice).
This prevents a memory leak.


## Where should reviewers focus?
When a UDP packet is sent the following series of events occur:
  1. `bm_pub_wl` allocates `buf = bm_udp_new(message_size)` (`ref`=1)             
  2. `bm_middleware_net_tx` -> `bm_udp_tx_perform`:                                                                                
    - Allocates `l2_buf = bm_l2_new(frame_size)` (`ref`=1)                      
    - Copies pubsub payload into the frame                                                                                    
    - `bm_l2_link_output(l2_buf, frame_size)`:                                
        - `bm_l2_tx_prep` bumps `ref`: 1->2                                                                                        
      - `bm_l2_tx` queues `l2_buf`, returns `BmOK `                                                                                 
    - Returns `BmOK` — no `bm_l2_free(l2_buf)` on success path
  3. Back in `bm_pub_wl`: `bm_udp_cleanup(buf)` frees the pubsub buffer. But l2_buf is not touched.
  4. L2 thread: `bm_l2_process_tx_evt` -> sends -> `bm_l2_free(tx_evt->buf)`->`ref` 2->1-> not freed



## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
