### PR TITLE
Remove network_frames include from messages.h

### DIFF
--- a/bcmp/messages.h
+++ b/bcmp/messages.h
@@ -6,7 +6,6 @@
 
 #include "configuration.h"
 #include "dfu_message_structs.h"
-#include "network_frames.h"
 
 typedef struct {
   uint16_t type;


### PR DESCRIPTION
## What changed?
Remove include that is not needed by messages.h file.


## How does it make Bristlemouth better?
Reduces dependencies when including this file in a project.


## Where should reviewers focus?
Rubber stamp.


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
