### PR TITLE
Fix Invoking Discovery Callback Only If Neighbor Resets

### DIFF
--- a/bcmp/heartbeat.c
+++ b/bcmp/heartbeat.c
@@ -43,9 +43,14 @@ static BmErr bcmp_process_heartbeat(BcmpProcessData data) {
   if (neighbor) {
     err = BmOK;
 
-    // Neighbor restarted, let's get additional info
-    if (heartbeat->time_since_boot_us < neighbor->last_time_since_boot_us) {
+    bool neighbor_reset = heartbeat->time_since_boot_us < neighbor->last_time_since_boot_us;
+    // Neighbor is coming online invoke neighbor discovery callback
+    if (!neighbor->online || neighbor_reset) {
       bcmp_neighbor_invoke_discovery_cb(true, neighbor);
+    }
+
+    // Neighbor restarted, let's get additional info
+    if (neighbor_reset) {
       bm_debug("🏘📡 Updating neighbor info! %016" PRIx64 "\n",
                neighbor->node_id);
       bcmp_request_info(neighbor->info.node_id, &multicast_ll_addr, NULL);


### PR DESCRIPTION


## What changed?
Invoke neighbor discovery callback whenever the neighbor comes online or resets.


## How does it make Bristlemouth better?
Ensures that neighbor discovery callback is invoked if neighbor goes from being offline to online without resetting.
This has been seen on the bm_sbc integration when the gateway application drops a heartbeat and the neighbor goes offline, this callback is never invoked again because the neighbor did not reset its ticks.


## Where should reviewers focus?
I ensured that the logic is still run in order as it was previously.
Is there a chance where the opposite might happen, where the ticks are way further ahead than expected but the neighbor is not offline?
If so, it might be worthwhile to get some unit tests going around heartbeats to make sure that the function runs what we expect it to.


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
