### PR TITLE
Add BmNetworkInfoChunk struct for chunked serial transfer

### DIFF
--- a/common/bm_common_structs.h
+++ b/common/bm_common_structs.h
@@ -44,6 +44,13 @@ typedef struct {
   uint8_t node_list_and_cbor_config_map[0];
 } __attribute__((packed)) BmNetworkInfo;
 
+typedef struct {
+  uint32_t total_size;
+  uint32_t offset;
+  uint16_t length;
+  uint8_t data[0];
+} __attribute__((packed)) BmNetworkInfoChunk;
+
 typedef enum {
   BM_COMMON_LOG_LEVEL_NONE = 0,
   BM_COMMON_LOG_LEVEL_FATAL = 1,


### PR DESCRIPTION
## What changed?
Adds BmNetworkInfoChunk packed struct to bm_common_structs.h.

## How does it make Bristlemouth better?
This is required by the chunked network info transfer protocol in bm_serial and bm_protocol.


## Where should reviewers focus?



## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
