### PR TITLE
ignore worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 **.bkp
 **.vscode
 **__pycache__
+.worktrees


### PR DESCRIPTION
Ignored `.worktrees` because it's a common place to put git worktrees.

Git worktrees enable cleaner parallel work on different branches of a repo simultaneously, by both humans and AI agents. Claude Code in the desktop app has a "worktree" checkbox if you want it to create one for a session.

Links about worktrees
- [git worktree docs](https://git-scm.com/docs/git-worktree)
- [a helpful medium post](https://medium.com/@weidagang/working-with-git-worktrees-43cdacf5ea9d)
- [a fun blog post](https://www.tomups.com/posts/git-worktrees/)