### PR TITLE
Adds a memory_stats metrics component

### DIFF
--- a/common/bm_freertos.c
+++ b/common/bm_freertos.c
@@ -11,6 +11,15 @@ void *bm_malloc(size_t size) { return pvPortMalloc(size); }
 
 void bm_free(void *ptr) { vPortFree(ptr); }
 
+void bm_heap_stats(BmHeapStats *stats) {
+  HeapStats_t heap_stats;
+  vPortGetHeapStats(&heap_stats);
+  stats->free_bytes = (uint32_t)heap_stats.xAvailableHeapSpaceInBytes;
+  stats->min_free_bytes = (uint32_t)heap_stats.xMinimumEverFreeBytesRemaining;
+  stats->largest_free_block =
+      (uint32_t)heap_stats.xSizeOfLargestFreeBlockInBytes;
+}
+
 BmQueue bm_queue_create(uint32_t queue_length, uint32_t item_size) {
   return xQueueCreate(queue_length, item_size);
 }

--- a/common/bm_os.h
+++ b/common/bm_os.h
@@ -25,6 +25,14 @@ typedef void (*BmTask)(void *arg);
 // Memory functions - these may not necessarily be tied to the OS but I'm including them here for now
 void *bm_malloc(size_t size);
 void bm_free(void *ptr);
+typedef struct {
+  uint32_t free_bytes;
+  uint32_t min_free_bytes;
+  uint32_t largest_free_block;
+} BmHeapStats;
+
+// Snapshot of current heap usage, in bytes.
+void bm_heap_stats(BmHeapStats *stats);
 
 // Queue functions
 BmQueue bm_queue_create(uint32_t queue_length, uint32_t item_size);

--- a/common/bm_os.h
+++ b/common/bm_os.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "util.h"
 
 #include <stdbool.h>

--- a/middleware/CMakeLists.txt
+++ b/middleware/CMakeLists.txt
@@ -12,9 +12,12 @@ set(SOURCES
     metrics_service.c
 )
 
-# bristlemouth.c hardcodes the ADIN2111 network device; exclude on hosted builds.
+# bristlemouth.c hardcodes the ADIN2111 network device; 
+# and memory_metrics.c relies on the FreeRTOS-backed bm_heap_stats(); 
+# exclude on hosted builds.
 if(NOT BM_HOSTED)
     list(APPEND SOURCES bristlemouth.c)
+    list(APPEND SOURCES memory_metrics.c)
 endif()
 
 add_library(middleware ${SOURCES})

--- a/middleware/bristlemouth.c
+++ b/middleware/bristlemouth.c
@@ -5,6 +5,7 @@
 #include "bm_ip.h"
 #include "bm_service.h"
 #include "l2.h"
+#include "memory_metrics.h"
 #include "metrics_service.h"
 #include "middleware.h"
 #include "topology.h"
@@ -24,6 +25,7 @@ BmErr bristlemouth_init(NetworkDevicePowerCallback net_power_cb) {
   bm_err_check(err, bm_middleware_init());
 #if (bm_metrics_enabled != 0)
   bm_err_check(err, metrics_service_init());
+  bm_err_check(err, memory_metrics_init());
 #endif
   return err;
 }

--- a/middleware/memory_metrics.c
+++ b/middleware/memory_metrics.c
@@ -1,0 +1,56 @@
+#include "memory_metrics.h"
+#include "bm_messages_helper.h"
+#include "bm_os.h"
+#include "metrics_service.h"
+#include "util.h"
+#include <stddef.h>
+#include <stdint.h>
+
+#define MEMORY_COMPONENT_KEY "memory_stats"
+
+typedef struct {
+  uint32_t heap_free; // bytes currently available
+  uint32_t heap_min_free; // low-water mark of available bytes (leak signal)
+  uint32_t heap_largest_block; // largest contiguous free block (fragmentation)
+} MemoryValues;
+
+typedef struct {
+  const char *name;
+  BmField type;
+  size_t offset; // location of the value within MemoryValues
+} MemoryFieldDesc;
+
+static const MemoryFieldDesc mem_fields[] = {
+  {"heap_free", BM_FIELD_UINT32, offsetof(MemoryValues, heap_free)},
+  {"heap_min_free", BM_FIELD_UINT32, offsetof(MemoryValues, heap_min_free)},
+  {"heap_largest_block", BM_FIELD_UINT32, offsetof(MemoryValues, heap_largest_block)},
+};
+
+#define MEMORY_FIELD_COUNT array_size(mem_fields)
+
+static MemoryValues mem_values;
+static BmEncoderTableEntry mem_lut[MEMORY_FIELD_COUNT];
+
+static BmErr memory_metrics_data(const char *metric_key, const BmEncoderTableEntry **lut,
+                                 size_t *num_fields) {
+  (void)metric_key;
+  BmHeapStats stats;
+  bm_heap_stats(&stats);
+  mem_values.heap_free = stats.free_bytes;
+  mem_values.heap_min_free = stats.min_free_bytes;
+  mem_values.heap_largest_block = stats.largest_free_block;
+
+  *lut = mem_lut;
+  *num_fields = MEMORY_FIELD_COUNT;
+  return BmOK;
+}
+
+BmErr memory_metrics_init(void) {
+  for (size_t f = 0; f < MEMORY_FIELD_COUNT; f++) {
+    mem_lut[f].key = mem_fields[f].name;
+    mem_lut[f].type = mem_fields[f].type;
+    mem_lut[f].value_source = (const uint8_t *)&mem_values + mem_fields[f].offset;
+  }
+  return metrics_service_add_component(MEMORY_COMPONENT_KEY, memory_metrics_data,
+                                       MEMORY_FIELD_COUNT);
+}

--- a/middleware/memory_metrics.h
+++ b/middleware/memory_metrics.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "util.h"
+
+BmErr memory_metrics_init(void);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## What changed?

- Adds a `memory_stats` metrics component to the generic metrics registry, reporting FreeRTOS heap health (`heap_free`, `heap_min_free`, `heap_largest_block`, in bytes).

## How does it make Bristlemouth better?

- Adds fleet-wide heap visibility per node and proves the generic registry takes a second producer cleanly.
- `heap_min_free` is a low-water leak signal, `heap_largest_block` catches fragmentation.

## Where should reviewers focus?

- Field choice: three of the seven `HeapStats_t` fields, free + low-water + largest-block.

## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
