### PR TITLE
Exact config key comparison

### DIFF
--- a/bcmp/configuration.c
+++ b/bcmp/configuration.c
@@ -26,7 +26,8 @@ static bool find_key_idx(BmConfigPartition partition, const char *key,
   bool ret = false;
 
   for (int i = 0; i < config_partition->header.numKeys; i++) {
-    if (strncmp(key, config_partition->keys[i].key_buf, len) == 0) {
+    if (config_partition->keys[i].key_len == len &&
+        strncmp(key, config_partition->keys[i].key_buf, len) == 0) {
       *idx = i;
       ret = true;
       break;

--- a/test/src/configuration_test.cpp
+++ b/test/src/configuration_test.cpp
@@ -458,3 +458,51 @@ TEST_F(ConfigurationTest, ClearingPartition) {
   // Test improper argument
   EXPECT_EQ(clear_partition(BM_CFG_PARTITION_COUNT), false);
 }
+
+// Regression: find_key_idx used strncmp(key, stored, len) without checking
+// keys[i].key_len == len, so a shorter lookup that is a prefix of a stored
+// key matched it. Setting "wifi" after "wifi_ssid" would then overwrite
+// "wifi_ssid" in place instead of adding a distinct key.
+TEST_F(ConfigurationTest, set_short_key_does_not_overwrite_longer_prefix) {
+  config_init();
+
+  ASSERT_TRUE(set_config_uint(BM_CFG_PARTITION_SYSTEM, "wifi_ssid",
+                              strlen("wifi_ssid"), 0xAAAAAAAAu));
+  ASSERT_TRUE(set_config_uint(BM_CFG_PARTITION_SYSTEM, "wifi", strlen("wifi"),
+                              0xBBBBBBBBu));
+
+  uint8_t num_keys = 0;
+  get_stored_keys(BM_CFG_PARTITION_SYSTEM, &num_keys);
+  EXPECT_EQ(num_keys, 2);
+
+  uint32_t v_ssid = 0;
+  EXPECT_TRUE(get_config_uint(BM_CFG_PARTITION_SYSTEM, "wifi_ssid",
+                              strlen("wifi_ssid"), &v_ssid));
+  EXPECT_EQ(v_ssid, 0xAAAAAAAAu);
+
+  uint32_t v_wifi = 0;
+  EXPECT_TRUE(get_config_uint(BM_CFG_PARTITION_SYSTEM, "wifi", strlen("wifi"),
+                              &v_wifi));
+  EXPECT_EQ(v_wifi, 0xBBBBBBBBu);
+}
+
+// Same root cause, viewed via remove_key: removing a prefix of a stored
+// key must not delete the longer key.
+TEST_F(ConfigurationTest, remove_prefix_does_not_remove_longer_key) {
+  config_init();
+
+  ASSERT_TRUE(set_config_uint(BM_CFG_PARTITION_SYSTEM, "wifi_ssid",
+                              strlen("wifi_ssid"), 0xAAAAAAAAu));
+
+  // "wifi" isn't stored — remove must report no-such-key.
+  EXPECT_FALSE(remove_key(BM_CFG_PARTITION_SYSTEM, "wifi", strlen("wifi")));
+
+  uint8_t num_keys = 0;
+  get_stored_keys(BM_CFG_PARTITION_SYSTEM, &num_keys);
+  EXPECT_EQ(num_keys, 1);
+
+  uint32_t v = 0;
+  EXPECT_TRUE(get_config_uint(BM_CFG_PARTITION_SYSTEM, "wifi_ssid",
+                              strlen("wifi_ssid"), &v));
+  EXPECT_EQ(v, 0xAAAAAAAAu);
+}


### PR DESCRIPTION
## What changed?

Fixed a bug in searching for config keys in the cbor serialization, where it has been doing substring prefix matching instead of exact matching. As an example, prior to this PR, searching for a config named `wifi` would retrieve a prior config named `wifi_ssid`.

With this PR we only match exactly the key we searched for.

## How does it make Bristlemouth better?

As the ecosystem of configs that various nodes expect of each other grows, this prevents various categories of future bugs, where the code would behave differently depending on completely unexpected external state.

## Where should reviewers focus?

Very small PR. Focus on understanding the unit tests. They fail if we don't check key length in configuration.c.

## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
