### PR TITLE
Prevents Topology Infinite Loop

### DIFF
--- a/integrations/topology.c
+++ b/integrations/topology.c
@@ -319,16 +319,23 @@ static void bcmp_topology_thread(void *parameters) {
     }
 
     case BcmpTopoEvtTimeout: {
-      if (++RETRY_COUNT >= topology_retries) {
-        network_topology_increment_port_count(CTX.network_topology);
+      BcmpTopoQueueItem check_item = {BcmpTopoEvtCheckNode, NULL, NULL};
+      bm_queue_send(CTX.evt_queue, &check_item, 0);
+      if (++RETRY_COUNT < topology_retries) {
+        break;
+      }
+
+      bool is_root = network_topology_is_root(CTX.network_topology);
+      RETRY_COUNT = 0;
+      network_topology_increment_port_count(CTX.network_topology);
+      // Can only change cursor if this is not the root node
+      if (!is_root) {
         if (INSERT_BEFORE) {
           network_topology_move_next(CTX.network_topology);
         } else {
           network_topology_move_prev(CTX.network_topology);
         }
       }
-      BcmpTopoQueueItem check_item = {BcmpTopoEvtCheckNode, NULL, NULL};
-      bm_queue_send(CTX.evt_queue, &check_item, 0);
       break;
     }
 

--- a/integrations/topology.c
+++ b/integrations/topology.c
@@ -321,20 +321,9 @@ static void bcmp_topology_thread(void *parameters) {
     case BcmpTopoEvtTimeout: {
       BcmpTopoQueueItem check_item = {BcmpTopoEvtCheckNode, NULL, NULL};
       bm_queue_send(CTX.evt_queue, &check_item, 0);
-      if (++RETRY_COUNT < topology_retries) {
-        break;
-      }
-
-      bool is_root = network_topology_is_root(CTX.network_topology);
-      RETRY_COUNT = 0;
-      network_topology_increment_port_count(CTX.network_topology);
-      // Can only change cursor if this is not the root node
-      if (!is_root) {
-        if (INSERT_BEFORE) {
-          network_topology_move_next(CTX.network_topology);
-        } else {
-          network_topology_move_prev(CTX.network_topology);
-        }
+      if (++RETRY_COUNT >= topology_retries) {
+        RETRY_COUNT = 0;
+        network_topology_increment_port_count(CTX.network_topology);
       }
       break;
     }
@@ -626,7 +615,7 @@ network_topology_check_all_ports_explored(NetworkTopology *network_topology) {
       }
     }
 
-    if (neighbors_online_count == network_topology->cursor->ports_explored) {
+    if (neighbors_online_count <= network_topology->cursor->ports_explored) {
       return true;
     }
   }


### PR DESCRIPTION
## What changed?
On a timeout event in the topology task, if on the root node, prevent changing the cursor.


## How does it make Bristlemouth better?
If running a topology request on the root node, this prevents an infinite loop from occurring by ensuring that the topology cursor cannot be changed if the neighbor request retry limit has been hit.


## Where should reviewers focus?
This prevents a node from hanging in the topology task and tripping the watchdog, but  this does not prevent handling link up/down events from a non-ADIN device, such as the UART for `bm_sbc`. Because of this behavior, when a UART device is no longer available, the topology task takes about 3 seconds to finish after waiting for all of the retries to occur (because the Bristlemouth stack still thinks the UART port is up).
We need to think of a way to trigger `link_change` in `l2.c` for the UART device, but that will have to occur when implementing the composite device.

## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
