### PR TITLE
feat: monitor heartbeats to trigger link up/down

### DIFF
--- a/bcmp/messages.h
+++ b/bcmp/messages.h
@@ -4,7 +4,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "configuration.h"
 #include "dfu_message_structs.h"
 #include "network_frames.h"
 

--- a/network/CMakeLists.txt
+++ b/network/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES
     l2.c
     l2_policy.c
+    bm_link_heartbeat_monitor.c
 )
 
 add_library(bmnetwork ${SOURCES})

--- a/network/bm_link_heartbeat_monitor.c
+++ b/network/bm_link_heartbeat_monitor.c
@@ -187,6 +187,19 @@ BmErr bm_link_heartbeat_monitor_init(const BmLinkHeartbeatMonitorCfg *cfg) {
     return err;
   }
 
+  // When ports start up, fire a synchronous up edge for each port so the
+  // consumer's view (typically bm_l2's per-port link state) matches the
+  // monitor's internal state. Without this, bm_l2 would gate heartbeat TX
+  // on its default-down state and the link could not bootstrap.
+  // Fired outside the lock to preserve the rule that on_link_change runs
+  // unlocked; the timer cannot race here because last_hb_ticks was just
+  // set to "now" for every port.
+  if (MONITOR.cfg.start_ports_up) {
+    for (uint8_t i = 0; i < MONITOR.cfg.num_ports; i++) {
+      MONITOR.cfg.on_link_change(i, true, MONITOR.cfg.ctx);
+    }
+  }
+
   return BmOK;
 }
 

--- a/network/bm_link_heartbeat_monitor.c
+++ b/network/bm_link_heartbeat_monitor.c
@@ -1,19 +1,8 @@
 #include "bm_link_heartbeat_monitor.h"
 #include "bm_os.h"
+#include "messages.h"
 #include "timer_callback_handler.h"
 #include <string.h>
-
-// We deliberately do NOT include bcmp/messages.h here. messages.h pulls in
-// the entire BCMP message catalog (configuration, dfu, cbor, etc.), which is
-// far more than this helper needs and creates an unwanted compile-time
-// dependency on tinycbor headers. Instead, we replicate the two stable
-// protocol values we depend on. If either of these ever changes, the
-// canonical definitions live in bcmp/messages.h.
-
-/// Mirror of BcmpHeartbeatMessage from bcmp/messages.h.
-/// The full BcmpHeader is 12 bytes; we only need to read the
-/// first two bytes, so we don't replicate the whole struct.
-#define BCMP_HEARTBEAT_MESSAGE_TYPE 0x0001
 
 // ----------------------------------------------------------------------------
 // Frame parsing constants
@@ -91,7 +80,7 @@ static bool is_bcmp_heartbeat(const uint8_t *frame, uint32_t len) {
   // convention (host-endian uint16_t).
   uint16_t bcmp_type;
   memcpy(&bcmp_type, frame + BCMP_HEADER_OFFSET, sizeof(bcmp_type));
-  return bcmp_type == BCMP_HEARTBEAT_MESSAGE_TYPE;
+  return bcmp_type == BcmpHeartbeatMessage;
 }
 
 // ----------------------------------------------------------------------------

--- a/network/bm_link_heartbeat_monitor.c
+++ b/network/bm_link_heartbeat_monitor.c
@@ -4,44 +4,6 @@
 #include "timer_callback_handler.h"
 #include <string.h>
 
-// ----------------------------------------------------------------------------
-// Frame parsing constants
-// ----------------------------------------------------------------------------
-//
-// The L2 frames passed to observe() are raw Ethernet + IPv6 + (optional)
-// upper-layer payload, exactly as they appear on the wire (no FCS — that is
-// added/stripped by hardware and is never present at this layer).
-//
-// We mirror the offset constants from network/l2.c rather than including
-// them, because those are file-local #defines. Duplicating four numbers
-// here is cheaper than refactoring l2.c to export a header.
-//
-//   Offset  Bytes  Field
-//   0       6      Ethernet destination MAC
-//   6       6      Ethernet source MAC
-//   12      2      Ethernet type           = ethernet_type_ipv6 (0x86DD)
-//   14      4      IPv6 version/class/flow
-//   18      2      IPv6 payload length
-//   20      1      IPv6 next header        = ip_proto_bcmp (0xBC)
-//   21      1      IPv6 hop limit
-//   22      16     IPv6 source address
-//   38      16     IPv6 destination address
-//   54      ...    BCMP header (12 bytes; see BcmpHeader in bcmp/messages.h).
-//                  First field is uint16_t type; we compare to
-//                  BcmpHeartbeatMessage.
-
-#define ETH_TYPE_OFFSET 12
-#define IPV6_NEXT_HEADER_OFFSET 20
-#define BCMP_HEADER_OFFSET 54
-// BCMP header is 12 bytes (see bcmp/messages.h::BcmpHeader). We only need to
-// read the first 2 bytes (the type field).
-#define BCMP_HEADER_LEN 12
-#define MIN_HEARTBEAT_FRAME_LEN (BCMP_HEADER_OFFSET + BCMP_HEADER_LEN)
-
-// ----------------------------------------------------------------------------
-// Singleton monitor state
-// ----------------------------------------------------------------------------
-
 typedef struct {
   bool up;
   uint32_t last_hb_ticks;
@@ -57,21 +19,17 @@ typedef struct {
 
 static Monitor MONITOR;
 
-// ----------------------------------------------------------------------------
-// Frame inspection
-// ----------------------------------------------------------------------------
-
 static bool is_bcmp_heartbeat(const uint8_t *frame, uint32_t len) {
-  if (len < MIN_HEARTBEAT_FRAME_LEN) {
+  if (len < min_bcmp_frame_size) {
     return false;
   }
   // Ethertype: big-endian on the wire.
-  uint16_t ethertype =
-      (uint16_t)((frame[ETH_TYPE_OFFSET] << 8) | frame[ETH_TYPE_OFFSET + 1]);
+  uint16_t ethertype = (uint16_t)((frame[ethernet_type_offset] << 8) |
+                                  frame[ethernet_type_offset + 1]);
   if (ethertype != ethernet_type_ipv6) {
     return false;
   }
-  if (frame[IPV6_NEXT_HEADER_OFFSET] != ip_proto_bcmp) {
+  if (frame[ipv6_next_header_offset] != ip_proto_bcmp) {
     return false;
   }
   // BcmpHeader.type is a uint16_t at the start of the BCMP header. The rest
@@ -79,7 +37,7 @@ static bool is_bcmp_heartbeat(const uint8_t *frame, uint32_t len) {
   // assumption that all BM nodes share endianness. Read in that same
   // convention (host-endian uint16_t).
   uint16_t bcmp_type;
-  memcpy(&bcmp_type, frame + BCMP_HEADER_OFFSET, sizeof(bcmp_type));
+  memcpy(&bcmp_type, frame + bcmp_header_offset, sizeof(bcmp_type));
   return bcmp_type == BcmpHeartbeatMessage;
 }
 

--- a/network/bm_link_heartbeat_monitor.c
+++ b/network/bm_link_heartbeat_monitor.c
@@ -1,5 +1,6 @@
 #include "bm_link_heartbeat_monitor.h"
 #include "bm_os.h"
+#include "timer_callback_handler.h"
 #include <string.h>
 
 // We deliberately do NOT include bcmp/messages.h here. messages.h pulls in
@@ -94,11 +95,11 @@ static bool is_bcmp_heartbeat(const uint8_t *frame, uint32_t len) {
 }
 
 // ----------------------------------------------------------------------------
-// Timer callback
+// Liveness check
 // ----------------------------------------------------------------------------
 
-static void liveness_timer_cb(BmTimer timer) {
-  (void)timer;
+static void liveness_check_handler(void *arg) {
+  (void)arg;
   if (!MONITOR.initialized) {
     return;
   }
@@ -112,9 +113,8 @@ static void liveness_timer_cb(BmTimer timer) {
 
   bm_semaphore_take(MONITOR.lock, UINT32_MAX);
   for (uint8_t i = 0; i < MONITOR.cfg.num_ports; i++) {
-    if (MONITOR.ports[i].up &&
-        time_remaining(MONITOR.ports[i].last_hb_ticks, now, timeout_ticks) ==
-            0) {
+    if (MONITOR.ports[i].up && time_remaining(MONITOR.ports[i].last_hb_ticks,
+                                              now, timeout_ticks) == 0) {
       MONITOR.ports[i].up = false;
       fire_down[i] = true;
     }
@@ -126,6 +126,14 @@ static void liveness_timer_cb(BmTimer timer) {
       MONITOR.cfg.on_link_change(i, false, MONITOR.cfg.ctx);
     }
   }
+}
+
+static void liveness_timer_cb(BmTimer timer) {
+  (void)timer;
+  // Non-blocking: post the real work to the timer_callback_handler task.
+  // A 0 ms timeout is intentional — if the handler queue is full, dropping
+  // one liveness check is far cheaper than stalling the timer-service task.
+  timer_callback_handler_send_cb(liveness_check_handler, NULL, 0);
 }
 
 // ----------------------------------------------------------------------------

--- a/network/bm_link_heartbeat_monitor.c
+++ b/network/bm_link_heartbeat_monitor.c
@@ -1,0 +1,268 @@
+#include "bm_link_heartbeat_monitor.h"
+#include "bm_os.h"
+#include <string.h>
+
+// We deliberately do NOT include bcmp/messages.h here. messages.h pulls in
+// the entire BCMP message catalog (configuration, dfu, cbor, etc.), which is
+// far more than this helper needs and creates an unwanted compile-time
+// dependency on tinycbor headers. Instead, we replicate the two stable
+// protocol values we depend on. If either of these ever changes, the
+// canonical definitions live in bcmp/messages.h.
+
+/// Mirror of BcmpHeartbeatMessage from bcmp/messages.h.
+/// The full BcmpHeader is 12 bytes; we only need to read the
+/// first two bytes, so we don't replicate the whole struct.
+#define BCMP_HEARTBEAT_MESSAGE_TYPE 0x0001
+
+// ----------------------------------------------------------------------------
+// Frame parsing constants
+// ----------------------------------------------------------------------------
+//
+// The L2 frames passed to observe() are raw Ethernet + IPv6 + (optional)
+// upper-layer payload, exactly as they appear on the wire (no FCS — that is
+// added/stripped by hardware and is never present at this layer).
+//
+// We mirror the offset constants from network/l2.c rather than including
+// them, because those are file-local #defines. Duplicating four numbers
+// here is cheaper than refactoring l2.c to export a header.
+//
+//   Offset  Bytes  Field
+//   0       6      Ethernet destination MAC
+//   6       6      Ethernet source MAC
+//   12      2      Ethernet type           = ethernet_type_ipv6 (0x86DD)
+//   14      4      IPv6 version/class/flow
+//   18      2      IPv6 payload length
+//   20      1      IPv6 next header        = ip_proto_bcmp (0xBC)
+//   21      1      IPv6 hop limit
+//   22      16     IPv6 source address
+//   38      16     IPv6 destination address
+//   54      ...    BCMP header (12 bytes; see BcmpHeader in bcmp/messages.h).
+//                  First field is uint16_t type; we compare to
+//                  BcmpHeartbeatMessage.
+
+#define ETH_TYPE_OFFSET 12
+#define IPV6_NEXT_HEADER_OFFSET 20
+#define BCMP_HEADER_OFFSET 54
+// BCMP header is 12 bytes (see bcmp/messages.h::BcmpHeader). We only need to
+// read the first 2 bytes (the type field).
+#define BCMP_HEADER_LEN 12
+#define MIN_HEARTBEAT_FRAME_LEN (BCMP_HEADER_OFFSET + BCMP_HEADER_LEN)
+
+// ----------------------------------------------------------------------------
+// Singleton monitor state
+// ----------------------------------------------------------------------------
+
+typedef struct {
+  bool up;
+  uint32_t last_hb_ticks;
+} PortState;
+
+typedef struct {
+  BmLinkHeartbeatMonitorCfg cfg;
+  PortState ports[BM_LINK_HEARTBEAT_MAX_PORTS];
+  BmTimer timer;
+  BmSemaphore lock;
+  bool initialized;
+} Monitor;
+
+static Monitor MONITOR;
+
+// ----------------------------------------------------------------------------
+// Frame inspection
+// ----------------------------------------------------------------------------
+
+static bool is_bcmp_heartbeat(const uint8_t *frame, uint32_t len) {
+  if (len < MIN_HEARTBEAT_FRAME_LEN) {
+    return false;
+  }
+  // Ethertype: big-endian on the wire.
+  uint16_t ethertype =
+      (uint16_t)((frame[ETH_TYPE_OFFSET] << 8) | frame[ETH_TYPE_OFFSET + 1]);
+  if (ethertype != ethernet_type_ipv6) {
+    return false;
+  }
+  if (frame[IPV6_NEXT_HEADER_OFFSET] != ip_proto_bcmp) {
+    return false;
+  }
+  // BcmpHeader.type is a uint16_t at the start of the BCMP header. The rest
+  // of bcmp/ uses the struct directly without explicit byte-swapping, on the
+  // assumption that all BM nodes share endianness. Read in that same
+  // convention (host-endian uint16_t).
+  uint16_t bcmp_type;
+  memcpy(&bcmp_type, frame + BCMP_HEADER_OFFSET, sizeof(bcmp_type));
+  return bcmp_type == BCMP_HEARTBEAT_MESSAGE_TYPE;
+}
+
+// ----------------------------------------------------------------------------
+// Timer callback
+// ----------------------------------------------------------------------------
+
+static void liveness_timer_cb(BmTimer timer) {
+  (void)timer;
+  if (!MONITOR.initialized) {
+    return;
+  }
+
+  // Snapshot which ports just transitioned, then fire callbacks outside the
+  // lock to keep lock ordering simple for consumers (their on_link_change
+  // typically takes L2's callback-list lock).
+  bool fire_down[BM_LINK_HEARTBEAT_MAX_PORTS] = {0};
+  uint32_t now = bm_get_tick_count();
+  uint32_t timeout_ticks = bm_ms_to_ticks(MONITOR.cfg.timeout_ms);
+
+  bm_semaphore_take(MONITOR.lock, UINT32_MAX);
+  for (uint8_t i = 0; i < MONITOR.cfg.num_ports; i++) {
+    if (MONITOR.ports[i].up &&
+        time_remaining(MONITOR.ports[i].last_hb_ticks, now, timeout_ticks) ==
+            0) {
+      MONITOR.ports[i].up = false;
+      fire_down[i] = true;
+    }
+  }
+  bm_semaphore_give(MONITOR.lock);
+
+  for (uint8_t i = 0; i < MONITOR.cfg.num_ports; i++) {
+    if (fire_down[i]) {
+      MONITOR.cfg.on_link_change(i, false, MONITOR.cfg.ctx);
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Public API
+// ----------------------------------------------------------------------------
+
+/*!
+  @brief Initialize the singleton monitor and start its check timer.
+
+  @param cfg Configuration; copied internally.
+
+  @return BmOK on success.
+  @return BmEINVAL on null pointer, num_ports out of range, or null callback.
+  @return BmEALREADY if init was already called (call deinit first).
+  @return BmENOMEM if the timer or lock cannot be allocated.
+ */
+BmErr bm_link_heartbeat_monitor_init(const BmLinkHeartbeatMonitorCfg *cfg) {
+  if (!cfg || !cfg->on_link_change) {
+    return BmEINVAL;
+  }
+  if (cfg->num_ports == 0 || cfg->num_ports > BM_LINK_HEARTBEAT_MAX_PORTS) {
+    return BmEINVAL;
+  }
+  if (MONITOR.initialized) {
+    return BmEALREADY;
+  }
+
+  memset(&MONITOR, 0, sizeof(MONITOR));
+  MONITOR.cfg = *cfg;
+
+  uint32_t now = bm_get_tick_count();
+  for (uint8_t i = 0; i < MONITOR.cfg.num_ports; i++) {
+    MONITOR.ports[i].up = MONITOR.cfg.start_ports_up;
+    MONITOR.ports[i].last_hb_ticks = now;
+  }
+
+  MONITOR.lock = bm_mutex_create();
+  if (!MONITOR.lock) {
+    return BmENOMEM;
+  }
+
+  MONITOR.timer = bm_timer_create("bm_link_hb", MONITOR.cfg.check_period_ms,
+                                  true, /* timer_id */ NULL, liveness_timer_cb);
+  if (!MONITOR.timer) {
+    bm_semaphore_delete(MONITOR.lock);
+    MONITOR.lock = NULL;
+    return BmENOMEM;
+  }
+
+  MONITOR.initialized = true;
+
+  BmErr err = bm_timer_start(MONITOR.timer, 0);
+  if (err != BmOK) {
+    MONITOR.initialized = false;
+    bm_timer_delete(MONITOR.timer, 0);
+    MONITOR.timer = NULL;
+    bm_semaphore_delete(MONITOR.lock);
+    MONITOR.lock = NULL;
+    return err;
+  }
+
+  return BmOK;
+}
+
+/*!
+  @brief Observe one received L2 frame.
+
+  @details Should be called by the transport's RX path for every frame. The
+           monitor inspects the bytes to decide whether the frame is a BCMP
+           heartbeat; non-heartbeat frames are silently ignored (returning
+           BmOK). On a heartbeat, refreshes per-port last-seen and may fire
+           a synchronous up edge if the port was previously down.
+
+  @param port_num One-based ingress port number (1..num_ports). Matches the
+                  port number convention used elsewhere in bm_core (1..15;
+                  0 means "all", which is invalid here).
+  @param frame    Pointer to the raw L2 Ethernet frame. May be modified by
+                  callers afterward; the monitor does not retain the
+                  pointer.
+  @param len      Frame length in bytes.
+
+  @return BmOK on success (whether or not the frame was a heartbeat).
+  @return BmEINVAL on null pointer, out-of-range port, or before init.
+ */
+BmErr bm_link_heartbeat_monitor_observe(uint8_t port_num, const uint8_t *frame,
+                                        uint32_t len) {
+  if (!MONITOR.initialized || !frame) {
+    return BmEINVAL;
+  }
+  if (port_num == 0 || port_num > MONITOR.cfg.num_ports) {
+    return BmEINVAL;
+  }
+
+  if (!is_bcmp_heartbeat(frame, len)) {
+    return BmOK; // not an error; just not relevant
+  }
+
+  uint8_t idx = port_num - 1;
+  bool fire_up = false;
+
+  bm_semaphore_take(MONITOR.lock, UINT32_MAX);
+  MONITOR.ports[idx].last_hb_ticks = bm_get_tick_count();
+  if (!MONITOR.ports[idx].up) {
+    MONITOR.ports[idx].up = true;
+    fire_up = true;
+  }
+  bm_semaphore_give(MONITOR.lock);
+
+  if (fire_up) {
+    MONITOR.cfg.on_link_change(idx, true, MONITOR.cfg.ctx);
+  }
+  return BmOK;
+}
+
+/*!
+  @brief Stop the timer, release internal resources, and mark the monitor
+         uninitialized. Idempotent.
+
+  @details Production code typically does not need to call this — the monitor
+           is a boot-time singleton. Exposed mainly so unit tests can reset
+           state between cases.
+
+  @return BmOK in all cases.
+ */
+BmErr bm_link_heartbeat_monitor_deinit(void) {
+  if (!MONITOR.initialized) {
+    return BmOK; // idempotent
+  }
+  MONITOR.initialized = false;
+  if (MONITOR.timer) {
+    bm_timer_stop(MONITOR.timer, 0);
+    bm_timer_delete(MONITOR.timer, 0);
+    MONITOR.timer = NULL;
+  }
+  if (MONITOR.lock) {
+    bm_semaphore_delete(MONITOR.lock);
+    MONITOR.lock = NULL;
+  }
+  return BmOK;
+}

--- a/network/bm_link_heartbeat_monitor.h
+++ b/network/bm_link_heartbeat_monitor.h
@@ -1,0 +1,101 @@
+#ifndef __BM_LINK_HEARTBEAT_MONITOR_H__
+#define __BM_LINK_HEARTBEAT_MONITOR_H__
+
+#include "util.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+  @file bm_link_heartbeat_monitor.h
+  @brief Heartbeat-driven link-state monitor for transports without a PHY.
+
+  @details For transports that lack an out-of-band link signal (UART tunnels,
+           network sockets, etc.), this helper infers per-port link state by
+           watching the BCMP heartbeats already produced by every active node.
+
+           The transport calls bm_link_heartbeat_monitor_observe() for every
+           received L2 frame. Heartbeats refresh per-port liveness; an
+           internal timer fires the configured on_link_change callback when a
+           port times out or comes back online.
+
+           This module is a singleton: a single monitor lives in the .c file's
+           BSS (~150 bytes on a 32-bit target). Executables that never call
+           init pay only this fixed cost; with linker --gc-sections it is
+           reclaimed entirely. Multi-instance use is intentionally unsupported.
+
+           This module is the software analogue of bm_adin2111's hardware
+           link-change interrupt. It does not modify L2, BCMP, or any other
+           bm_core component.
+ */
+
+/// Maximum number of ports the monitor will accept. BM L2 encodes ingress/
+/// egress ports in 4 bits, so 15 is the spec limit.
+#define BM_LINK_HEARTBEAT_MAX_PORTS 15
+
+/*!
+  @brief Edge-triggered link-state callback.
+
+  @details Fired once per state transition (up<->down). Not called during
+           steady state. Called outside the monitor's internal lock so the
+           callback may safely acquire other locks (typically the L2
+           callback registry).
+
+  @param port_idx Zero-based port index (port_num - 1).
+  @param up      True if the port has become live, false if it has timed out.
+  @param ctx     Caller-supplied context from BmLinkHeartbeatMonitorCfg.
+ */
+typedef void (*BmLinkHeartbeatMonitorCb)(uint8_t port_idx, bool up, void *ctx);
+
+/*!
+  @brief Configuration passed to bm_link_heartbeat_monitor_init.
+
+  @details All fields are copied into the monitor; the cfg pointer need not
+           remain valid after init returns.
+ */
+typedef struct {
+  /// Number of ports to track (1..BM_LINK_HEARTBEAT_MAX_PORTS).
+  uint8_t num_ports;
+
+  /// Mark a port down after this many milliseconds with no observed
+  /// heartbeat. Should be a small multiple of the BCMP heartbeat period
+  /// (typically 2 * 10s = 20000 ms).
+  uint32_t timeout_ms;
+
+  /// How often the monitor wakes to check for timed-out ports.
+  /// Setting this lower trades wake-ups for sharper down-edge timing.
+  /// Typical value: 1000.
+  uint32_t check_period_ms;
+
+  /// If true, all ports start in the up state and no initial callback is
+  /// fired. The first down edge can occur after timeout_ms with no
+  /// observed heartbeat. Use this when the transport's send path does
+  /// not gate on link state and you want heartbeats to flow at boot.
+  ///
+  /// If false, all ports start down. The first up edge fires when a
+  /// heartbeat is observed. Note that L2 will mask TX on ports it
+  /// believes are down (see bm_l2_tx in network/l2.c) — only set this to
+  /// false if the transport bypasses that mask, otherwise the link can
+  /// never bootstrap.
+  bool start_ports_up;
+
+  /// Edge-triggered callback. Required (init returns BmEINVAL if null).
+  BmLinkHeartbeatMonitorCb on_link_change;
+
+  /// Opaque context passed to on_link_change.
+  void *ctx;
+} BmLinkHeartbeatMonitorCfg;
+
+BmErr bm_link_heartbeat_monitor_init(const BmLinkHeartbeatMonitorCfg *cfg);
+BmErr bm_link_heartbeat_monitor_observe(uint8_t port_num, const uint8_t *frame,
+                                        uint32_t len);
+BmErr bm_link_heartbeat_monitor_deinit(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __BM_LINK_HEARTBEAT_MONITOR_H__

--- a/network/bm_link_heartbeat_monitor.h
+++ b/network/bm_link_heartbeat_monitor.h
@@ -70,16 +70,21 @@ typedef struct {
   /// Typical value: 1000.
   uint32_t check_period_ms;
 
-  /// If true, all ports start in the up state and no initial callback is
-  /// fired. The first down edge can occur after timeout_ms with no
-  /// observed heartbeat. Use this when the transport's send path does
-  /// not gate on link state and you want heartbeats to flow at boot.
+  /// If true, all ports start in the up state and init fires a
+  /// synchronous up edge via on_link_change for each port before
+  /// returning. This keeps the consumer's view (e.g. bm_l2's per-port
+  /// link state) in sync with the monitor's internal state, which
+  /// matters because bm_l2 gates heartbeat TX on link-up — without the
+  /// initial callback, two peers could never bootstrap from each other.
+  /// The first down edge can occur after timeout_ms with no observed
+  /// heartbeat. Use this for transports where link liveness is inferred
+  /// purely from received heartbeats (UART tunnels, sockets, etc.).
   ///
-  /// If false, all ports start down. The first up edge fires when a
-  /// heartbeat is observed. Note that L2 will mask TX on ports it
-  /// believes are down (see bm_l2_tx in network/l2.c) — only set this to
-  /// false if the transport bypasses that mask, otherwise the link can
-  /// never bootstrap.
+  /// If false, all ports start down and no initial callback is fired.
+  /// The first up edge fires when a heartbeat is observed. Note that L2
+  /// will mask TX on ports it believes are down (see bm_l2_tx in
+  /// network/l2.c) — only set this to false if the transport bypasses
+  /// that mask, otherwise the link can never bootstrap.
   bool start_ports_up;
 
   /// Edge-triggered callback. Required (init returns BmEINVAL if null).

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -639,3 +639,16 @@ if (NOT WIN32)
     )
     create_gtest("bm_linux" "${LINUX_NET_SRCS}")
 endif()
+
+# Heartbeat-driven link monitor tests
+set (BM_LINK_HEARTBEAT_MONITOR_SRCS
+    # File we're testing
+    ${NETWORK_DIR}/bm_link_heartbeat_monitor.c
+
+    # Support files
+    ${COMMON_DIR}/util.c
+
+    # Stubs
+    ${STUB_DIR}/bm_os_stub.c
+)
+create_gtest("bm_link_heartbeat_monitor" "${BM_LINK_HEARTBEAT_MONITOR_SRCS}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -650,5 +650,6 @@ set (BM_LINK_HEARTBEAT_MONITOR_SRCS
 
     # Stubs
     ${STUB_DIR}/bm_os_stub.c
+    ${STUB_DIR}/timer_callback_handler_stub.c
 )
 create_gtest("bm_link_heartbeat_monitor" "${BM_LINK_HEARTBEAT_MONITOR_SRCS}")

--- a/test/src/bm_link_heartbeat_monitor_test.cpp
+++ b/test/src/bm_link_heartbeat_monitor_test.cpp
@@ -1,0 +1,420 @@
+#include <gtest/gtest.h>
+#include <helpers.hpp>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "fff.h"
+
+DEFINE_FFF_GLOBALS;
+
+extern "C" {
+#include "bm_link_heartbeat_monitor.h"
+#include "mock_bm_os.h"
+}
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+namespace {
+
+constexpr uint32_t TIMEOUT_MS = 20000;
+constexpr uint32_t CHECK_PERIOD_MS = 1000;
+
+// Track on_link_change invocations.
+struct LinkChangeRecord {
+  uint8_t port_idx;
+  bool up;
+};
+
+struct CallbackTracker {
+  std::vector<LinkChangeRecord> events;
+  void *expected_ctx = nullptr;
+  uint32_t bad_ctx_count = 0;
+};
+
+void on_link_change(uint8_t port_idx, bool up, void *ctx) {
+  auto *t = static_cast<CallbackTracker *>(ctx);
+  if (t->expected_ctx != nullptr && ctx != t->expected_ctx) {
+    t->bad_ctx_count++;
+  }
+  t->events.push_back({port_idx, up});
+}
+
+// ---------------------------------------------------------------------------
+// Frame builders
+// ---------------------------------------------------------------------------
+//
+// Mirror the on-wire layout used by network/l2.c:
+//   [0..5]   destination MAC
+//   [6..11]  source MAC
+//   [12..13] ethertype           (big-endian)
+//   [14..17] IPv6 vers/class/flow
+//   [18..19] IPv6 payload length (big-endian)
+//   [20]     IPv6 next header
+//   [21]     IPv6 hop limit
+//   [22..37] IPv6 source addr
+//   [38..53] IPv6 dest addr
+//   [54..]   upper-layer payload
+
+constexpr size_t ETH_HDR_LEN = 14;
+constexpr size_t IPV6_HDR_LEN = 40;
+constexpr size_t FRAME_HDR_LEN = ETH_HDR_LEN + IPV6_HDR_LEN;
+constexpr size_t BCMP_HDR_LEN = 12;
+constexpr uint16_t ETH_TYPE_IPV6 = 0x86DD;
+constexpr uint8_t IP_PROTO_BCMP = 0xBC;
+constexpr uint16_t HEARTBEAT_TYPE = 0x0001;
+constexpr uint16_t INFO_REQUEST_TYPE = 0x0004; // some other BCMP type
+
+std::vector<uint8_t> build_frame(uint16_t ethertype, uint8_t next_header,
+                                 uint16_t bcmp_type, size_t total_len) {
+  std::vector<uint8_t> f(total_len, 0);
+  f[12] = static_cast<uint8_t>(ethertype >> 8);
+  f[13] = static_cast<uint8_t>(ethertype & 0xFF);
+  f[20] = next_header;
+  if (total_len >= FRAME_HDR_LEN + sizeof(bcmp_type)) {
+    memcpy(f.data() + FRAME_HDR_LEN, &bcmp_type, sizeof(bcmp_type));
+  }
+  return f;
+}
+
+std::vector<uint8_t> build_heartbeat_frame() {
+  return build_frame(ETH_TYPE_IPV6, IP_PROTO_BCMP, HEARTBEAT_TYPE,
+                     FRAME_HDR_LEN + BCMP_HDR_LEN);
+}
+
+std::vector<uint8_t> build_bcmp_non_heartbeat_frame() {
+  return build_frame(ETH_TYPE_IPV6, IP_PROTO_BCMP, INFO_REQUEST_TYPE,
+                     FRAME_HDR_LEN + BCMP_HDR_LEN);
+}
+
+std::vector<uint8_t> build_udp_frame() {
+  return build_frame(ETH_TYPE_IPV6, /*UDP*/ 0x11, 0, FRAME_HDR_LEN + 8);
+}
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+//
+// The mocked bm_timer_create returns a sentinel pointer; we don't need it to
+// fire on its own, the tests invoke the captured callback directly with a
+// controlled bm_get_tick_count.
+
+void *MUTEX_HANDLE = reinterpret_cast<void *>(0xA11CABBA);
+void *TIMER_HANDLE = reinterpret_cast<void *>(0xCAFEFEED);
+
+// Captured timer callback so tests can drive the down-edge logic directly.
+BmTimerCb captured_timer_cb = nullptr;
+
+BmTimer create_timer_capture(const char *name, uint32_t period_ms,
+                             bool auto_reload, void *time_id, BmTimerCb cb) {
+  (void)name;
+  (void)period_ms;
+  (void)auto_reload;
+  (void)time_id;
+  captured_timer_cb = cb;
+  return TIMER_HANDLE;
+}
+
+uint32_t mocked_now_ms = 0;
+uint32_t get_tick_count_custom() { return mocked_now_ms; }
+uint32_t ms_to_ticks_passthrough(uint32_t ms) { return ms; }
+
+void install_default_os_mocks() {
+  RESET_FAKE(bm_mutex_create);
+  RESET_FAKE(bm_semaphore_take);
+  RESET_FAKE(bm_semaphore_give);
+  RESET_FAKE(bm_semaphore_delete);
+  RESET_FAKE(bm_timer_create);
+  RESET_FAKE(bm_timer_start);
+  RESET_FAKE(bm_timer_stop);
+  RESET_FAKE(bm_timer_delete);
+  RESET_FAKE(bm_get_tick_count);
+  RESET_FAKE(bm_ms_to_ticks);
+
+  bm_mutex_create_fake.return_val = MUTEX_HANDLE;
+  bm_semaphore_take_fake.return_val = BmOK;
+  bm_semaphore_give_fake.return_val = BmOK;
+  bm_timer_create_fake.custom_fake = create_timer_capture;
+  bm_timer_start_fake.return_val = BmOK;
+  bm_timer_stop_fake.return_val = BmOK;
+  bm_get_tick_count_fake.custom_fake = get_tick_count_custom;
+  bm_ms_to_ticks_fake.custom_fake = ms_to_ticks_passthrough;
+
+  captured_timer_cb = nullptr;
+  mocked_now_ms = 1000;
+}
+
+class HeartbeatMonitor : public ::testing::Test {
+protected:
+  CallbackTracker tracker;
+
+  void SetUp() override { install_default_os_mocks(); }
+
+  void TearDown() override { bm_link_heartbeat_monitor_deinit(); }
+
+  BmLinkHeartbeatMonitorCfg make_cfg(uint8_t num_ports = 4,
+                                     bool start_up = false) {
+    BmLinkHeartbeatMonitorCfg cfg{};
+    cfg.num_ports = num_ports;
+    cfg.timeout_ms = TIMEOUT_MS;
+    cfg.check_period_ms = CHECK_PERIOD_MS;
+    cfg.start_ports_up = start_up;
+    cfg.on_link_change = on_link_change;
+    cfg.ctx = &tracker;
+    tracker.expected_ctx = &tracker;
+    return cfg;
+  }
+};
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// init / deinit
+// ---------------------------------------------------------------------------
+
+TEST_F(HeartbeatMonitor, init_rejects_invalid_args) {
+  EXPECT_EQ(bm_link_heartbeat_monitor_init(nullptr), BmEINVAL);
+
+  BmLinkHeartbeatMonitorCfg cfg = make_cfg();
+  cfg.on_link_change = nullptr;
+  EXPECT_EQ(bm_link_heartbeat_monitor_init(&cfg), BmEINVAL);
+
+  cfg = make_cfg();
+  cfg.num_ports = 0;
+  EXPECT_EQ(bm_link_heartbeat_monitor_init(&cfg), BmEINVAL);
+
+  cfg = make_cfg();
+  cfg.num_ports = BM_LINK_HEARTBEAT_MAX_PORTS + 1;
+  EXPECT_EQ(bm_link_heartbeat_monitor_init(&cfg), BmEINVAL);
+}
+
+TEST_F(HeartbeatMonitor, init_creates_timer_and_starts_it) {
+  BmLinkHeartbeatMonitorCfg cfg = make_cfg();
+  EXPECT_EQ(bm_link_heartbeat_monitor_init(&cfg), BmOK);
+
+  EXPECT_EQ(bm_timer_create_fake.call_count, 1u);
+  EXPECT_EQ(bm_timer_create_fake.arg1_val, CHECK_PERIOD_MS); // period
+  EXPECT_TRUE(bm_timer_create_fake.arg2_val);                // auto_reload
+  EXPECT_EQ(bm_timer_start_fake.call_count, 1u);
+  EXPECT_NE(captured_timer_cb, nullptr);
+
+  EXPECT_EQ(tracker.events.size(), 0u); // no spurious callbacks at init
+}
+
+TEST_F(HeartbeatMonitor, init_returns_enomem_when_timer_create_fails) {
+  bm_timer_create_fake.custom_fake = nullptr;
+  bm_timer_create_fake.return_val = nullptr;
+
+  BmLinkHeartbeatMonitorCfg cfg = make_cfg();
+  EXPECT_EQ(bm_link_heartbeat_monitor_init(&cfg), BmENOMEM);
+}
+
+TEST_F(HeartbeatMonitor, deinit_is_idempotent_and_releases_resources) {
+  BmLinkHeartbeatMonitorCfg cfg = make_cfg();
+  ASSERT_EQ(bm_link_heartbeat_monitor_init(&cfg), BmOK);
+  EXPECT_EQ(bm_link_heartbeat_monitor_deinit(), BmOK);
+  EXPECT_EQ(bm_timer_stop_fake.call_count, 1u);
+  EXPECT_EQ(bm_timer_delete_fake.call_count, 1u);
+  // Second call on deinited monitor: still OK, no further OS work.
+  EXPECT_EQ(bm_link_heartbeat_monitor_deinit(), BmOK);
+  EXPECT_EQ(bm_timer_stop_fake.call_count, 1u);
+  EXPECT_EQ(bm_timer_delete_fake.call_count, 1u);
+}
+
+// ---------------------------------------------------------------------------
+// observe()
+// ---------------------------------------------------------------------------
+
+TEST_F(HeartbeatMonitor, observe_rejects_invalid_args) {
+  BmLinkHeartbeatMonitorCfg cfg = make_cfg(/*num_ports=*/2);
+  ASSERT_EQ(bm_link_heartbeat_monitor_init(&cfg), BmOK);
+
+  auto frame = build_heartbeat_frame();
+  EXPECT_EQ(bm_link_heartbeat_monitor_observe(1, nullptr, frame.size()),
+            BmEINVAL);
+  EXPECT_EQ(bm_link_heartbeat_monitor_observe(0, frame.data(), frame.size()),
+            BmEINVAL);
+  EXPECT_EQ(bm_link_heartbeat_monitor_observe(3, frame.data(), frame.size()),
+            BmEINVAL);
+}
+
+TEST_F(HeartbeatMonitor, observe_ignores_non_heartbeat_traffic) {
+  BmLinkHeartbeatMonitorCfg cfg = make_cfg();
+  ASSERT_EQ(bm_link_heartbeat_monitor_init(&cfg), BmOK);
+
+  auto udp = build_udp_frame();
+  auto bcmp_other = build_bcmp_non_heartbeat_frame();
+  std::vector<uint8_t> tiny(10, 0); // too short
+
+  EXPECT_EQ(bm_link_heartbeat_monitor_observe(1, udp.data(), udp.size()),
+            BmOK);
+  EXPECT_EQ(bm_link_heartbeat_monitor_observe(1, bcmp_other.data(),
+                                              bcmp_other.size()),
+            BmOK);
+  EXPECT_EQ(bm_link_heartbeat_monitor_observe(1, tiny.data(), tiny.size()),
+            BmOK);
+
+  EXPECT_EQ(tracker.events.size(), 0u);
+}
+
+TEST_F(HeartbeatMonitor, observe_first_heartbeat_fires_up_edge) {
+  BmLinkHeartbeatMonitorCfg cfg = make_cfg(/*num_ports=*/2);
+  ASSERT_EQ(bm_link_heartbeat_monitor_init(&cfg), BmOK);
+
+  auto hb = build_heartbeat_frame();
+  EXPECT_EQ(bm_link_heartbeat_monitor_observe(2, hb.data(), hb.size()),
+            BmOK);
+
+  ASSERT_EQ(tracker.events.size(), 1u);
+  EXPECT_EQ(tracker.events[0].port_idx, 1); // port_num 2 -> idx 1
+  EXPECT_TRUE(tracker.events[0].up);
+}
+
+TEST_F(HeartbeatMonitor, observe_subsequent_heartbeats_do_not_refire) {
+  BmLinkHeartbeatMonitorCfg cfg = make_cfg();
+  ASSERT_EQ(bm_link_heartbeat_monitor_init(&cfg), BmOK);
+
+  auto hb = build_heartbeat_frame();
+  for (int i = 0; i < 5; i++) {
+    mocked_now_ms += 1000;
+    EXPECT_EQ(bm_link_heartbeat_monitor_observe(1, hb.data(), hb.size()),
+              BmOK);
+  }
+  EXPECT_EQ(tracker.events.size(), 1u); // only the first one fired
+}
+
+TEST_F(HeartbeatMonitor, observe_per_port_independence) {
+  BmLinkHeartbeatMonitorCfg cfg = make_cfg(/*num_ports=*/3);
+  ASSERT_EQ(bm_link_heartbeat_monitor_init(&cfg), BmOK);
+
+  auto hb = build_heartbeat_frame();
+  EXPECT_EQ(bm_link_heartbeat_monitor_observe(1, hb.data(), hb.size()),
+            BmOK);
+  EXPECT_EQ(bm_link_heartbeat_monitor_observe(3, hb.data(), hb.size()),
+            BmOK);
+
+  ASSERT_EQ(tracker.events.size(), 2u);
+  EXPECT_EQ(tracker.events[0].port_idx, 0);
+  EXPECT_EQ(tracker.events[1].port_idx, 2);
+  EXPECT_TRUE(tracker.events[0].up);
+  EXPECT_TRUE(tracker.events[1].up);
+}
+
+// ---------------------------------------------------------------------------
+// Timer-driven down edges
+// ---------------------------------------------------------------------------
+
+TEST_F(HeartbeatMonitor, timer_fires_down_edge_after_timeout) {
+  BmLinkHeartbeatMonitorCfg cfg = make_cfg(/*num_ports=*/2);
+  ASSERT_EQ(bm_link_heartbeat_monitor_init(&cfg), BmOK);
+  ASSERT_NE(captured_timer_cb, nullptr);
+
+  // Bring port 1 up.
+  auto hb = build_heartbeat_frame();
+  ASSERT_EQ(bm_link_heartbeat_monitor_observe(1, hb.data(), hb.size()),
+            BmOK);
+  ASSERT_EQ(tracker.events.size(), 1u);
+
+  // Tick the timer at t = last_hb + timeout - 1 -- still within the window.
+  mocked_now_ms += TIMEOUT_MS - 1;
+  captured_timer_cb(TIMER_HANDLE);
+  EXPECT_EQ(tracker.events.size(), 1u);
+
+  // Tick past timeout: edge to down expected.
+  mocked_now_ms += 2;
+  captured_timer_cb(TIMER_HANDLE);
+  ASSERT_EQ(tracker.events.size(), 2u);
+  EXPECT_EQ(tracker.events[1].port_idx, 0);
+  EXPECT_FALSE(tracker.events[1].up);
+
+  // Subsequent ticks do not re-fire while still down.
+  mocked_now_ms += TIMEOUT_MS;
+  captured_timer_cb(TIMER_HANDLE);
+  EXPECT_EQ(tracker.events.size(), 2u);
+}
+
+TEST_F(HeartbeatMonitor, recovery_fires_up_edge_after_down) {
+  BmLinkHeartbeatMonitorCfg cfg = make_cfg();
+  ASSERT_EQ(bm_link_heartbeat_monitor_init(&cfg), BmOK);
+
+  auto hb = build_heartbeat_frame();
+  ASSERT_EQ(bm_link_heartbeat_monitor_observe(1, hb.data(), hb.size()),
+            BmOK);
+
+  // Force timeout.
+  mocked_now_ms += TIMEOUT_MS + 1;
+  captured_timer_cb(TIMER_HANDLE);
+  ASSERT_EQ(tracker.events.size(), 2u);
+  EXPECT_FALSE(tracker.events[1].up);
+
+  // Receive heartbeat -> edge back up.
+  ASSERT_EQ(bm_link_heartbeat_monitor_observe(1, hb.data(), hb.size()),
+            BmOK);
+  ASSERT_EQ(tracker.events.size(), 3u);
+  EXPECT_TRUE(tracker.events[2].up);
+}
+
+// ---------------------------------------------------------------------------
+// Bootstrap policies
+// ---------------------------------------------------------------------------
+
+TEST_F(HeartbeatMonitor, start_ports_up_does_not_fire_initial_callbacks) {
+  BmLinkHeartbeatMonitorCfg cfg = make_cfg(/*num_ports=*/3, /*start_up=*/true);
+  ASSERT_EQ(bm_link_heartbeat_monitor_init(&cfg), BmOK);
+  EXPECT_EQ(tracker.events.size(), 0u);
+}
+
+TEST_F(HeartbeatMonitor,
+       start_ports_up_fires_down_when_no_heartbeat_within_timeout) {
+  BmLinkHeartbeatMonitorCfg cfg = make_cfg(/*num_ports=*/2, /*start_up=*/true);
+  ASSERT_EQ(bm_link_heartbeat_monitor_init(&cfg), BmOK);
+
+  // Tick past timeout; both ports should fire down.
+  mocked_now_ms += TIMEOUT_MS + 1;
+  captured_timer_cb(TIMER_HANDLE);
+
+  ASSERT_EQ(tracker.events.size(), 2u);
+  EXPECT_FALSE(tracker.events[0].up);
+  EXPECT_FALSE(tracker.events[1].up);
+}
+
+TEST_F(HeartbeatMonitor, start_ports_up_first_heartbeat_does_not_fire_up) {
+  BmLinkHeartbeatMonitorCfg cfg = make_cfg(/*num_ports=*/2, /*start_up=*/true);
+  ASSERT_EQ(bm_link_heartbeat_monitor_init(&cfg), BmOK);
+
+  auto hb = build_heartbeat_frame();
+  EXPECT_EQ(bm_link_heartbeat_monitor_observe(1, hb.data(), hb.size()),
+            BmOK);
+  // Already considered up; observe just refreshed last_hb_ticks.
+  EXPECT_EQ(tracker.events.size(), 0u);
+
+  // Tick well past timeout *for port 2 only* (port 1 just got refreshed).
+  mocked_now_ms += TIMEOUT_MS + 1;
+  captured_timer_cb(TIMER_HANDLE);
+
+  // Port 1 should still be up (heartbeat was at mocked_now_ms - timeout - 1
+  // + small delta -> within window after timer tick). Wait, we need to be
+  // careful: we incremented mocked_now_ms by timeout+1 AFTER the heartbeat,
+  // so port 1 is also out of window.
+  //
+  // Adjust: the heartbeat refreshed last_hb_ticks to the value of
+  // mocked_now_ms at time of observe (before the increment). That value is
+  // (initial)1000. After incrementing by timeout+1, now = 1000 + timeout+1.
+  // time_remaining(1000, 1000+timeout+1, timeout) = 0 -> down.
+  ASSERT_EQ(tracker.events.size(), 2u);
+  EXPECT_FALSE(tracker.events[0].up);
+  EXPECT_FALSE(tracker.events[1].up);
+}
+
+TEST_F(HeartbeatMonitor, callback_ctx_is_passed_through) {
+  BmLinkHeartbeatMonitorCfg cfg = make_cfg();
+  ASSERT_EQ(bm_link_heartbeat_monitor_init(&cfg), BmOK);
+
+  auto hb = build_heartbeat_frame();
+  ASSERT_EQ(bm_link_heartbeat_monitor_observe(1, hb.data(), hb.size()),
+            BmOK);
+
+  EXPECT_EQ(tracker.bad_ctx_count, 0u);
+}

--- a/test/src/bm_link_heartbeat_monitor_test.cpp
+++ b/test/src/bm_link_heartbeat_monitor_test.cpp
@@ -10,8 +10,11 @@ DEFINE_FFF_GLOBALS;
 
 extern "C" {
 #include "bm_link_heartbeat_monitor.h"
+#include "messages.h"
 #include "mock_bm_os.h"
 #include "mock_timer_callback_handler.h"
+#include "network_frames.h"
+#include "util.h"
 }
 
 // ---------------------------------------------------------------------------
@@ -43,55 +46,31 @@ void on_link_change(uint8_t port_idx, bool up, void *ctx) {
   t->events.push_back({port_idx, up});
 }
 
-// ---------------------------------------------------------------------------
-// Frame builders
-// ---------------------------------------------------------------------------
-//
-// Mirror the on-wire layout used by network/l2.c:
-//   [0..5]   destination MAC
-//   [6..11]  source MAC
-//   [12..13] ethertype           (big-endian)
-//   [14..17] IPv6 vers/class/flow
-//   [18..19] IPv6 payload length (big-endian)
-//   [20]     IPv6 next header
-//   [21]     IPv6 hop limit
-//   [22..37] IPv6 source addr
-//   [38..53] IPv6 dest addr
-//   [54..]   upper-layer payload
-
-constexpr size_t ETH_HDR_LEN = 14;
-constexpr size_t IPV6_HDR_LEN = 40;
-constexpr size_t FRAME_HDR_LEN = ETH_HDR_LEN + IPV6_HDR_LEN;
-constexpr size_t BCMP_HDR_LEN = 12;
-constexpr uint16_t ETH_TYPE_IPV6 = 0x86DD;
-constexpr uint8_t IP_PROTO_BCMP = 0xBC;
-constexpr uint16_t HEARTBEAT_TYPE = 0x0001;
-constexpr uint16_t INFO_REQUEST_TYPE = 0x0004; // some other BCMP type
-
 std::vector<uint8_t> build_frame(uint16_t ethertype, uint8_t next_header,
                                  uint16_t bcmp_type, size_t total_len) {
   std::vector<uint8_t> f(total_len, 0);
-  f[12] = static_cast<uint8_t>(ethertype >> 8);
-  f[13] = static_cast<uint8_t>(ethertype & 0xFF);
-  f[20] = next_header;
-  if (total_len >= FRAME_HDR_LEN + sizeof(bcmp_type)) {
-    memcpy(f.data() + FRAME_HDR_LEN, &bcmp_type, sizeof(bcmp_type));
+  f[ethernet_type_offset] = static_cast<uint8_t>(ethertype >> 8);
+  f[ethernet_type_offset + 1] = static_cast<uint8_t>(ethertype & 0xFF);
+  f[ipv6_next_header_offset] = next_header;
+  if (total_len >= bcmp_header_offset + sizeof(bcmp_type)) {
+    memcpy(f.data() + bcmp_header_offset, &bcmp_type, sizeof(bcmp_type));
   }
   return f;
 }
 
 std::vector<uint8_t> build_heartbeat_frame() {
-  return build_frame(ETH_TYPE_IPV6, IP_PROTO_BCMP, HEARTBEAT_TYPE,
-                     FRAME_HDR_LEN + BCMP_HDR_LEN);
+  return build_frame(ethernet_type_ipv6, ip_proto_bcmp, BcmpHeartbeatMessage,
+                     min_bcmp_frame_size);
 }
 
 std::vector<uint8_t> build_bcmp_non_heartbeat_frame() {
-  return build_frame(ETH_TYPE_IPV6, IP_PROTO_BCMP, INFO_REQUEST_TYPE,
-                     FRAME_HDR_LEN + BCMP_HDR_LEN);
+  return build_frame(ethernet_type_ipv6, ip_proto_bcmp,
+                     BcmpDeviceInfoRequestMessage, min_bcmp_frame_size);
 }
 
 std::vector<uint8_t> build_udp_frame() {
-  return build_frame(ETH_TYPE_IPV6, /*UDP*/ 0x11, 0, FRAME_HDR_LEN + 8);
+  return build_frame(ethernet_type_ipv6, /*UDP*/ 0x11, 0,
+                     bcmp_header_offset + 8);
 }
 
 // ---------------------------------------------------------------------------

--- a/test/src/bm_link_heartbeat_monitor_test.cpp
+++ b/test/src/bm_link_heartbeat_monitor_test.cpp
@@ -11,6 +11,7 @@ DEFINE_FFF_GLOBALS;
 extern "C" {
 #include "bm_link_heartbeat_monitor.h"
 #include "mock_bm_os.h"
+#include "mock_timer_callback_handler.h"
 }
 
 // ---------------------------------------------------------------------------
@@ -121,6 +122,18 @@ uint32_t mocked_now_ms = 0;
 uint32_t get_tick_count_custom() { return mocked_now_ms; }
 uint32_t ms_to_ticks_passthrough(uint32_t ms) { return ms; }
 
+// Synchronously runs the offloaded handler. The production code posts the
+// liveness scan to the timer_callback_handler task; in unit tests we just
+// invoke it inline so the existing tests can drive the down-edge logic by
+// calling captured_timer_cb() directly.
+bool send_cb_passthrough(timer_handler_cb cb, void *arg, uint32_t timeout_ms) {
+  (void)timeout_ms;
+  if (cb) {
+    cb(arg);
+  }
+  return true;
+}
+
 void install_default_os_mocks() {
   RESET_FAKE(bm_mutex_create);
   RESET_FAKE(bm_semaphore_take);
@@ -132,6 +145,7 @@ void install_default_os_mocks() {
   RESET_FAKE(bm_timer_delete);
   RESET_FAKE(bm_get_tick_count);
   RESET_FAKE(bm_ms_to_ticks);
+  RESET_FAKE(timer_callback_handler_send_cb);
 
   bm_mutex_create_fake.return_val = MUTEX_HANDLE;
   bm_semaphore_take_fake.return_val = BmOK;
@@ -141,6 +155,7 @@ void install_default_os_mocks() {
   bm_timer_stop_fake.return_val = BmOK;
   bm_get_tick_count_fake.custom_fake = get_tick_count_custom;
   bm_ms_to_ticks_fake.custom_fake = ms_to_ticks_passthrough;
+  timer_callback_handler_send_cb_fake.custom_fake = send_cb_passthrough;
 
   captured_timer_cb = nullptr;
   mocked_now_ms = 1000;
@@ -248,8 +263,7 @@ TEST_F(HeartbeatMonitor, observe_ignores_non_heartbeat_traffic) {
   auto bcmp_other = build_bcmp_non_heartbeat_frame();
   std::vector<uint8_t> tiny(10, 0); // too short
 
-  EXPECT_EQ(bm_link_heartbeat_monitor_observe(1, udp.data(), udp.size()),
-            BmOK);
+  EXPECT_EQ(bm_link_heartbeat_monitor_observe(1, udp.data(), udp.size()), BmOK);
   EXPECT_EQ(bm_link_heartbeat_monitor_observe(1, bcmp_other.data(),
                                               bcmp_other.size()),
             BmOK);
@@ -264,8 +278,7 @@ TEST_F(HeartbeatMonitor, observe_first_heartbeat_fires_up_edge) {
   ASSERT_EQ(bm_link_heartbeat_monitor_init(&cfg), BmOK);
 
   auto hb = build_heartbeat_frame();
-  EXPECT_EQ(bm_link_heartbeat_monitor_observe(2, hb.data(), hb.size()),
-            BmOK);
+  EXPECT_EQ(bm_link_heartbeat_monitor_observe(2, hb.data(), hb.size()), BmOK);
 
   ASSERT_EQ(tracker.events.size(), 1u);
   EXPECT_EQ(tracker.events[0].port_idx, 1); // port_num 2 -> idx 1
@@ -279,8 +292,7 @@ TEST_F(HeartbeatMonitor, observe_subsequent_heartbeats_do_not_refire) {
   auto hb = build_heartbeat_frame();
   for (int i = 0; i < 5; i++) {
     mocked_now_ms += 1000;
-    EXPECT_EQ(bm_link_heartbeat_monitor_observe(1, hb.data(), hb.size()),
-              BmOK);
+    EXPECT_EQ(bm_link_heartbeat_monitor_observe(1, hb.data(), hb.size()), BmOK);
   }
   EXPECT_EQ(tracker.events.size(), 1u); // only the first one fired
 }
@@ -290,10 +302,8 @@ TEST_F(HeartbeatMonitor, observe_per_port_independence) {
   ASSERT_EQ(bm_link_heartbeat_monitor_init(&cfg), BmOK);
 
   auto hb = build_heartbeat_frame();
-  EXPECT_EQ(bm_link_heartbeat_monitor_observe(1, hb.data(), hb.size()),
-            BmOK);
-  EXPECT_EQ(bm_link_heartbeat_monitor_observe(3, hb.data(), hb.size()),
-            BmOK);
+  EXPECT_EQ(bm_link_heartbeat_monitor_observe(1, hb.data(), hb.size()), BmOK);
+  EXPECT_EQ(bm_link_heartbeat_monitor_observe(3, hb.data(), hb.size()), BmOK);
 
   ASSERT_EQ(tracker.events.size(), 2u);
   EXPECT_EQ(tracker.events[0].port_idx, 0);
@@ -313,8 +323,7 @@ TEST_F(HeartbeatMonitor, timer_fires_down_edge_after_timeout) {
 
   // Bring port 1 up.
   auto hb = build_heartbeat_frame();
-  ASSERT_EQ(bm_link_heartbeat_monitor_observe(1, hb.data(), hb.size()),
-            BmOK);
+  ASSERT_EQ(bm_link_heartbeat_monitor_observe(1, hb.data(), hb.size()), BmOK);
   ASSERT_EQ(tracker.events.size(), 1u);
 
   // Tick the timer at t = last_hb + timeout - 1 -- still within the window.
@@ -335,13 +344,37 @@ TEST_F(HeartbeatMonitor, timer_fires_down_edge_after_timeout) {
   EXPECT_EQ(tracker.events.size(), 2u);
 }
 
+TEST_F(HeartbeatMonitor, timer_cb_offloads_to_handler_task) {
+  // FreeRTOS docs forbid blocking inside the timer callback. Verify
+  // the callback delegates via timer_callback_handler_send_cb rather
+  // than running the (mutex-taking) liveness scan inline.
+  BmLinkHeartbeatMonitorCfg cfg = make_cfg();
+  ASSERT_EQ(bm_link_heartbeat_monitor_init(&cfg), BmOK);
+  ASSERT_NE(captured_timer_cb, nullptr);
+
+  uint32_t take_calls_before = bm_semaphore_take_fake.call_count;
+  uint32_t send_cb_calls_before =
+      timer_callback_handler_send_cb_fake.call_count;
+
+  // Disable the passthrough so the bottom half does NOT run inline; we
+  // only want to observe what the top half does.
+  timer_callback_handler_send_cb_fake.custom_fake = nullptr;
+  timer_callback_handler_send_cb_fake.return_val = true;
+
+  captured_timer_cb(TIMER_HANDLE);
+
+  EXPECT_EQ(timer_callback_handler_send_cb_fake.call_count,
+            send_cb_calls_before + 1);
+  // Timer callback must not have taken the lock.
+  EXPECT_EQ(bm_semaphore_take_fake.call_count, take_calls_before);
+}
+
 TEST_F(HeartbeatMonitor, recovery_fires_up_edge_after_down) {
   BmLinkHeartbeatMonitorCfg cfg = make_cfg();
   ASSERT_EQ(bm_link_heartbeat_monitor_init(&cfg), BmOK);
 
   auto hb = build_heartbeat_frame();
-  ASSERT_EQ(bm_link_heartbeat_monitor_observe(1, hb.data(), hb.size()),
-            BmOK);
+  ASSERT_EQ(bm_link_heartbeat_monitor_observe(1, hb.data(), hb.size()), BmOK);
 
   // Force timeout.
   mocked_now_ms += TIMEOUT_MS + 1;
@@ -350,8 +383,7 @@ TEST_F(HeartbeatMonitor, recovery_fires_up_edge_after_down) {
   EXPECT_FALSE(tracker.events[1].up);
 
   // Receive heartbeat -> edge back up.
-  ASSERT_EQ(bm_link_heartbeat_monitor_observe(1, hb.data(), hb.size()),
-            BmOK);
+  ASSERT_EQ(bm_link_heartbeat_monitor_observe(1, hb.data(), hb.size()), BmOK);
   ASSERT_EQ(tracker.events.size(), 3u);
   EXPECT_TRUE(tracker.events[2].up);
 }
@@ -397,8 +429,7 @@ TEST_F(HeartbeatMonitor, start_ports_up_first_heartbeat_does_not_refire_up) {
   ASSERT_EQ(tracker.events.size(), 2u);
 
   auto hb = build_heartbeat_frame();
-  EXPECT_EQ(bm_link_heartbeat_monitor_observe(1, hb.data(), hb.size()),
-            BmOK);
+  EXPECT_EQ(bm_link_heartbeat_monitor_observe(1, hb.data(), hb.size()), BmOK);
   // Already considered up; observe just refreshes last_hb_ticks.
   EXPECT_EQ(tracker.events.size(), 2u);
 
@@ -417,8 +448,7 @@ TEST_F(HeartbeatMonitor, callback_ctx_is_passed_through) {
   ASSERT_EQ(bm_link_heartbeat_monitor_init(&cfg), BmOK);
 
   auto hb = build_heartbeat_frame();
-  ASSERT_EQ(bm_link_heartbeat_monitor_observe(1, hb.data(), hb.size()),
-            BmOK);
+  ASSERT_EQ(bm_link_heartbeat_monitor_observe(1, hb.data(), hb.size()), BmOK);
 
   EXPECT_EQ(tracker.bad_ctx_count, 0u);
 }

--- a/test/src/bm_link_heartbeat_monitor_test.cpp
+++ b/test/src/bm_link_heartbeat_monitor_test.cpp
@@ -360,10 +360,17 @@ TEST_F(HeartbeatMonitor, recovery_fires_up_edge_after_down) {
 // Bootstrap policies
 // ---------------------------------------------------------------------------
 
-TEST_F(HeartbeatMonitor, start_ports_up_does_not_fire_initial_callbacks) {
+TEST_F(HeartbeatMonitor, start_ports_up_fires_initial_up_callbacks) {
   BmLinkHeartbeatMonitorCfg cfg = make_cfg(/*num_ports=*/3, /*start_up=*/true);
   ASSERT_EQ(bm_link_heartbeat_monitor_init(&cfg), BmOK);
-  EXPECT_EQ(tracker.events.size(), 0u);
+
+  // One synchronous up edge per port so the consumer (e.g. bm_l2) can
+  // mirror the monitor's "ports up" state.
+  ASSERT_EQ(tracker.events.size(), 3u);
+  for (uint8_t i = 0; i < 3; i++) {
+    EXPECT_EQ(tracker.events[i].port_idx, i);
+    EXPECT_TRUE(tracker.events[i].up);
+  }
 }
 
 TEST_F(HeartbeatMonitor,
@@ -371,41 +378,38 @@ TEST_F(HeartbeatMonitor,
   BmLinkHeartbeatMonitorCfg cfg = make_cfg(/*num_ports=*/2, /*start_up=*/true);
   ASSERT_EQ(bm_link_heartbeat_monitor_init(&cfg), BmOK);
 
-  // Tick past timeout; both ports should fire down.
+  // Two initial up edges from init, then two down edges from the timer.
+  ASSERT_EQ(tracker.events.size(), 2u);
+
   mocked_now_ms += TIMEOUT_MS + 1;
   captured_timer_cb(TIMER_HANDLE);
 
-  ASSERT_EQ(tracker.events.size(), 2u);
-  EXPECT_FALSE(tracker.events[0].up);
-  EXPECT_FALSE(tracker.events[1].up);
+  ASSERT_EQ(tracker.events.size(), 4u);
+  EXPECT_FALSE(tracker.events[2].up);
+  EXPECT_FALSE(tracker.events[3].up);
 }
 
-TEST_F(HeartbeatMonitor, start_ports_up_first_heartbeat_does_not_fire_up) {
+TEST_F(HeartbeatMonitor, start_ports_up_first_heartbeat_does_not_refire_up) {
   BmLinkHeartbeatMonitorCfg cfg = make_cfg(/*num_ports=*/2, /*start_up=*/true);
   ASSERT_EQ(bm_link_heartbeat_monitor_init(&cfg), BmOK);
+
+  // Init fired one up edge per port.
+  ASSERT_EQ(tracker.events.size(), 2u);
 
   auto hb = build_heartbeat_frame();
   EXPECT_EQ(bm_link_heartbeat_monitor_observe(1, hb.data(), hb.size()),
             BmOK);
-  // Already considered up; observe just refreshed last_hb_ticks.
-  EXPECT_EQ(tracker.events.size(), 0u);
+  // Already considered up; observe just refreshes last_hb_ticks.
+  EXPECT_EQ(tracker.events.size(), 2u);
 
-  // Tick well past timeout *for port 2 only* (port 1 just got refreshed).
+  // Heartbeat at observe-time refreshed port 1's last_hb_ticks to
+  // mocked_now_ms (1000). Advance past the timeout so both ports go down.
   mocked_now_ms += TIMEOUT_MS + 1;
   captured_timer_cb(TIMER_HANDLE);
 
-  // Port 1 should still be up (heartbeat was at mocked_now_ms - timeout - 1
-  // + small delta -> within window after timer tick). Wait, we need to be
-  // careful: we incremented mocked_now_ms by timeout+1 AFTER the heartbeat,
-  // so port 1 is also out of window.
-  //
-  // Adjust: the heartbeat refreshed last_hb_ticks to the value of
-  // mocked_now_ms at time of observe (before the increment). That value is
-  // (initial)1000. After incrementing by timeout+1, now = 1000 + timeout+1.
-  // time_remaining(1000, 1000+timeout+1, timeout) = 0 -> down.
-  ASSERT_EQ(tracker.events.size(), 2u);
-  EXPECT_FALSE(tracker.events[0].up);
-  EXPECT_FALSE(tracker.events[1].up);
+  ASSERT_EQ(tracker.events.size(), 4u);
+  EXPECT_FALSE(tracker.events[2].up);
+  EXPECT_FALSE(tracker.events[3].up);
 }
 
 TEST_F(HeartbeatMonitor, callback_ctx_is_passed_through) {


### PR DESCRIPTION
## What changed?

Added `bm_link_heartbeat_monitor.{h,c}` to the `network` directory, with unit tests and no other callers.

This module can be used with transports like UART that have no PHY for triggering link up/down events. When we get heartbeats, the the link goes up; when heartbeats stop, the link goes down. The code path is analogous to the driver level and doesn't touch bcmp or L2.

Usage looks like this, with an init call and then peeking every received packet:

```c
#include "bm_link_heartbeat_monitor.h"

static void on_link_change(uint8_t port_idx, bool up, void *ctx) {
  (void)ctx;
  printf("port %u %s\n", port_idx + 1, up ? "UP" : "DOWN");
}

void uart_transport_init(void) {
  BmLinkHeartbeatMonitorCfg cfg = {
      .num_ports = 1,
      .timeout_ms = 20000,         // 2 * BCMP heartbeat period
      .check_period_ms = 1000,
      .start_ports_up = true,      // assume up at boot so heartbeats can flow
      .on_link_change = on_link_change,
      .ctx = NULL,
  };
  bm_link_heartbeat_monitor_init(&cfg);
}

// In the transport's RX path, for every received L2 frame:
void uart_rx(const uint8_t *frame, uint32_t len) {
  bm_link_heartbeat_monitor_observe(/*port_num=*/1, frame, len);
  // ...hand the frame to L2 as usual...
}
```


## How does it make Bristlemouth better?

Our mote-SBC uart ports (both sides) will correctly join and leave the topology as their links go up and down, instead of remaining as phantoms when they're gone.

## Where should reviewers focus?

Does the API make sense? Is the level of doc comments OK? Claude was pretty verbose, and I trimmed it down some. Happy to trim more if requested, but some of the comments I could imagine being pretty helpful to newcomers to aid understanding.

## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
